### PR TITLE
Add cylinder cutout shape

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -17,7 +17,7 @@ class FingerHole(BaseModel):
     width: float | None = None  # for rectangles
     height: float | None = None  # for rectangles
     rotation: float = 0.0  # degrees
-    shape: Literal["circle", "square", "rectangle"] = "circle"
+    shape: Literal["circle", "cylinder", "square", "rectangle"] = "circle"
 
 
 class TextLabel(BaseModel):

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -417,6 +417,12 @@ def _make_finger_holes(
                     cutter = mf.Manifold.sphere(r, circular_segments=ROUND_SEGS).translate(
                         (fh_x, fh_y, sphere_z)
                     )
+                elif shape == 'cylinder':
+                    r = fh.radius_mm
+                    cutter = (
+                        mf.Manifold.cylinder(pocket_depth + 0.01, r, circular_segments=ROUND_SEGS)
+                        .translate((fh_x, fh_y, wall_top_z - pocket_depth))
+                    )
                 elif shape == 'square':
                     size = fh.radius_mm * 2
                     cut_z = wall_top_z - pocket_depth / 2
@@ -464,7 +470,7 @@ def _make_finger_hole_chamfers(
             shape = getattr(fh, 'shape', 'circle')
             rotation = getattr(fh, 'rotation', 0.0)
             try:
-                if shape == 'circle':
+                if shape == 'circle' or shape == 'cylinder':
                     r = fh.radius_mm
                     cs = mf.CrossSection.circle(r, circular_segments=ROUND_SEGS)
                     cs_outer = cs.offset(chamfer_size, mf.JoinType.Round)

--- a/backend/tests/test_cylinder_shape.py
+++ b/backend/tests/test_cylinder_shape.py
@@ -1,0 +1,87 @@
+"""Tests for the cylinder finger-hole shape."""
+from app.models.schemas import BinParams
+from app.services.polygon_scaler import ScaledFingerHole, ScaledPolygon
+from app.services.stl_generator_manifold import (
+    _make_finger_hole_chamfers,
+    _make_finger_holes,
+)
+
+
+def _scaled_poly_with_hole(shape: str, radius=10.0):
+    fh = ScaledFingerHole(
+        id="fh1",
+        x_mm=0.0,
+        y_mm=0.0,
+        radius_mm=radius,
+        shape=shape,
+    )
+    return ScaledPolygon(
+        id="p1",
+        points_mm=[(-30, -30), (30, -30), (30, 30), (-30, 30)],
+        label="test",
+        finger_holes=[fh],
+    )
+
+
+class TestCylinderShape:
+    def test_cylinder_produces_cutter(self):
+        poly = _scaled_poly_with_hole("cylinder")
+        config = BinParams(cutout_depth=15.0)
+        result = _make_finger_holes(
+            [poly], config, wall_top_z=33.0, pocket_depth=15.0,
+            offset_x=0.0, offset_y=0.0,
+        )
+        assert result is not None
+        bb = result.bounding_box()
+        # bb is (min_x, min_y, min_z, max_x, max_y, max_z)
+        z_extent = bb[5] - bb[2]
+        assert 14.5 < z_extent < 16.0, f"expected ~15mm, got {z_extent}"
+
+    def test_cylinder_bottom_is_flat(self):
+        # cylinder's bottom face sits at exactly wall_top_z - pocket_depth,
+        # proving full-depth reach (vs the sphere shape which is capped at
+        # its own radius).
+        poly = _scaled_poly_with_hole("cylinder")
+        config = BinParams(cutout_depth=12.0)
+        wall_top = 30.0
+        result = _make_finger_holes(
+            [poly], config, wall_top_z=wall_top, pocket_depth=12.0,
+            offset_x=0.0, offset_y=0.0,
+        )
+        assert result is not None
+        bb = result.bounding_box()
+        expected_floor = wall_top - 12.0
+        assert abs(bb[2] - expected_floor) < 0.05
+
+    def test_cylinder_chamfer_cutter_built(self):
+        poly = _scaled_poly_with_hole("cylinder")
+        config = BinParams(cutout_depth=15.0, cutout_chamfer=1.0)
+        result = _make_finger_hole_chamfers(
+            [poly], config, wall_top_z=33.0, chamfer_size=1.0,
+            offset_x=0.0, offset_y=0.0,
+        )
+        assert result is not None
+
+    def test_cylinder_cuts_deeper_than_sphere_when_radius_limits(self):
+        # the circle (sphere) cutter is sphere-shaped, so when the requested
+        # pocket_depth exceeds the sphere's radius the sphere is recentred at
+        # wall_top_z and only reaches `radius` deep — losing the rest. The
+        # cylinder reaches the full pocket_depth regardless. This is the
+        # primary use case for the cylinder shape (clearance pockets that
+        # need to be deeper than the hole's own radius).
+        wall_top = 30.0
+        depth = 15.0
+        radius = 10.0  # depth > radius → sphere truncates
+
+        cyl_poly = _scaled_poly_with_hole("cylinder", radius=radius)
+        circ_poly = _scaled_poly_with_hole("circle", radius=radius)
+        config = BinParams(cutout_depth=depth)
+
+        cyl = _make_finger_holes([cyl_poly], config, wall_top_z=wall_top, pocket_depth=depth, offset_x=0.0, offset_y=0.0)
+        circ = _make_finger_holes([circ_poly], config, wall_top_z=wall_top, pocket_depth=depth, offset_x=0.0, offset_y=0.0)
+        cyl_floor_z = cyl.bounding_box()[2]
+        circ_floor_z = circ.bounding_box()[2]
+
+        assert abs(cyl_floor_z - (wall_top - depth)) < 0.05
+        assert abs(circ_floor_z - (wall_top - radius)) < 0.05
+        assert cyl_floor_z < circ_floor_z - 1.0

--- a/frontend/src/components/CutoutOverlay.tsx
+++ b/frontend/src/components/CutoutOverlay.tsx
@@ -31,13 +31,20 @@ export function CutoutOverlay({ holes, zoom = 1, interactive, selectedId, editMo
 
         return (
           <g key={fh.id} transform={rotation !== 0 ? `rotate(${rotation} ${x} ${y})` : undefined}>
-            {shape === 'circle' && (
+            {(shape === 'circle' || shape === 'cylinder') && (
               <circle
                 cx={x} cy={y} r={r}
                 fill={fill} stroke={stroke} strokeWidth={strokeWidth}
                 className={cursor}
                 onMouseDown={interactive && onMouseDown ? (e) => onMouseDown(fh.id, e) : undefined}
                 onClick={interactive && onClick ? onClick : undefined}
+              />
+            )}
+            {shape === 'cylinder' && (
+              <circle
+                cx={x} cy={y} r={Math.max(0.5, r * 0.35)}
+                fill="none" stroke={stroke} strokeWidth={strokeWidth}
+                className="pointer-events-none"
               />
             )}
             {(shape === 'square' || shape === 'rectangle') && (

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
-import { Plus, Circle, Square, RectangleHorizontal, Fingerprint } from 'lucide-react'
+import { Plus, Circle, Disc, Square, RectangleHorizontal, Fingerprint } from 'lucide-react'
 import type { Point, FingerHole } from '@/types'
 import { simplifyPolygon, smoothEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
 import { DISPLAY_SCALE, SNAP_GRID, ZOOM_FACTOR } from '@/lib/constants'
@@ -302,6 +302,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     switch (editMode) {
       case 'finger-hole': return { ...base, radius: 15, shape: 'circle' as const }
       case 'circle': return { ...base, radius: 10, shape: 'circle' as const }
+      case 'cylinder': return { ...base, radius: 10, shape: 'cylinder' as const }
       case 'square': return { ...base, radius: 10, shape: 'square' as const }
       case 'rectangle': return { ...base, radius: 15, width: 30, height: 20, shape: 'rectangle' as const }
       default: return null
@@ -393,7 +394,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       didPanRef.current = false
       return
     }
-    if (editMode === 'finger-hole' || editMode === 'circle' || editMode === 'square' || editMode === 'rectangle') {
+    if (editMode === 'finger-hole' || editMode === 'circle' || editMode === 'cylinder' || editMode === 'square' || editMode === 'rectangle') {
       const pos = screenToMm(e.clientX, e.clientY)
       const cutout = createCutout(snapToGrid(pos.x), snapToGrid(pos.y))
       if (cutout) {
@@ -551,16 +552,18 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     onInteriorRingsChange(updated)
   }, [currentRings, points, fingerHoles, pushHistory, onInteriorRingsChange])
 
-  const isCutoutMode = editMode === 'finger-hole' || editMode === 'circle' || editMode === 'square' || editMode === 'rectangle'
+  const isCutoutMode = editMode === 'finger-hole' || editMode === 'circle' || editMode === 'cylinder' || editMode === 'square' || editMode === 'rectangle'
 
   const cutoutModeIcon = editMode === 'finger-hole' ? <Fingerprint className="w-4.5 h-4.5" />
     : editMode === 'circle' ? <Circle className="w-4.5 h-4.5" />
+    : editMode === 'cylinder' ? <Disc className="w-4.5 h-4.5" />
     : editMode === 'square' ? <Square className="w-4.5 h-4.5" />
     : editMode === 'rectangle' ? <RectangleHorizontal className="w-4.5 h-4.5" />
     : <Plus className="w-4.5 h-4.5" />
 
   const cutoutModeLabel = editMode === 'finger-hole' ? 'Finger hole'
     : editMode === 'circle' ? 'Circle'
+    : editMode === 'cylinder' ? 'Cylinder'
     : editMode === 'square' ? 'Square'
     : editMode === 'rectangle' ? 'Rectangle'
     : 'Cutout'

--- a/frontend/src/components/ToolEditorCanvas.tsx
+++ b/frontend/src/components/ToolEditorCanvas.tsx
@@ -253,7 +253,7 @@ export function ToolEditorCanvas({
             const h = shape === 'rectangle' && fh.height ? fh.height * DISPLAY_SCALE : r * 2
             const s = zvbW / 800
             const handleR = 10 * s
-            const topEdge = shape === 'circle' ? r : h / 2
+            const topEdge = shape === 'circle' || shape === 'cylinder' ? r : h / 2
             const hr = 18 * s
 
             if (shape === 'rectangle') {

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket } from 'lucide-react'
+import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket } from 'lucide-react'
 import type { FingerHole } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
 
-export type EditMode = 'select' | 'add-vertex' | 'delete-vertex' | 'finger-hole' | 'circle' | 'square' | 'rectangle' | 'fill-ring'
+export type EditMode = 'select' | 'add-vertex' | 'delete-vertex' | 'finger-hole' | 'circle' | 'cylinder' | 'square' | 'rectangle' | 'fill-ring'
 
 export type Selection =
   | { type: 'vertex'; pointIdx: number }
@@ -103,7 +103,8 @@ export function ToolEditorToolbar({
                 <div className="absolute top-full left-0 mt-1 bg-elevated border border-border rounded-lg shadow-lg z-20 py-1 min-w-[160px]">
                   {([
                     { mode: 'finger-hole' as EditMode, icon: <Fingerprint className="w-4 h-4" />, label: 'Finger hole', size: '15mm' },
-                    { mode: 'circle' as EditMode, icon: <Circle className="w-4 h-4" />, label: 'Circle', size: '10mm' },
+                    { mode: 'circle' as EditMode, icon: <Circle className="w-4 h-4" />, label: 'Circle (sphere)', size: '10mm' },
+                    { mode: 'cylinder' as EditMode, icon: <Disc className="w-4 h-4" />, label: 'Cylinder (flat)', size: '10mm' },
                     { mode: 'square' as EditMode, icon: <Square className="w-4 h-4" />, label: 'Square', size: '20mm' },
                     { mode: 'rectangle' as EditMode, icon: <RectangleHorizontal className="w-4 h-4" />, label: 'Rectangle', size: '30x20mm' },
                   ]).map(item => (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,7 +9,7 @@ export interface FingerHole {
   y: number
   radius: number
   rotation?: number
-  shape?: 'circle' | 'square' | 'rectangle'
+  shape?: 'circle' | 'cylinder' | 'square' | 'rectangle'
   width?: number
   height?: number
 }


### PR DESCRIPTION
## Summary

Adds `cylinder` as a new object shape next to the existing primitives. Cylinder extrudes a flat-bottomed cylinder for the full pocket depth, so a 10mm-radius hole can actually go 25mm deep (the sphere shape can't go deeper than its radius). Useful for clearance pockets that need to be deeper than wide.