### PR TITLE
Add per-object depth control

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1021,6 +1021,7 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
                 fh.id, fh.x, fh.y, fh.radius,
                 shape=fh.shape, width_mm=fh.width, height_mm=fh.height,
                 rotation=fh.rotation,
+                depth_override=fh.depth_override,
             )
             for fh in pt.finger_holes
         ]
@@ -1028,7 +1029,7 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
             [(p.x, p.y) for p in ring]
             for ring in pt.interior_rings
         ]
-        sp = ScaledPolygon(pt.id, points_mm, pt.name, fholes, interior_rings_mm)
+        sp = ScaledPolygon(pt.id, points_mm, pt.name, fholes, interior_rings_mm, depth_override=pt.depth_override)
         sp = polygon_scaler.add_clearance(sp, bc.cutout_clearance)
         source_tool = user_tools.get(pt.tool_id)
         if source_tool and source_tool.smoothed:

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -18,6 +18,7 @@ class FingerHole(BaseModel):
     height: float | None = None  # for rectangles
     rotation: float = 0.0  # degrees
     shape: Literal["circle", "cylinder", "square", "rectangle"] = "circle"
+    depth_override: float | None = None  # mm; None = use bin_config.cutout_depth
 
 
 class TextLabel(BaseModel):
@@ -259,6 +260,7 @@ class PlacedTool(BaseModel):
     finger_holes: list[FingerHole] = []  # mm, bin-space
     interior_rings: list[list[Point]] = []  # mm, bin-space
     rotation: float = 0.0  # degrees, applied on top of library points
+    depth_override: float | None = None  # mm; None = use bin_config.cutout_depth
 
 
 class BinConfig(BinParams):

--- a/backend/app/services/bin_service.py
+++ b/backend/app/services/bin_service.py
@@ -29,6 +29,10 @@ def sync_placed_tools(bin_data, user_tools) -> bool:
             ry = (p.x - lib_cx) * sin_r + (p.y - lib_cy) * cos_r
             new_points.append(Point(x=placed_cx + rx, y=placed_cy + ry))
 
+        # preserve per-placement state (depth_override, etc.) by matching
+        # source-tool holes to existing placed holes by id. without this,
+        # GET /bins/{id} silently overwrites stored overrides on every load.
+        existing_overrides = {fh.id: fh.depth_override for fh in pt.finger_holes}
         new_fh = []
         for fh in tool.finger_holes:
             rx = (fh.x - lib_cx) * cos_r - (fh.y - lib_cy) * sin_r
@@ -37,6 +41,7 @@ def sync_placed_tools(bin_data, user_tools) -> bool:
                 id=fh.id, x=placed_cx + rx, y=placed_cy + ry,
                 radius=fh.radius, width=fh.width, height=fh.height,
                 rotation=fh.rotation, shape=fh.shape,
+                depth_override=existing_overrides.get(fh.id),
             ))
 
         new_rings = []

--- a/backend/app/services/polygon_scaler.py
+++ b/backend/app/services/polygon_scaler.py
@@ -33,6 +33,7 @@ class ScaledFingerHole:
         width_mm: float | None = None,
         height_mm: float | None = None,
         rotation: float = 0.0,
+        depth_override: float | None = None,
     ):
         self.id = id
         self.x_mm = x_mm
@@ -42,15 +43,17 @@ class ScaledFingerHole:
         self.width_mm = width_mm
         self.height_mm = height_mm
         self.rotation = rotation
+        self.depth_override = depth_override
 
 
 class ScaledPolygon:
-    def __init__(self, id: str, points_mm: list[tuple[float, float]], label: str, finger_holes: list[ScaledFingerHole] = None, interior_rings_mm: list[list[tuple[float, float]]] = None):
+    def __init__(self, id: str, points_mm: list[tuple[float, float]], label: str, finger_holes: list[ScaledFingerHole] = None, interior_rings_mm: list[list[tuple[float, float]]] = None, depth_override: float | None = None):
         self.id = id
         self.points_mm = points_mm
         self.label = label
         self.finger_holes = finger_holes or []
         self.interior_rings_mm = interior_rings_mm or []
+        self.depth_override = depth_override
 
 
 class PolygonScaler:
@@ -138,7 +141,7 @@ class PolygonScaler:
                 coords = polygon.points_mm
                 holes = polygon.interior_rings_mm
 
-            return ScaledPolygon(polygon.id, coords, polygon.label, polygon.finger_holes, holes)
+            return ScaledPolygon(polygon.id, coords, polygon.label, polygon.finger_holes, holes, depth_override=polygon.depth_override)
 
         except Exception:
             return polygon
@@ -158,7 +161,7 @@ class PolygonScaler:
             if simplified.geom_type == "Polygon" and len(simplified.exterior.coords) >= 4:
                 coords = list(simplified.exterior.coords)[:-1]
                 holes = [list(interior.coords)[:-1] for interior in simplified.interiors]
