### PR TITLE
Add GPU-backed BiRefNet General tracer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,11 @@ GOOGLE_API_KEY=
 # gemini-2.5-flash-image - faster/cheaper, needs post-hoc alignment
 GEMINI_IMAGE_MODEL=gemini-3-pro-image-preview
 
+# Local tracing (optional)
+# Comma-separated tracer list, e.g. birefnet-general,birefnet-lite,isnet
+TRACERS=
+# auto prefers CUDA when available; cuda requires GPU; cpu disables GPU use
+TRACEFINITY_ONNX_PROVIDER=auto
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ GOOGLE_API_KEY=
 GEMINI_IMAGE_MODEL=gemini-3-pro-image-preview
 
 # Local tracing (optional)
-# Comma-separated tracer list, e.g. birefnet-general,birefnet-lite,isnet
+# Comma-separated tracer list, e.g. birefnet-lite,isnet
+# Add birefnet-general only when you have installed the optional GPU requirements.
 TRACERS=
 # auto prefers CUDA when available; cuda requires GPU; cpu disables GPU use
 TRACEFINITY_ONNX_PROVIDER=auto

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 |-|-|-|
 | `GOOGLE_API_KEY` | | Gemini API key. Uses Gemini instead of local models |
 | `TRACERS` | auto-detected | Comma-separated list of available tracers, e.g. `gemini,birefnet-lite,isnet` |
+| `TRACEFINITY_ONNX_PROVIDER` | `auto` | Local ONNX provider: `auto`, `cuda`, or `cpu` |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |
 
 ### From Source
