### PR TITLE
Fix cutout drag glitch with auto-size grid

### DIFF
--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -66,6 +66,7 @@ export default function BinPage() {
   const smoothLevelTimerRef = useRef<NodeJS.Timeout | null>(null)
 
   const [autoSize, setAutoSize] = useState(true)
+  const [isDragging, setIsDragging] = useState(false)
   const [exportOpen, setExportOpen] = useState(false)
   const exportRef = useRef<HTMLDivElement>(null)
 
@@ -204,7 +205,7 @@ export default function BinPage() {
 
   // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
   useEffect(() => {
-    if (!autoSize || placedTools.length === 0) return
+    if (!autoSize || isDragging || placedTools.length === 0) return
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
     for (const tool of placedTools) {
       for (const p of tool.points) {
@@ -242,7 +243,7 @@ export default function BinPage() {
         ),
       })))
     }
-  }, [autoSize, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance])
+  }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance])
 
   const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
     try {
@@ -462,6 +463,7 @@ export default function BinPage() {
                 onToggleSmoothed={handleToggleSmoothed}
                 smoothLevels={smoothLevels}
                 onSmoothLevelChange={handleSmoothLevelChange}
+                onDraggingChange={setIsDragging}
               />
             </div>
 

--- a/frontend/src/components/BinEditor.tsx
+++ b/frontend/src/components/BinEditor.tsx
@@ -20,6 +20,7 @@ interface Props {
   onToggleSmoothed?: (toolId: string, smoothed: boolean) => void
   smoothLevels?: Map<string, number>
   onSmoothLevelChange?: (toolId: string, level: number) => void
+  onDraggingChange?: (dragging: boolean) => void
 }
 
 type Tool = 'select' | 'text'
@@ -49,6 +50,7 @@ export function BinEditor({
   onToggleSmoothed,
   smoothLevels,
   onSmoothLevelChange,
+  onDraggingChange,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null)
   const [selection, setSelection] = useState<Selection>(null)
@@ -71,6 +73,8 @@ export function BinEditor({
   useEffect(() => { onChangeRef.current = onPlacedToolsChange }, [onPlacedToolsChange])
   useEffect(() => { textLabelsRef.current = textLabels }, [textLabels])
   useEffect(() => { onTextLabelsChangeRef.current = onTextLabelsChange }, [onTextLabelsChange])
+
+  useEffect(() => { onDraggingChange?.(dragging !== null) }, [dragging, onDraggingChange])
 
   const binWidthMm = gridX * GRID_UNIT
   const binHeightMm = gridY * GRID_UNIT


### PR DESCRIPTION
## Summary

- Suppresses auto-size grid recalculation while a cutout is being dragged, preventing the position-fighting glitch
- When the drag ends, auto-size runs once to settle grid dimensions
- Adds `onDraggingChange` callback from `BinEditor` to the bin page

Closes #29

## Test plan

- [ ] Enable "Auto-size grid", place a tool, drag it — should move smoothly without glitching
- [ ] After releasing the drag, grid should auto-size to fit the new position
- [ ] With auto-size disabled, drag behaviour unchanged
- [ ] Test in Firefox and Chrome