-                return ScaledPolygon(polygon.id, coords, polygon.label, polygon.finger_holes, holes)
+                return ScaledPolygon(polygon.id, coords, polygon.label, polygon.finger_holes, holes, depth_override=polygon.depth_override)
         except Exception:
             pass
 
@@ -181,7 +184,7 @@ class PolygonScaler:
         smoothed_rings = [_chaikin_smooth(ring) for ring in simplified.interior_rings_mm]
         # clean up dense chaikin output — remove near-collinear points that
         # cause clipper2 chord artifacts, while keeping the smooth shape
-        result = ScaledPolygon(polygon.id, smoothed_pts, polygon.label, polygon.finger_holes, smoothed_rings)
+        result = ScaledPolygon(polygon.id, smoothed_pts, polygon.label, polygon.finger_holes, smoothed_rings, depth_override=polygon.depth_override)
         return self.simplify(result, tolerance_mm=0.05)
 
     def compute_bounding_box(

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -171,6 +171,15 @@ def _build_shell(config: GenerateRequest):
 
 # ── cutter builders ───────────────────────────────────────────────────────────
 
+def _resolve_pocket_depth(override: float | None, config, max_depth: float) -> float:
+    """Per-feature pocket depth: override → config.cutout_depth fallback,
+    plus insert_height when enabled, clamped to [5, max_depth]."""
+    base = override if override is not None else config.cutout_depth
+    if getattr(config, 'insert_enabled', False):
+        base += getattr(config, 'insert_height', 1.0)
+    return max(5, min(base, max_depth))
+
+
 def _make_magnet_holes(config: GenerateRequest):
     """Batch union of all magnet hole cylinders (4 per grid cell, or corners only)."""
     import manifold3d as mf
@@ -259,7 +268,7 @@ def _make_polygon_cutouts(
     polygons: list[ScaledPolygon],
     config: GenerateRequest,
     wall_top_z: float,
-    pocket_depth: float,
+    max_depth: float,
     offset_x: float,
     offset_y: float,
 ):
@@ -296,6 +305,7 @@ def _make_polygon_cutouts(
             if cs.area() <= 0:
                 cs = mf.CrossSection([r[::-1] for r in rings], mf.FillRule.EvenOdd if has_holes else mf.FillRule.Positive)
             if cs.area() > 0:
+                pocket_depth = _resolve_pocket_depth(poly.depth_override, config, max_depth)
                 cutter = mf.Manifold.extrude(cs, pocket_depth + 0.01).translate(
                     (0.0, 0.0, wall_top_z - pocket_depth)
                 )
@@ -313,6 +323,7 @@ def _make_chamfer_cutouts(
     config,
     wall_top_z: float,
     chamfer_size: float,
+    max_depth: float,
     offset_x: float,
     offset_y: float,
 ):
@@ -321,6 +332,9 @@ def _make_chamfer_cutouts(
     Uses CrossSection.offset() for uniform chamfer width regardless of shape
     or rotation, then extrudes with scale_top to taper from the offset shape
     (at the bin surface) down to approximately the original shape.
+
+    Chamfer is clamped per-polygon to (pocket_depth - 1) so deep cutouts get
+    their full chamfer and shallow ones don't punch through the floor.
     """
     import manifold3d as mf
 
@@ -337,6 +351,12 @@ def _make_chamfer_cutouts(
             sh = [(p[0] + offset_x, -(p[1] + offset_y)) for p in hole]
             if len(sh) >= 3:
                 shifted_holes.append(sh)
+
+        pocket_depth = _resolve_pocket_depth(poly.depth_override, config, max_depth)
+        eff_chamfer = min(chamfer_size, max(0.0, pocket_depth - 1))
+        if eff_chamfer <= 0:
+            continue
+
         try:
             rings = _shapely_to_cross_sections(shifted, shifted_holes)
             if not rings:
@@ -354,7 +374,7 @@ def _make_chamfer_cutouts(
             # offset for uniform chamfer width regardless of shape/rotation.
             # use the offset bounds to compute scale_top — more accurate
             # than raw bounding-box math for rotated/irregular shapes.
-            cs_outer = cs.offset(chamfer_size, mf.JoinType.Round)
+            cs_outer = cs.offset(eff_chamfer, mf.JoinType.Round)
             if cs_outer.is_empty() or cs_outer.area() <= 0:
                 continue
 
@@ -375,10 +395,10 @@ def _make_chamfer_cutouts(
             # (bin surface). scale_top > 1 creates the taper.
             cutter = (
                 mf.Manifold.extrude(
-                    cs_centred, chamfer_size + 0.01,
+                    cs_centred, eff_chamfer + 0.01,
                     scale_top=(ow / iw, oh / ih),
                 )
-                .translate((icx, icy, wall_top_z - chamfer_size))
+                .translate((icx, icy, wall_top_z - eff_chamfer))
             )
             cutters.append(cutter)
         except Exception as e:
@@ -393,11 +413,14 @@ def _make_finger_holes(
     polygons: list[ScaledPolygon],
     config: GenerateRequest,
     wall_top_z: float,
-    pocket_depth: float,
+    max_depth: float,
     offset_x: float,
     offset_y: float,
 ):
-    """Batch union of all finger hole cutters."""
+    """Batch union of all finger hole cutters.
+
+    Per-feature depth: each hole resolves to its own depth_override, falling
+    back to the parent polygon's override, then the global cutout_depth."""
     import manifold3d as mf
 
     cutters = []
@@ -407,6 +430,8 @@ def _make_finger_holes(
             fh_y = -(fh.y_mm + offset_y)
             shape = getattr(fh, 'shape', 'circle')
             rotation = getattr(fh, 'rotation', 0.0)
+            override = fh.depth_override if fh.depth_override is not None else poly.depth_override
+            pocket_depth = _resolve_pocket_depth(override, config, max_depth)
             try:
                 if shape == 'circle':
                     r = fh.radius_mm
@@ -456,10 +481,14 @@ def _make_finger_hole_chamfers(
     config,
     wall_top_z: float,
     chamfer_size: float,
+    max_depth: float,
     offset_x: float,
     offset_y: float,
 ):
-    """Chamfer cutters for finger holes (circles, squares, rectangles)."""
+    """Chamfer cutters for finger holes (circles, squares, rectangles).
+
+    Per-feature: chamfer is clamped to (pocket_depth - 1) of each finger hole's
+    own depth (override → parent polygon override → global cutout_depth)."""
     import manifold3d as mf
 
     cutters = []
@@ -469,24 +498,29 @@ def _make_finger_hole_chamfers(
             fh_y = -(fh.y_mm + offset_y)
             shape = getattr(fh, 'shape', 'circle')
             rotation = getattr(fh, 'rotation', 0.0)
+            override = fh.depth_override if fh.depth_override is not None else poly.depth_override
+            pocket_depth = _resolve_pocket_depth(override, config, max_depth)
+            eff_chamfer = min(chamfer_size, max(0.0, pocket_depth - 1))
+            if eff_chamfer <= 0:
+                continue
             try:
                 if shape == 'circle' or shape == 'cylinder':
                     r = fh.radius_mm
                     cs = mf.CrossSection.circle(r, circular_segments=ROUND_SEGS)
-                    cs_outer = cs.offset(chamfer_size, mf.JoinType.Round)
+                    cs_outer = cs.offset(eff_chamfer, mf.JoinType.Round)
                 elif shape == 'square':
                     size = fh.radius_mm * 2
                     cs = mf.CrossSection.square((size, size), center=True)
                     if rotation:
                         cs = cs.rotate(rotation)
-                    cs_outer = cs.offset(chamfer_size, mf.JoinType.Round)
+                    cs_outer = cs.offset(eff_chamfer, mf.JoinType.Round)
                 elif shape == 'rectangle':
                     w = fh.width_mm if fh.width_mm else fh.radius_mm * 2
                     h = fh.height_mm if fh.height_mm else fh.radius_mm * 2
                     cs = mf.CrossSection.square((w, h), center=True)
                     if rotation:
                         cs = cs.rotate(rotation)
-                    cs_outer = cs.offset(chamfer_size, mf.JoinType.Round)
+                    cs_outer = cs.offset(eff_chamfer, mf.JoinType.Round)
                 else:
                     continue
 
@@ -504,10 +538,10 @@ def _make_finger_hole_chamfers(
 
                 cutter = (
                     mf.Manifold.extrude(
-                        cs, chamfer_size + 0.01,
+                        cs, eff_chamfer + 0.01,
                         scale_top=(ow / iw, oh / ih),
                     )
-                    .translate((fh_x, fh_y, wall_top_z - chamfer_size))
+                    .translate((fh_x, fh_y, wall_top_z - eff_chamfer))
                 )
                 cutters.append(cutter)
             except Exception as e:
@@ -761,35 +795,33 @@ class ManifoldSTLGenerator:
             floor_z = GF_BASE_HEIGHT
             lip_deduction = (LIP_D3 + LIP_D4) if config.stacking_lip else 0
             max_depth = wall_top_z - floor_z - 2 - lip_deduction
-            effective_cutout = config.cutout_depth
-            if getattr(config, 'insert_enabled', False):
-                effective_cutout += getattr(config, 'insert_height', 1.0)
-            pocket_depth = max(5, min(effective_cutout, max_depth))
+            # Default pocket_depth (used by text labels below) still tracks the
+            # global cutout_depth; per-cutout overrides are resolved inside the
+            # cutter functions via _resolve_pocket_depth.
+            pocket_depth = _resolve_pocket_depth(None, config, max_depth)
 
             t1 = time.monotonic()
-            cutouts = _make_polygon_cutouts(polygons, config, wall_top_z, pocket_depth, offset_x, offset_y)
+            cutouts = _make_polygon_cutouts(polygons, config, wall_top_z, max_depth, offset_x, offset_y)
             if cutouts:
                 cutters.append(cutouts)
             logger.info("polygon cutouts (%d): %.2fs", len(polygons), time.monotonic() - t1)
 
             t1 = time.monotonic()
-            fholes = _make_finger_holes(polygons, config, wall_top_z, pocket_depth, offset_x, offset_y)
+            fholes = _make_finger_holes(polygons, config, wall_top_z, max_depth, offset_x, offset_y)
             if fholes:
                 cutters.append(fholes)
             logger.info("finger holes: %.2fs", time.monotonic() - t1)
 
             chamfer_size = getattr(config, 'cutout_chamfer', 0.0)
             if chamfer_size > 0:
-                effective_chamfer = min(chamfer_size, max(0, pocket_depth - 1))
-                if effective_chamfer > 0:
-                    t1 = time.monotonic()
-                    chamfers = _make_chamfer_cutouts(polygons, config, wall_top_z, effective_chamfer, offset_x, offset_y)
-                    if chamfers:
-                        cutters.append(chamfers)
-                    fh_chamfers = _make_finger_hole_chamfers(polygons, config, wall_top_z, effective_chamfer, offset_x, offset_y)
-                    if fh_chamfers:
-                        cutters.append(fh_chamfers)
-                    logger.info("chamfer cutouts: %.2fs", time.monotonic() - t1)
+                t1 = time.monotonic()
+                chamfers = _make_chamfer_cutouts(polygons, config, wall_top_z, chamfer_size, max_depth, offset_x, offset_y)
+                if chamfers:
+                    cutters.append(chamfers)
+                fh_chamfers = _make_finger_hole_chamfers(polygons, config, wall_top_z, chamfer_size, max_depth, offset_x, offset_y)
+                if fh_chamfers:
+                    cutters.append(fh_chamfers)
+                logger.info("chamfer cutouts: %.2fs", time.monotonic() - t1)
 
         # text labels (recessed cutters + embossed body additions)
         text_body = None

--- a/backend/tests/test_cylinder_shape.py
+++ b/backend/tests/test_cylinder_shape.py
@@ -28,7 +28,7 @@ class TestCylinderShape:
         poly = _scaled_poly_with_hole("cylinder")
         config = BinParams(cutout_depth=15.0)
         result = _make_finger_holes(
-            [poly], config, wall_top_z=33.0, pocket_depth=15.0,
+            [poly], config, wall_top_z=33.0, max_depth=15.0,
             offset_x=0.0, offset_y=0.0,
         )
         assert result is not None
@@ -45,7 +45,7 @@ class TestCylinderShape:
         config = BinParams(cutout_depth=12.0)
         wall_top = 30.0
         result = _make_finger_holes(
-            [poly], config, wall_top_z=wall_top, pocket_depth=12.0,
+            [poly], config, wall_top_z=wall_top, max_depth=12.0,
             offset_x=0.0, offset_y=0.0,
         )
         assert result is not None
@@ -58,7 +58,7 @@ class TestCylinderShape:
         config = BinParams(cutout_depth=15.0, cutout_chamfer=1.0)
         result = _make_finger_hole_chamfers(
             [poly], config, wall_top_z=33.0, chamfer_size=1.0,
-            offset_x=0.0, offset_y=0.0,
+            max_depth=15.0, offset_x=0.0, offset_y=0.0,
         )
         assert result is not None
 
@@ -77,8 +77,8 @@ class TestCylinderShape:
         circ_poly = _scaled_poly_with_hole("circle", radius=radius)
         config = BinParams(cutout_depth=depth)
 
-        cyl = _make_finger_holes([cyl_poly], config, wall_top_z=wall_top, pocket_depth=depth, offset_x=0.0, offset_y=0.0)
-        circ = _make_finger_holes([circ_poly], config, wall_top_z=wall_top, pocket_depth=depth, offset_x=0.0, offset_y=0.0)
+        cyl = _make_finger_holes([cyl_poly], config, wall_top_z=wall_top, max_depth=depth, offset_x=0.0, offset_y=0.0)
+        circ = _make_finger_holes([circ_poly], config, wall_top_z=wall_top, max_depth=depth, offset_x=0.0, offset_y=0.0)
         cyl_floor_z = cyl.bounding_box()[2]
         circ_floor_z = circ.bounding_box()[2]
 

--- a/backend/tests/test_per_cutout_depth.py
+++ b/backend/tests/test_per_cutout_depth.py
@@ -1,0 +1,41 @@
+"""Tests for per-cutout depth override in stl_generator_manifold."""
+from app.models.schemas import BinParams
+from app.services.stl_generator_manifold import _resolve_pocket_depth
+
+
+class TestResolvePocketDepth:
+    def test_no_override_uses_global(self):
+        bp = BinParams(cutout_depth=20)
+        assert _resolve_pocket_depth(None, bp, max_depth=100) == 20.0
+
+    def test_override_takes_precedence(self):
+        bp = BinParams(cutout_depth=20)
+        assert _resolve_pocket_depth(8, bp, max_depth=100) == 8.0
+
+    def test_override_clamped_to_min(self):
+        bp = BinParams(cutout_depth=20)
+        assert _resolve_pocket_depth(2, bp, max_depth=100) == 5.0
+
+    def test_override_clamped_to_max(self):
+        bp = BinParams(cutout_depth=20)
+        assert _resolve_pocket_depth(150, bp, max_depth=100) == 100.0
+
+    def test_global_clamped_to_max(self):
+        bp = BinParams(cutout_depth=200)
+        assert _resolve_pocket_depth(None, bp, max_depth=50) == 50.0
+
+    def test_insert_height_added_to_global(self):
+        bp = BinParams(cutout_depth=20, insert_enabled=True, insert_height=2.5)
+        assert _resolve_pocket_depth(None, bp, max_depth=100) == 22.5
+
+    def test_insert_height_added_to_override(self):
+        bp = BinParams(cutout_depth=20, insert_enabled=True, insert_height=2.5)
+        assert _resolve_pocket_depth(10, bp, max_depth=100) == 12.5
+
+    def test_insert_disabled_ignores_insert_height(self):
+        bp = BinParams(cutout_depth=20, insert_enabled=False, insert_height=5.0)
+        assert _resolve_pocket_depth(None, bp, max_depth=100) == 20.0
+
+    def test_zero_override_is_clamped_to_min(self):
+        bp = BinParams(cutout_depth=20)
+        assert _resolve_pocket_depth(0, bp, max_depth=100) == 5.0

--- a/backend/tests/test_sync_preserves_overrides.py
+++ b/backend/tests/test_sync_preserves_overrides.py
@@ -1,0 +1,83 @@
+"""Tests that sync_placed_tools preserves per-placement state across loads.
+
+Regression: GET /bins/{id} runs sync_placed_tools, which rebuilt finger_holes
+from the source tool and dropped depth_override; the diff check then wrote
+the cleared bin back to disk, permanently losing user overrides.
+"""
+from app.models.schemas import FingerHole, PlacedTool, Point, Tool, BinModel, BinConfig
+from app.services.bin_service import sync_placed_tools
+
+
+class _Store:
+    def __init__(self, items):
+        self._d = {item.id: item for item in items}
+
+    def get(self, key):
+        return self._d.get(key)
+
+
+def _make_source_tool(tool_id="tool1", hole_ids=("h1",)):
+    return Tool(
+        id=tool_id,
+        name="hammer",
+        points=[Point(x=0, y=0), Point(x=10, y=0), Point(x=10, y=10), Point(x=0, y=10)],
+        finger_holes=[FingerHole(id=hid, x=5, y=5, radius=2.0, shape="circle") for hid in hole_ids],
+        interior_rings=[],
+    )
+
+
+def _make_bin_with_placed(tool_id, hole_ids, depth_override=None, hole_depth_overrides=None):
+    hole_depth_overrides = hole_depth_overrides or {}
+    placed = PlacedTool(
+        id="placement1",
+        tool_id=tool_id,
+        name="hammer",
+        points=[Point(x=20, y=20), Point(x=30, y=20), Point(x=30, y=30), Point(x=20, y=30)],
+        finger_holes=[
+            FingerHole(
+                id=hid, x=25, y=25, radius=2.0, shape="circle",
+                depth_override=hole_depth_overrides.get(hid),
+            )
+            for hid in hole_ids
+        ],
+        interior_rings=[],
+        depth_override=depth_override,
+    )
+    return BinModel(id="bin1", bin_config=BinConfig(), placed_tools=[placed])
+
+
+class TestSyncPreservesOverrides:
+    def test_per_hole_depth_override_survives_sync(self):
+        bin_data = _make_bin_with_placed("tool1", ["h1"], hole_depth_overrides={"h1": 25.0})
+        tools = _Store([_make_source_tool("tool1", ("h1",))])
+
+        sync_placed_tools(bin_data, tools)
+
+        assert bin_data.placed_tools[0].finger_holes[0].depth_override == 25.0
+
+    def test_per_tool_depth_override_survives_sync(self):
+        bin_data = _make_bin_with_placed("tool1", ["h1"], depth_override=30.0)
+        tools = _Store([_make_source_tool("tool1", ("h1",))])
+
+        sync_placed_tools(bin_data, tools)
+
+        assert bin_data.placed_tools[0].depth_override == 30.0
+
+    def test_new_source_hole_gets_no_override(self):
+        # source tool gains a new hole h2; placed should pick it up with no override
+        bin_data = _make_bin_with_placed("tool1", ["h1"], hole_depth_overrides={"h1": 25.0})
+        tools = _Store([_make_source_tool("tool1", ("h1", "h2"))])
+
+        sync_placed_tools(bin_data, tools)
+
+        holes = {fh.id: fh for fh in bin_data.placed_tools[0].finger_holes}
+        assert holes["h1"].depth_override == 25.0
+        assert holes["h2"].depth_override is None
+
+    def test_no_override_means_no_change_to_override_field(self):
+        bin_data = _make_bin_with_placed("tool1", ["h1"])
+        tools = _Store([_make_source_tool("tool1", ("h1",))])
+
+        sync_placed_tools(bin_data, tools)
+
+        assert bin_data.placed_tools[0].finger_holes[0].depth_override is None

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { BinEditor } from '@/components/BinEditor'
-import { BinConfigurator } from '@/components/BinConfigurator'
+import { BinConfigurator, calcMaxCutoutDepth } from '@/components/BinConfigurator'
 import { BinPreview3D } from '@/components/BinPreview3D'
 import { ToolBrowser } from '@/components/ToolBrowser'
 import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
@@ -470,6 +470,8 @@ export default function BinPage() {
                 gridX={config.grid_x}
                 gridY={config.grid_y}
                 wallThickness={config.wall_thickness}
+                defaultCutoutDepth={config.cutout_depth}
+                maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
                 onEditTool={(toolId) => router.push(`/tools/${toolId}`)}
                 smoothedToolIds={smoothedToolIds}
                 onToggleSmoothed={handleToggleSmoothed}

--- a/frontend/src/components/BinEditor.tsx
+++ b/frontend/src/components/BinEditor.tsx
@@ -15,6 +15,8 @@ interface Props {
   gridX: number
   gridY: number
   wallThickness: number
+  defaultCutoutDepth: number
+  maxCutoutDepth: number
   onEditTool?: (toolId: string) => void
   smoothedToolIds?: Set<string>
   onToggleSmoothed?: (toolId: string, smoothed: boolean) => void
@@ -27,6 +29,7 @@ type Tool = 'select' | 'text'
 
 type Selection =
   | { type: 'tool'; toolId: string }
+  | { type: 'hole'; toolId: string; holeId: string }
   | { type: 'label'; labelId: string }
   | null
 
@@ -45,6 +48,8 @@ export function BinEditor({
   gridX,
   gridY,
   wallThickness,
+  defaultCutoutDepth,
+  maxCutoutDepth,
   onEditTool,
   smoothedToolIds,
   onToggleSmoothed,
@@ -450,12 +455,41 @@ export function BinEditor({
     ? placedTools.find(t => t.id === selection.toolId)
     : null
 
+  const selectedHole = selection?.type === 'hole'
+    ? placedTools
+        .find(t => t.id === selection.toolId)
+        ?.finger_holes.find(fh => fh.id === selection.holeId)
+    : null
+
   const updateSelectedLabel = (updates: Partial<TextLabel>) => {
     if (selection?.type !== 'label') return
     onTextLabelsChange(textLabels.map(l => {
       if (l.id !== selection.labelId) return l
       return { ...l, ...updates }
     }))
+  }
+
+  const setCutoutDepthOverride = (toolId: string, depth: number | null) => {
+    onPlacedToolsChange(placedTools.map(t =>
+      t.id === toolId ? { ...t, depth_override: depth } : t
+    ))
+  }
+
+  const setHoleDepthOverride = (toolId: string, holeId: string, depth: number | null) => {
+    onPlacedToolsChange(placedTools.map(t => {
+      if (t.id !== toolId) return t
+      return {
+        ...t,
+        finger_holes: t.finger_holes.map(fh =>
+          fh.id === holeId ? { ...fh, depth_override: depth } : fh
+        ),
+      }
+    }))
+  }
+
+  const handleHoleClick = (toolId: string, holeId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSelection({ type: 'hole', toolId, holeId })
   }
 
   const handleEditingLabelKeyDown = (e: React.KeyboardEvent) => {
@@ -480,6 +514,8 @@ export function BinEditor({
           handleRecenter={handleRecenter}
           selectedTool={selectedTool ?? null}
           selectedLabel={selectedLabel ?? null}
+          selectedHole={selectedHole ?? null}
+          selectedHoleToolId={selection?.type === 'hole' ? selection.toolId : null}
           onEditTool={onEditTool}
           onRemoveTool={handleDeleteTool}
           onRemoveLabel={handleDeleteLabel}
@@ -488,6 +524,10 @@ export function BinEditor({
           onToggleSmoothed={onToggleSmoothed}
           onSmoothLevelChange={onSmoothLevelChange}
           onUpdateLabel={updateSelectedLabel}
+          defaultCutoutDepth={defaultCutoutDepth}
+          maxCutoutDepth={maxCutoutDepth}
+          onSetCutoutDepthOverride={setCutoutDepthOverride}
+          onSetHoleDepthOverride={setHoleDepthOverride}
         />
       </div>
       <BinEditorCanvas
@@ -499,6 +539,7 @@ export function BinEditor({
         wallThickness={wallThickness}
         placedTools={placedTools}
         selection={selection}
+        onHoleClick={handleHoleClick}
         textLabels={textLabels}
         editingLabelId={editingLabelId}
         editingText={editingText}

--- a/frontend/src/components/BinEditorCanvas.tsx
+++ b/frontend/src/components/BinEditorCanvas.tsx
@@ -10,6 +10,7 @@ type Tool = 'select' | 'text'
 
 type Selection =
   | { type: 'tool'; toolId: string }
+  | { type: 'hole'; toolId: string; holeId: string }
   | { type: 'label'; labelId: string }
   | null
 
@@ -45,6 +46,7 @@ interface Props {
   handleLabelMouseDown: (labelId: string) => (e: React.MouseEvent) => void
   handleLabelRotateMouseDown: (labelId: string) => (e: React.MouseEvent) => void
   handleLabelDoubleClick: (labelId: string) => (e: React.MouseEvent) => void
+  onHoleClick: (toolId: string, holeId: string, e: React.MouseEvent) => void
   handleBackgroundClick: (e: React.MouseEvent) => void
   stopClick: (e: React.MouseEvent) => void
   stopClickUnlessText: (e: React.MouseEvent) => void
@@ -85,6 +87,7 @@ export function BinEditorCanvas({
   handleLabelMouseDown,
   handleLabelRotateMouseDown,
   handleLabelDoubleClick,
+  onHoleClick,
   handleBackgroundClick,
   stopClick,
   stopClickUnlessText,
@@ -164,7 +167,12 @@ export function BinEditorCanvas({
                   onClick={stopClickUnlessText}
                 />
 
-                <CutoutOverlay holes={tool.finger_holes} />
+                <CutoutOverlay
+                  holes={tool.finger_holes}
+                  interactive={activeTool === 'select'}
+                  selectedId={selection?.type === 'hole' && selection.toolId === tool.id ? selection.holeId : undefined}
+                  onMouseDown={(holeId, e) => onHoleClick(tool.id, holeId, e)}
+                />
               </g>
             )
           })}

--- a/frontend/src/components/BinEditorToolbar.tsx
+++ b/frontend/src/components/BinEditorToolbar.tsx
@@ -1,8 +1,73 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { MousePointer2, Trash2, Magnet, Type, Pencil, Maximize2 } from 'lucide-react'
-import type { PlacedTool, TextLabel } from '@/types'
+import type { FingerHole, PlacedTool, TextLabel } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
+
+interface DepthInputProps {
+  value: number | null | undefined
+  defaultDepth: number
+  maxDepth: number
+  onCommit: (depth: number | null) => void
+  resetKey: string
+}
+
+function DepthInput({ value, defaultDepth, maxDepth, onCommit, resetKey }: DepthInputProps) {
+  const [text, setText] = useState<string>(value == null ? '' : String(value))
+
+  // sync local text when the selected item changes (resetKey switches)
+  useEffect(() => {
+    setText(value == null ? '' : String(value))
+  }, [resetKey, value])
+
+  const commit = (raw: string) => {
+    const trimmed = raw.trim()
+    if (trimmed === '') {
+      onCommit(null)
+      return
+    }
+    const n = parseFloat(trimmed)
+    if (Number.isNaN(n)) {
+      // revert local text to last committed value
+      setText(value == null ? '' : String(value))
+      return
+    }
+    const clamped = Math.max(5, Math.min(maxDepth, n))
+    setText(String(clamped))
+    onCommit(clamped)
+  }
+
+  return (
+    <>
+      <input
+        type="number"
+        value={text}
+        placeholder={defaultDepth.toFixed(1)}
+        step={0.5}
+        onChange={e => setText(e.target.value)}
+        onBlur={e => commit(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur()
+          if (e.key === 'Escape') {
+            setText(value == null ? '' : String(value))
+            ;(e.currentTarget as HTMLInputElement).blur()
+          }
+        }}
+        className="w-12 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
+      />
+      {value != null && (
+        <button
+          onClick={() => { setText(''); onCommit(null) }}
+          className="text-[10px] text-text-muted hover:text-text-secondary px-1"
+          title="Reset to default"
+        >
+          ×
+        </button>
+      )}
+    </>
+  )
+}
 
 type Tool = 'select' | 'text'
 
@@ -14,6 +79,8 @@ interface Props {
   handleRecenter: () => void
   selectedTool: PlacedTool | null
   selectedLabel: TextLabel | null
+  selectedHole: FingerHole | null
+  selectedHoleToolId: string | null
   onEditTool?: (toolId: string) => void
   onRemoveTool: () => void
   onRemoveLabel: () => void
@@ -22,6 +89,10 @@ interface Props {
   onToggleSmoothed?: (toolId: string, smoothed: boolean) => void
   onSmoothLevelChange?: (toolId: string, level: number) => void
   onUpdateLabel: (updates: Partial<TextLabel>) => void
+  defaultCutoutDepth: number
+  maxCutoutDepth: number
+  onSetCutoutDepthOverride: (toolId: string, depth: number | null) => void
+  onSetHoleDepthOverride: (toolId: string, holeId: string, depth: number | null) => void
 }
 
 const tbBtn = 'flex items-center gap-1.5 px-2.5 py-1.5 rounded-[7px] text-[11px] font-medium transition-colors cursor-pointer whitespace-nowrap'
@@ -36,6 +107,8 @@ export function BinEditorToolbar({
   handleRecenter,
   selectedTool,
   selectedLabel,
+  selectedHole,
+  selectedHoleToolId,
   onEditTool,
   onRemoveTool,
   onRemoveLabel,
@@ -44,6 +117,10 @@ export function BinEditorToolbar({
   onToggleSmoothed,
   onSmoothLevelChange,
   onUpdateLabel,
+  defaultCutoutDepth,
+  maxCutoutDepth,
+  onSetCutoutDepthOverride,
+  onSetHoleDepthOverride,
 }: Props) {
   return (
     <>
@@ -110,6 +187,19 @@ export function BinEditorToolbar({
               className="w-16 h-1 accent-accent"
             />
           )}
+          <div
+            className="flex items-center gap-1 text-[10px] text-text-muted"
+            title={`Cutout depth (mm). Default: ${defaultCutoutDepth.toFixed(1)}mm. Max: ${maxCutoutDepth.toFixed(1)}mm.`}
+          >
+            <span>Depth</span>
+            <DepthInput
+              value={selectedTool.depth_override}
+              defaultDepth={defaultCutoutDepth}
+              maxDepth={maxCutoutDepth}
+              onCommit={(d) => onSetCutoutDepthOverride(selectedTool.id, d)}
+              resetKey={`tool:${selectedTool.id}`}
+            />
+          </div>
           {onEditTool && (
             <button
               onClick={() => onEditTool(selectedTool.tool_id)}
@@ -180,6 +270,33 @@ export function BinEditorToolbar({
           <button onClick={onRemoveLabel} className={`${tbBtn} text-red-400 hover:bg-red-900/20`}>
             <Trash2 className="w-3 h-3" />
           </button>
+        </>
+      )}
+
+      {selectedHole && selectedHoleToolId && (
+        <>
+          <div className="w-px h-4 bg-glass-border mx-1 flex-shrink-0" />
+          <span className="text-[10px] text-text-muted">
+            {selectedHole.shape || 'circle'}
+            {selectedHole.shape === 'rectangle' && selectedHole.width && selectedHole.height
+              ? ` ${selectedHole.width.toFixed(0)}×${selectedHole.height.toFixed(0)}mm`
+              : selectedHole.shape === 'square'
+              ? ` ${(selectedHole.radius * 2).toFixed(0)}mm`
+              : ` r=${selectedHole.radius.toFixed(1)}mm`}
+          </span>
+          <div
+            className="flex items-center gap-1 text-[10px] text-text-muted"
+            title={`Cutout depth (mm). Default: ${defaultCutoutDepth.toFixed(1)}mm. Max: ${maxCutoutDepth.toFixed(1)}mm. Set deeper than the tool to clear protruding features.`}
+          >
+            <span>Depth</span>
+            <DepthInput
+              value={selectedHole.depth_override}
+              defaultDepth={defaultCutoutDepth}
+              maxDepth={maxCutoutDepth}
+              onCommit={(d) => onSetHoleDepthOverride(selectedHoleToolId, selectedHole.id, d)}
+              resetKey={`hole:${selectedHoleToolId}:${selectedHole.id}`}
+            />
+          </div>
         </>
       )}
     </>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ export interface FingerHole {
   shape?: 'circle' | 'cylinder' | 'square' | 'rectangle'
   width?: number
   height?: number
+  depth_override?: number | null
 }
 
 export interface Polygon {
@@ -148,6 +149,7 @@ export interface PlacedTool {
   finger_holes: FingerHole[]
   interior_rings: Point[][]
   rotation: number
+  depth_override?: number | null
 }
 
 export interface BinData {


### PR DESCRIPTION
## Summary

- `PlacedTool` and `FingerHole` gain an optional `depth_override` that beats the bin's global `cutout_depth`. Resolution is `fh.depth_override` → `polygon.depth_override` → global, clamped to `[5, max_depth]`.
- Chamfer is clamped per-feature against its own pocket depth, so deep cutouts get a full chamfer and shallow ones don't punch through the floor.
- Bin Editor: click a placed tool to set the outline depth; click a finger hole to set that hole's depth. Empty input inherits; × resets. The existing `CutoutOverlay` is now interactive in the bin editor as well as the tool editor.