### PR TITLE
fix: invalid cutout options. Also, add horizontal/vertical tool flipping in tracing

### DIFF
--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -116,6 +116,7 @@ export function BinConfigurator({ config, onChange }: Props) {
     onChange({ ...config, ...partial })
   }
 
+  const maxCutoutDepth = Math.max(5, config.height_units * 7 - 2)
   const binWidth = config.grid_x * 42
   const binDepth = config.grid_y * 42
   const needsSplit = config.bed_size > 0 && (binWidth > config.bed_size || binDepth > config.bed_size)
@@ -149,15 +150,18 @@ export function BinConfigurator({ config, onChange }: Props) {
         min={1}
         max={20}
         unit="u"
-        onChange={(v) => update({ height_units: v })}
+        onChange={(v) => {
+          const newMax = Math.max(5, v * 7 - 2)
+          update({ height_units: v, cutout_depth: Math.min(config.cutout_depth, newMax) })
+        }}
       />
 
       <SliderRow
         label="Cutout Depth"
-        help="How deep the tool pocket is cut into the bin."
-        value={config.cutout_depth}
+        help={`How deep the tool pocket is cut into the bin. Max ${maxCutoutDepth.toFixed(1)}mm at ${config.height_units}u height.`}
+        value={Math.min(config.cutout_depth, maxCutoutDepth)}
         min={5}
-        max={100}
+        max={maxCutoutDepth}
         step={0.5}
         unit="mm"
         onChange={(v) => update({ cutout_depth: v })}

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -256,6 +256,31 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     onHolesRef.current(newHoles)
   }, [pushHistory, currentRings])
 
+  const flipAll = useCallback((axis: 'horizontal' | 'vertical') => {
+    const pts = pointsRef.current
+    const holes = holesRef.current
+    const rings = currentRingsRef.current
+    const n = pts.length
+    if (n === 0) return
+    const cx = pts.reduce((s, p) => s + p.x, 0) / n
+    const cy = pts.reduce((s, p) => s + p.y, 0) / n
+    const flip = (p: Point) => axis === 'horizontal'
+      ? { x: 2 * cx - p.x, y: p.y }
+      : { x: p.x, y: 2 * cy - p.y }
+    // flipping reverses winding order
+    const newPts = pts.map(flip).reverse()
+    const newHoles = holes.map(fh => ({
+      ...fh,
+      ...(axis === 'horizontal' ? { x: 2 * cx - fh.x } : { y: 2 * cy - fh.y }),
+      rotation: -((fh.rotation || 0) % 360),
+    }))
+    const newRings = rings.map(ring => ring.map(flip).reverse())
+    pushHistory({ points: newPts, fingerHoles: newHoles, interiorRings: newRings })
+    onPointsRef.current(newPts)
+    onHolesRef.current(newHoles)
+    onInteriorRingsChange?.(newRings)
+  }, [pushHistory, onInteriorRingsChange])
+
   const handleRotatePolygonMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation()
     const pos = screenToMm(e.clientX, e.clientY)
@@ -565,6 +590,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
         handleDeleteHole={handleDeleteHole}
         displayPointsCount={displayPoints.length}
         rotateAll={rotateAll}
+        flipAll={flipAll}
         hasInteriorRings={currentRings.length > 0}
       />
       <ToolEditorCanvas

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, ChevronDown, PaintBucket } from 'lucide-react'
+import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket } from 'lucide-react'
 import type { FingerHole } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
 
@@ -35,6 +35,7 @@ interface Props {
   handleDeleteHole: () => void
   displayPointsCount: number
   rotateAll: (angleDeg: number) => void
+  flipAll: (axis: 'horizontal' | 'vertical') => void
   hasInteriorRings: boolean
 }
 
@@ -46,7 +47,7 @@ export function ToolEditorToolbar({
   cutoutOpen, setCutoutOpen,
   isCutoutMode, cutoutModeIcon, cutoutModeLabel,
   selection, selectedHole, handleDeleteHole,
-  displayPointsCount, rotateAll, hasInteriorRings,
+  displayPointsCount, rotateAll, flipAll, hasInteriorRings,
 }: Props) {
   return (
     <>
@@ -152,6 +153,20 @@ export function ToolEditorToolbar({
             title="Rotate 90° clockwise"
           >
             <RotateCw className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => flipAll('horizontal')}
+            className="p-1.5 rounded hover:bg-border/50 hover:text-text-secondary"
+            title="Flip horizontally"
+          >
+            <FlipHorizontal2 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => flipAll('vertical')}
+            className="p-1.5 rounded hover:bg-border/50 hover:text-text-secondary"
+            title="Flip vertically"
+          >
+            <FlipVertical2 className="w-4 h-4" />
           </button>
           <div className="h-4 w-px bg-border-subtle mx-1" />
           <button


### PR DESCRIPTION
- feat: add tool horizontal/vertical flipping in tool trace
- bugfix: users can have invalid combos of height and cutout depth. Re: #8 
  - The cutout depth slider max is now dynamically capped to the actual usable depth
