### PR TITLE
fix: surface contrast insert generation failures to user

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -9,13 +9,13 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-
 from fastapi import APIRouter, Depends, UploadFile, HTTPException
 from fastapi.responses import FileResponse, Response
 from starlette.requests import Request
 from PIL import Image
 import io
+
+logger = logging.getLogger(__name__)
 
 from app.config import settings, ensure_user_dirs
 from app.auth import get_user_id

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -9,6 +9,8 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 from fastapi import APIRouter, Depends, UploadFile, HTTPException
 from fastapi.responses import FileResponse, Response
 from starlette.requests import Request
@@ -203,6 +205,9 @@ def _run_generate(
             f"/storage/{user_id}/outputs/{entity_id}_insert.stl"
             if insert_path.exists() else None
         )
+        cached_warning = None
+        if getattr(gen_req, 'insert_enabled', False) and not insert_path.exists():
+            cached_warning = "Insert generation failed -- check server logs for details"
         return GenerateResponse(
             stl_url=f"/storage/{user_id}/outputs/{entity_id}.stl",
             stl_urls=stl_urls,
@@ -210,6 +215,7 @@ def _run_generate(
             split_count=max(1, len(stl_urls)),
             zip_url=f"/storage/{user_id}/outputs/{entity_id}_parts.zip" if zip_path.exists() else None,
             insert_stl_url=insert_stl_url,
+            warning=cached_warning,
         )
 
     threemf_path.unlink(missing_ok=True)
@@ -234,15 +240,19 @@ def _run_generate(
             zip_url = f"/storage/{user_id}/outputs/{entity_id}_parts.zip"
 
     insert_stl_url = None
+    warning = None
     if getattr(gen_req, 'insert_enabled', False) and scaled:
         bin_width = gen_req.grid_x * GF_GRID
         bin_depth = gen_req.grid_y * GF_GRID
         offset_x = -bin_width / 2
         offset_y = -bin_depth / 2
-        success = stl_generator.generate_insert(scaled, gen_req, str(insert_path), offset_x, offset_y)
+        try:
+            success = stl_generator.generate_insert(scaled, gen_req, str(insert_path), offset_x, offset_y)
+        except Exception:
+            logger.exception("insert generation crashed")
+            success = False
         if success:
             insert_stl_url = f"/storage/{user_id}/outputs/{entity_id}_insert.stl"
-            # bundle bin + insert into a ZIP so users get both files
             if zip_path.exists():
                 with zipfile.ZipFile(str(zip_path), 'a') as zf:
                     zf.write(str(insert_path), f"{entity_id}_insert.stl")
@@ -251,6 +261,8 @@ def _run_generate(
                     zf.write(str(output_path), f"{entity_id}.stl")
                     zf.write(str(insert_path), f"{entity_id}_insert.stl")
                 zip_url = f"/storage/{user_id}/outputs/{entity_id}_parts.zip"
+        else:
+            warning = "Insert generation failed -- check server logs for details"
 
     hash_path.write_text(input_hash)
 
@@ -265,6 +277,7 @@ def _run_generate(
         split_count=max(1, len(stl_urls)),
         zip_url=zip_url,
         insert_stl_url=insert_stl_url,
+        warning=warning,
     )
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -207,7 +207,7 @@ def _run_generate(
         )
         cached_warning = None
         if getattr(gen_req, 'insert_enabled', False) and not insert_path.exists():
-            cached_warning = "Insert generation failed -- check server logs for details"
+            cached_warning = "Insert generation failed. Try re-tracing the tools or adjusting their placement."
         return GenerateResponse(
             stl_url=f"/storage/{user_id}/outputs/{entity_id}.stl",
             stl_urls=stl_urls,
@@ -262,7 +262,7 @@ def _run_generate(
                     zf.write(str(insert_path), f"{entity_id}_insert.stl")
                 zip_url = f"/storage/{user_id}/outputs/{entity_id}_parts.zip"
         else:
-            warning = "Insert generation failed -- check server logs for details"
+            warning = "Insert generation failed. Try re-tracing the tools or adjusting their placement."
 
     hash_path.write_text(input_hash)
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -149,6 +149,7 @@ class GenerateResponse(BaseModel):
     split_count: int = 1
     zip_url: str | None = None
     insert_stl_url: str | None = None
+    warning: str | None = None
 
 
 class Layout(BaseModel):

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -843,6 +843,7 @@ class ManifoldSTLGenerator:
             ]
             if len(shifted) < 3:
                 logger.warning("insert: skipping polygon %s (%d points)", poly.id, len(shifted))
+                failed += 1
                 continue
             shifted_holes = []
             for hole in (poly.interior_rings_mm or []):

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -831,17 +831,18 @@ class ManifoldSTLGenerator:
         offset_x: float,
         offset_y: float,
     ) -> bool:
-        # Generate insert STL, tool silhouettes extruded to insert_height.
         import manifold3d as mf
 
         insert_height = getattr(config, 'insert_height', 1.0)
         shapes = []
+        failed = 0
         for poly in polygons:
             shifted = [
                 (p[0] + offset_x, -(p[1] + offset_y))
                 for p in poly.points_mm
             ]
             if len(shifted) < 3:
+                logger.warning("insert: skipping polygon %s (%d points)", poly.id, len(shifted))
                 continue
             shifted_holes = []
             for hole in (poly.interior_rings_mm or []):
@@ -854,6 +855,8 @@ class ManifoldSTLGenerator:
             try:
                 rings = _shapely_to_cross_sections(shifted, shifted_holes)
                 if not rings:
+                    logger.warning("insert: empty cross-section for polygon %s", poly.id)
+                    failed += 1
                     continue
                 has_holes = len(rings) > 1
                 cs = mf.CrossSection(rings, mf.FillRule.EvenOdd) if has_holes else mf.CrossSection(rings)
@@ -861,14 +864,20 @@ class ManifoldSTLGenerator:
                     cs = mf.CrossSection([r[::-1] for r in rings], mf.FillRule.EvenOdd if has_holes else mf.FillRule.Positive)
                 if cs.area() > 0:
                     shapes.append(mf.Manifold.extrude(cs, insert_height))
+                else:
+                    logger.warning("insert: zero-area cross-section for polygon %s", poly.id)
+                    failed += 1
             except Exception as e:
-                logger.warning("insert polygon failed: %s", e)
+                logger.warning("insert polygon %s failed: %s", poly.id, e)
+                failed += 1
 
         if not shapes:
+            logger.error("insert generation produced no shapes (%d polygons, %d failed)", len(polygons), failed)
             return False
 
         combined = mf.Manifold.batch_boolean(shapes, mf.OpType.Add)
         _export_stl(combined, output_path)
+        logger.info("insert: exported %d shapes to %s", len(shapes), output_path)
         return True
 
     @staticmethod

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))

--- a/backend/tests/test_insert.py
+++ b/backend/tests/test_insert.py
@@ -1,11 +1,8 @@
 """Tests for contrast insert STL generation."""
 import os
-import sys
 import tempfile
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app.services.stl_generator_manifold import ManifoldSTLGenerator
 from app.services.polygon_scaler import ScaledPolygon

--- a/backend/tests/test_insert.py
+++ b/backend/tests/test_insert.py
@@ -1,0 +1,129 @@
+"""Tests for contrast insert STL generation."""
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.stl_generator_manifold import ManifoldSTLGenerator
+from app.services.polygon_scaler import ScaledPolygon
+
+GF_GRID = 42.0
+
+
+class FakeConfig:
+    def __init__(self, insert_height=1.0, grid_x=2, grid_y=2):
+        self.insert_enabled = True
+        self.insert_height = insert_height
+        self.grid_x = grid_x
+        self.grid_y = grid_y
+
+
+def _make_polygon(x, y, size, poly_id="test"):
+    return ScaledPolygon(
+        id=poly_id,
+        points_mm=[(x, y), (x + size, y), (x + size, y + size), (x, y + size)],
+        label="test",
+        finger_holes=[],
+        interior_rings_mm=[],
+    )
+
+
+def _grid_offsets(grid_x=2, grid_y=2):
+    bin_width = grid_x * GF_GRID
+    bin_depth = grid_y * GF_GRID
+    return -bin_width / 2, -bin_depth / 2
+
+
+@pytest.fixture
+def generator():
+    return ManifoldSTLGenerator()
+
+
+@pytest.fixture
+def output_path():
+    fd, path = tempfile.mkstemp(suffix=".stl")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+def test_generate_insert_produces_file(generator, output_path):
+    poly = _make_polygon(10, 10, 20)
+    config = FakeConfig()
+    ox, oy = _grid_offsets()
+
+    result = generator.generate_insert([poly], config, output_path, ox, oy)
+
+    assert result is True
+    assert os.path.exists(output_path)
+    assert os.path.getsize(output_path) > 0
+
+
+def test_generate_insert_empty_polygons(generator, output_path):
+    config = FakeConfig()
+
+    result = generator.generate_insert([], config, output_path, 0, 0)
+
+    assert result is False
+
+
+def test_generate_insert_custom_height(generator, output_path):
+    poly = _make_polygon(10, 10, 20)
+    config = FakeConfig(insert_height=2.5)
+    ox, oy = _grid_offsets()
+
+    result = generator.generate_insert([poly], config, output_path, ox, oy)
+
+    assert result is True
+    assert os.path.getsize(output_path) > 0
+
+
+def test_generate_insert_multiple_polygons(generator, output_path):
+    polys = [
+        _make_polygon(5, 5, 15, "tool1"),
+        _make_polygon(30, 30, 10, "tool2"),
+    ]
+    config = FakeConfig()
+    ox, oy = _grid_offsets()
+
+    result = generator.generate_insert(polys, config, output_path, ox, oy)
+
+    assert result is True
+    assert os.path.getsize(output_path) > 0
+
+
+def test_generate_insert_degenerate_polygon(generator, output_path):
+    degen = ScaledPolygon(
+        id="degen",
+        points_mm=[(0, 0), (1, 0)],
+        label="degen",
+        finger_holes=[],
+        interior_rings_mm=[],
+    )
+    config = FakeConfig()
+    ox, oy = _grid_offsets()
+
+    result = generator.generate_insert([degen], config, output_path, ox, oy)
+
+    assert result is False
+
+
+def test_generate_insert_with_hole(generator, output_path):
+    poly = ScaledPolygon(
+        id="holed",
+        points_mm=[(0, 0), (40, 0), (40, 40), (0, 40)],
+        label="holed",
+        finger_holes=[],
+        interior_rings_mm=[[(10, 10), (30, 10), (30, 30), (10, 30)]],
+    )
+    config = FakeConfig()
+    ox, oy = _grid_offsets()
+
+    result = generator.generate_insert([poly], config, output_path, ox, oy)
+
+    assert result is True
+    assert os.path.getsize(output_path) > 0

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -15,6 +15,14 @@ import { Alert } from '@/components/Alert'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { GRID_UNIT } from '@/lib/constants'
 
+function InfoBanner({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
+      {children}
+    </div>
+  )
+}
+
 function defaultConfig(): BinConfig {
   return {
     grid_x: 2,
@@ -376,14 +384,10 @@ export default function BinPage() {
         <div className="p-3 flex-shrink-0 space-y-1.5">
           {error && <Alert variant="error">{error}</Alert>}
           {warning && (
-            <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
-              {warning}
-            </div>
+            <InfoBanner>{warning}</InfoBanner>
           )}
           {splitCount > 1 && (
-            <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
-              Split into {splitCount} pieces
-            </div>
+            <InfoBanner>Split into {splitCount} pieces</InfoBanner>
           )}
           {hasExports && (
             <div className="relative" ref={exportRef}>

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -56,6 +56,7 @@ export default function BinPage() {
   const [loading, setLoading] = useState(true)
   const [generating, setGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [warning, setWarning] = useState<string | null>(null)
   const generateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastGenerateRef = useRef<string>('')
   const generatingRef = useRef(false)
@@ -134,6 +135,7 @@ export default function BinPage() {
     generatingRef.current = true
     setGenerating(true)
     setError(null)
+    setWarning(null)
     setStlUrl(null)
     setStlUrls([])
     setThreemfUrl(null)
@@ -152,6 +154,7 @@ export default function BinPage() {
       setInsertStlUrl(result.insert_stl_url ? getImageUrl(result.insert_stl_url) : null)
       setSplitCount(result.split_count || 1)
       setStlVersion(v => v + 1)
+      setWarning(result.warning || null)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
       setError(err instanceof Error ? err.message : 'generation failed')
@@ -372,6 +375,11 @@ export default function BinPage() {
         {/* export buttons */}
         <div className="p-3 flex-shrink-0 space-y-1.5">
           {error && <Alert variant="error">{error}</Alert>}
+          {warning && (
+            <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
+              {warning}
+            </div>
+          )}
           {splitCount > 1 && (
             <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
               Split into {splitCount} pieces

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -90,6 +90,7 @@ export interface GenerateResponse {
   split_count?: number
   zip_url?: string | null
   insert_stl_url?: string | null
+  warning?: string | null
 }
 
 export interface BinConfig {


### PR DESCRIPTION
Ref #26

## Summary

When "Contrast Insert" is toggled on but insert STL generation fails silently, the user sees a deeper pocket in the bin (correct) but no "Insert STL" option in the Export menu and no feedback about why. This PR:

- Adds a `warning` field to `GenerateResponse` so partial failures (insert generation failing while the bin itself succeeds) are communicated to the frontend
- Displays the warning in the export sidebar when insert generation fails
- Adds per-polygon logging in `generate_insert` with polygon IDs and failure reasons, so the root cause can be diagnosed from server logs
- Wraps the `generate_insert` call in a try/except so uncaught exceptions don't crash the entire generation
- Adds the warning to the cached response path too, so refreshing the page still shows the warning
- Adds `test_insert.py` with pytest tests covering: basic generation, empty polygons, custom height, multiple polygons, degenerate polygons, and polygons with holes

## Test plan

- [ ] Enable contrast insert on a bin with placed tools, verify "Insert STL" appears in Export dropdown
- [ ] Check server logs for new insert-related log lines
- [ ] If insert generation fails, verify warning message appears in the export sidebar
- [ ] Run `pytest backend/tests/test_insert.py` to verify insert generation tests pass