@@ -80,11 +81,17 @@ When no API key is configured, Tracefinity runs a local salient object detection
 |-|-|-|-|-|
 | [IS-Net](https://github.com/xuebinqin/DIS) (default) | ~0.8s | 2GB | Good | Fastest, lowest memory |
 | [BiRefNet Lite](https://github.com/ZhengPeng7/BiRefNet) | ~3.6s | 8GB | Best | Handles reflections and shiny surfaces well |
+| [BiRefNet General](https://github.com/ZhengPeng7/BiRefNet) | GPU recommended | 8GB+ | Best | Full general BiRefNet model for higher-quality masks |
 | [InSPyReNet](https://github.com/plemeri/InSPyReNet) | ~2.8s | 6GB | Good | Apple Silicon (MPS) support |
 
 Paper corner detection runs [U2-Net Portable](https://github.com/xuebinqin/U-2-Net) alongside the tracer. RAM figures include both models. All models load at startup.
 
 **Minimum RAM: 2GB** (IS-Net). BiRefNet Lite needs **8GB**.
+
+For NVIDIA GPU tracing from source, install `backend/requirements.txt` and set
+`TRACEFINITY_ONNX_PROVIDER=cuda` to require CUDA. This uses ONNX Runtime GPU for
+the `rembg` models (`isnet`, `birefnet-lite`, `birefnet-general`)
+and avoids PyTorch CUDA for those tracers.
 
 See [#21](https://github.com/tracefinity/tracefinity/issues/21) for the benchmark that led to this selection.
 

--- a/README.md
+++ b/README.md
@@ -75,23 +75,29 @@ Tracefinity supports three ways to trace tool outlines from photos. All three pr
 
 ### Local models (default)
 
-When no API key is configured, Tracefinity runs a local salient object detection model. No API key, no network access, no cost. Model weights download automatically on first trace. Three models are available, selectable via the `TRACERS` env var or the UI dropdown:
+When no API key is configured, Tracefinity runs a local salient object detection model. No API key, no network access, no cost. Model weights download automatically on first trace. Three CPU-friendly models are available by default, selectable via the `TRACERS` env var or the UI dropdown:
 
 | Model | Speed (CPU) | Min RAM | Quality | Notes |
 |-|-|-|-|-|
 | [IS-Net](https://github.com/xuebinqin/DIS) (default) | ~0.8s | 2GB | Good | Fastest, lowest memory |
 | [BiRefNet Lite](https://github.com/ZhengPeng7/BiRefNet) | ~3.6s | 8GB | Best | Handles reflections and shiny surfaces well |
-| [BiRefNet General](https://github.com/ZhengPeng7/BiRefNet) | GPU recommended | 8GB+ | Best | Full general BiRefNet model for higher-quality masks |
 | [InSPyReNet](https://github.com/plemeri/InSPyReNet) | ~2.8s | 6GB | Good | Apple Silicon (MPS) support |
 
 Paper corner detection runs [U2-Net Portable](https://github.com/xuebinqin/U-2-Net) alongside the tracer. RAM figures include both models. All models load at startup.
 
 **Minimum RAM: 2GB** (IS-Net). BiRefNet Lite needs **8GB**.
 
-For NVIDIA GPU tracing from source, install `backend/requirements.txt` and set
-`TRACEFINITY_ONNX_PROVIDER=cuda` to require CUDA. This uses ONNX Runtime GPU for
-the `rembg` models (`isnet`, `birefnet-lite`, `birefnet-general`)
-and avoids PyTorch CUDA for those tracers.
+BiRefNet General is available as an opt-in GPU tracer. For NVIDIA GPU tracing from
+source, install the optional GPU requirements after the default backend
+requirements, set `TRACERS=birefnet-general,birefnet-lite,isnet`, and set
+`TRACEFINITY_ONNX_PROVIDER=cuda` to require CUDA:
+
+```bash
+pip install -r backend/requirements.txt -r backend/requirements-gpu.txt
+```
+
+This uses ONNX Runtime GPU for the `rembg` models (`isnet`, `birefnet-lite`,
+`birefnet-general`) and avoids PyTorch CUDA for those tracers.
 
 See [#21](https://github.com/tracefinity/tracefinity/issues/21) for the benchmark that led to this selection.
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -148,10 +148,6 @@ def _get_tracer(tracer_id: str | None = None) -> AITracer:
             )
     return _tracers[tid]
 
-# pre-load all configured tracers at startup
-for _tid in settings.available_tracers:
-    _get_tracer(_tid)
-
 polygon_scaler = PolygonScaler()
 stl_generator = ManifoldSTLGenerator()
 
@@ -364,6 +360,7 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
 TRACER_LABELS = {
     "gemini": "Gemini API",
     "inspyrenet": "InSPyReNet",
+    "birefnet-general": "BiRefNet General",
     "birefnet-lite": "BiRefNet Lite",
     "isnet": "IS-Net",
 }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
         # auto-detect
         if self.google_api_key or self.openrouter_api_key:
             return ["gemini"]
-        return ["isnet", "birefnet-lite", "inspyrenet"]
+        return ["isnet", "birefnet-lite", "inspyrenet", "birefnet-general"]
 
     @property
     def use_local_model(self) -> bool:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
         # auto-detect
         if self.google_api_key or self.openrouter_api_key:
             return ["gemini"]
-        return ["isnet", "birefnet-lite", "inspyrenet", "birefnet-general"]
+        return ["isnet", "birefnet-lite", "inspyrenet"]
 
     @property
     def use_local_model(self) -> bool:

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -133,12 +133,14 @@ class AITracer:
 
     # rembg model names for each local model option
     _REMBG_MODELS = {
+        "birefnet-general": "birefnet-general",
         "birefnet-lite": "birefnet-general-lite",
         "isnet": "isnet-general-use",
     }
 
     _LOCAL_MODEL_LABELS = {
         "inspyrenet": "InSPyReNet",
+        "birefnet-general": "BiRefNet General",
         "birefnet-lite": "BiRefNet Lite",
         "isnet": "IS-Net",
     }
@@ -151,12 +153,16 @@ class AITracer:
         label = self._LOCAL_MODEL_LABELS.get(name, name)
         if name in self._REMBG_MODELS:
             from rembg import new_session
-            logging.info("loading %s via rembg", label)
-            self._local_remover = ("rembg", new_session(self._REMBG_MODELS[name]))
+            from app.services.ort_runtime import get_onnx_providers
+            providers = get_onnx_providers()
+            logging.info("loading %s via rembg with providers: %s", label, providers)
+            session = new_session(self._REMBG_MODELS[name], providers=providers)
+            logging.info("%s actual ONNX providers: %s", label, session.inner_session.get_providers())
+            self._local_remover = ("rembg", session)
         else:
             from transparent_background import Remover
             import torch
-            device = "mps" if torch.backends.mps.is_available() else "cpu"
+            device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
             logging.info("loading %s on %s", label, device)
             self._local_remover = ("inspyrenet", Remover(mode="base", device=device))
 

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -19,8 +19,9 @@ PX_PER_MM = 10
 class ImageProcessor:
     def __init__(self):
         from rembg import new_session
+        from app.services.ort_runtime import get_onnx_providers
         logger.info("loading U2-Net Portable for paper detection")
-        self._tool_mask_session = new_session("u2netp")
+        self._tool_mask_session = new_session("u2netp", providers=get_onnx_providers())
 
     def _get_tool_mask(self, image_path: str) -> np.ndarray:
         """get a rough tool mask via U2-Net Portable for paper detection."""

--- a/backend/app/services/ort_runtime.py
+++ b/backend/app/services/ort_runtime.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+import os
+import site
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+_DLL_DIRS_ADDED = False
+_DLL_DIR_HANDLES = []
+
+
+def _add_nvidia_dll_dirs():
+    """Make NVIDIA wheel DLLs visible to CUDA/cuDNN on Windows."""
+    global _DLL_DIRS_ADDED
+    if _DLL_DIRS_ADDED or os.name != "nt":
+        return
+
+    roots = [Path(p) for p in site.getsitepackages()]
+    user_site = site.getusersitepackages()
+    if user_site:
+        roots.append(Path(user_site))
+
+    for root in roots:
+        nvidia_root = root / "nvidia"
+        for rel in (
+            ("cublas", "bin"),
+            ("cuda_nvrtc", "bin"),
+            ("cuda_runtime", "bin"),
+            ("cudnn", "bin"),
+            ("cufft", "bin"),
+            ("curand", "bin"),
+            ("nvjitlink", "bin"),
+        ):
+            dll_dir = nvidia_root.joinpath(*rel)
+            if dll_dir.exists():
+                _DLL_DIR_HANDLES.append(os.add_dll_directory(str(dll_dir)))
+                os.environ["PATH"] = f"{dll_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+                logger.debug("added NVIDIA DLL directory: %s", dll_dir)
+
+    _DLL_DIRS_ADDED = True
+
+
+def _preload_onnxruntime_cuda_dlls():
+    """Preload CUDA/cuDNN DLLs when onnxruntime-gpu provides the helper."""
+    try:
+        import onnxruntime as ort
+    except ImportError:
+        return
+
+    preload = getattr(ort, "preload_dlls", None)
+    if preload is None:
+        return
+
+    try:
+        _add_nvidia_dll_dirs()
+        # Empty string means "search NVIDIA CUDA/cuDNN site-packages first".
+        preload(directory="")
+    except Exception as exc:
+        logger.warning("failed to preload ONNX Runtime CUDA DLLs: %s", exc)
+
+
+def get_onnx_providers(require_gpu: bool = False):
+    """Return ONNX Runtime providers for local segmentation models.
+
+    TRACEFINITY_ONNX_PROVIDER controls selection:
+    - auto: CUDA if available, otherwise CPU
+    - cuda: require CUDAExecutionProvider
+    - cpu: CPUExecutionProvider only
+    """
+    import onnxruntime as ort
+
+    requested = os.getenv("TRACEFINITY_ONNX_PROVIDER", "auto").lower()
+    if requested not in {"auto", "cuda", "cpu"}:
+        raise ValueError("TRACEFINITY_ONNX_PROVIDER must be one of: auto, cuda, cpu")
+
+    if requested == "cpu":
+        return ["CPUExecutionProvider"]
+
+    _add_nvidia_dll_dirs()
+    _preload_onnxruntime_cuda_dlls()
+    available = set(ort.get_available_providers())
+    if "CUDAExecutionProvider" in available:
+        logger.info("using ONNX Runtime CUDAExecutionProvider for local models")
+        return [
+            (
+                "CUDAExecutionProvider",
+                {
+                    "device_id": 0,
+                    "cudnn_conv_algo_search": "DEFAULT",
+                    "cudnn_conv_use_max_workspace": "1",
+                    "do_copy_in_default_stream": "1",
+                },
+            ),
+            "CPUExecutionProvider",
+        ]
+
+    if requested == "cuda" or require_gpu:
+        raise RuntimeError(
+            "CUDAExecutionProvider is not available. Install onnxruntime-gpu[cuda,cudnn] "
+            "and make sure your NVIDIA driver supports CUDA 12."
+        )
+
+    logger.info("using ONNX Runtime CPUExecutionProvider for local models")
+    return ["CPUExecutionProvider"]

--- a/backend/requirements-gpu.txt
+++ b/backend/requirements-gpu.txt
@@ -1,0 +1,4 @@
+# Optional NVIDIA CUDA runtime for rembg/ONNX tracers.
+# Install after requirements.txt when GPU tracing is desired:
+#   pip install -r requirements.txt -r requirements-gpu.txt
+onnxruntime-gpu[cuda,cudnn]>=1.23.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,7 +16,7 @@ Pillow>=10.0.0
 pillow-heif>=0.16.0
 # local model support
 transparent-background>=1.3.0  # inspyrenet
-rembg>=2.0.50  # birefnet-lite, isnet, paper detection
-onnxruntime>=1.17.0  # rembg runtime
+rembg>=2.0.75  # birefnet, isnet, paper detection
+onnxruntime-gpu[cuda,cudnn]>=1.23.0  # rembg runtime with CUDA provider
 torch>=2.0.0
 torchvision>=0.15.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,6 @@ pillow-heif>=0.16.0
 # local model support
 transparent-background>=1.3.0  # inspyrenet
 rembg>=2.0.75  # birefnet, isnet, paper detection
-onnxruntime-gpu[cuda,cudnn]>=1.23.0  # rembg runtime with CUDA provider
+onnxruntime>=1.17.0  # rembg runtime
 torch>=2.0.0
 torchvision>=0.15.0

--- a/backend/tests/test_tracer_config.py
+++ b/backend/tests/test_tracer_config.py
@@ -1,0 +1,22 @@
+"""Tests for tracer availability configuration."""
+
+from app.config import Settings
+
+
+def test_default_local_tracers_exclude_gpu_only_birefnet_general():
+    settings = Settings(_env_file=None)
+
+    assert settings.available_tracers == ["isnet", "birefnet-lite", "inspyrenet"]
+    assert "birefnet-general" not in settings.available_tracers
+
+
+def test_birefnet_general_can_be_enabled_explicitly():
+    settings = Settings(_env_file=None, tracers="birefnet-general,birefnet-lite,isnet")
+
+    assert settings.available_tracers == ["birefnet-general", "birefnet-lite", "isnet"]
+
+
+def test_cloud_key_still_prefers_gemini_when_tracers_unset():
+    settings = Settings(_env_file=None, google_api_key="test-key")
+
+    assert settings.available_tracers == ["gemini"]


### PR DESCRIPTION
This PR adds BiRefNet General as a GPU-backed local tracing option so higher-quality background removal can run locally without forcing every model to load at startup. It also wires rembg/ONNX Runtime provider selection and Windows CUDA DLL discovery so NVIDIA setups can use CUDA when available while retaining CPU fallback.

Code and PR drafted by Codex

## Summary
- add BiRefNet General as an additional local tracer
- route rembg-based local tracers through ONNX Runtime GPU provider selection
- add Windows NVIDIA wheel DLL path setup for CUDA/cuDNN runtime discovery
- lazy-load tracers instead of preloading every configured model at startup

## Verification
- backend compileall: python -m compileall app
- frontend build:
pm run build
- CUDA smoke test: BiRefNet General rembg session reports ['CUDAExecutionProvider', 'CPUExecutionProvider'] and completes inference