### PR TITLE
Show source photo behind tool editor outline

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -183,6 +183,120 @@ def _translate_finger_holes(holes: list[FingerHole], dx: float, dy: float) -> li
     ]
 
 
+def _polygon_source_transform(poly: Polygon, scale_factor: float) -> tuple[float, float] | None:
+    """return image-pixel origin in the centered tool's mm coordinate space."""
+    points_mm = [(p.x * scale_factor, p.y * scale_factor) for p in poly.points]
+    if not points_mm:
+        return None
+    xs = [p[0] for p in points_mm]
+    ys = [p[1] for p in points_mm]
+    cx = (min(xs) + max(xs)) / 2
+    cy = (min(ys) + max(ys)) / 2
+    return -cx, -cy
+
+
+def _bounds_mm(points: list[Point]) -> tuple[float, float, float, float] | None:
+    if not points:
+        return None
+    xs = [p.x for p in points]
+    ys = [p.y for p in points]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def _source_polygon_score(tool: Tool, candidate: list[Point], label: str) -> float:
+    score = 0.0 if label == tool.name else 25.0
+    tool_bounds = _bounds_mm(tool.points)
+    candidate_bounds = _bounds_mm(candidate)
+    if tool_bounds and candidate_bounds:
+        _, _, tool_max_x, tool_max_y = tool_bounds
+        tool_min_x, tool_min_y, _, _ = tool_bounds
+        _, _, cand_max_x, cand_max_y = candidate_bounds
+        cand_min_x, cand_min_y, _, _ = candidate_bounds
+        score += abs((tool_max_x - tool_min_x) - (cand_max_x - cand_min_x))
+        score += abs((tool_max_y - tool_min_y) - (cand_max_y - cand_min_y))
+    if len(tool.points) == len(candidate):
+        total = 0.0
+        for a, b in zip(tool.points, candidate):
+            total += math.hypot(a.x - b.x, a.y - b.y)
+        score += total / max(1, len(candidate))
+    else:
+        score += min(30.0, abs(len(tool.points) - len(candidate)) * 0.5)
+    return score
+
+
+def _find_source_polygon(tool: Tool, session: Session) -> Polygon | None:
+    if not session.polygons:
+        return None
+    if tool.source_polygon_id:
+        for poly in session.polygons:
+            if poly.id == tool.source_polygon_id:
+                return poly
+    if not session.scale_factor:
+        return None
+
+    best: tuple[float, Polygon] | None = None
+    for poly in session.polygons:
+        centered, _, _ = polygon_scaler.scale_and_centre(poly, session.scale_factor)
+        if not centered:
+            continue
+        score = _source_polygon_score(tool, centered, poly.label)
+        if best is None or score < best[0]:
+            best = (score, poly)
+
+    return best[1] if best and best[0] < 80 else None
+
+
+def _tool_image_context(tool: Tool, sessions: SessionStore) -> dict | None:
+    image_path = tool.source_image_path
+    width = tool.source_image_width
+    height = tool.source_image_height
+    origin_x = tool.source_origin_x_mm
+    origin_y = tool.source_origin_y_mm
+    scale_factor = tool.source_scale_factor
+
+    if (
+        (not image_path or origin_x is None or origin_y is None or scale_factor is None)
+        and tool.source_session_id
+    ):
+        session = sessions.get(tool.source_session_id)
+        if session and session.corrected_image_path and session.scale_factor:
+            poly = _find_source_polygon(tool, session)
+            transform = _polygon_source_transform(poly, session.scale_factor) if poly else None
+            if transform:
+                image_path = session.corrected_image_path
+                origin_x, origin_y = transform
+                scale_factor = session.scale_factor
+
+    if not image_path or origin_x is None or origin_y is None or scale_factor is None:
+        return None
+
+    abs_path = _abs(image_path)
+    if not abs_path or not Path(abs_path).exists():
+        return None
+
+    if width is None or height is None:
+        try:
+            with Image.open(abs_path) as img:
+                width, height = img.size
+        except Exception:
+            return None
+
+    transform = tool.source_image_transform
+    if transform is None or len(transform) != 6:
+        # baseline identity-orientation matrix derived from saved origin and scale
+        transform = [scale_factor, 0.0, 0.0, scale_factor, origin_x, origin_y]
+
+    return {
+        "image_url": f"/storage/{image_path}",
+        "image_width": width,
+        "image_height": height,
+        "origin_x_mm": origin_x,
+        "origin_y_mm": origin_y,
+        "scale_factor": scale_factor,
+        "transform": transform,
+    }
+
+
 def _run_generate(
     scaled: list[ScaledPolygon],
     gen_req: GenerateRequest,
@@ -680,13 +794,14 @@ async def download_threemf(request: Request, session_id: str, user_id: str = Dep
 
 @router.get("/tools", response_model=ToolListResponse)
 async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
-    _, user_tools, _ = get_stores(user_id)
+    user_sessions, user_tools, _ = get_stores(user_id)
     all_tools = user_tools.all()
     summaries = []
     for tid, tool in all_tools.items():
         thumb_url = None
         if tool.thumbnail_path and Path(_abs(tool.thumbnail_path)).exists():
             thumb_url = f"/storage/{tool.thumbnail_path}"
+        image_context = _tool_image_context(tool, user_sessions)
         summaries.append(ToolSummary(
             id=tid,
             name=tool.name,
@@ -697,6 +812,8 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
             smoothed=tool.smoothed,
             smooth_level=tool.smooth_level,
             thumbnail_url=thumb_url,
+            image_transform=tool.source_image_transform,
+            image_context=image_context,
         ))
     summaries.sort(key=lambda t: t.created_at or "", reverse=True)
     return ToolListResponse(tools=summaries)
@@ -704,11 +821,13 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
 
 @router.get("/tools/{tool_id}")
 async def get_tool(request: Request, tool_id: str, user_id: str = Depends(get_user_id)):
-    _, user_tools, _ = get_stores(user_id)
+    user_sessions, user_tools, _ = get_stores(user_id)
     tool = user_tools.get(tool_id)
     if not tool:
         raise HTTPException(status_code=404, detail="tool not found")
-    return tool
+    data = tool.model_dump()
+    data["image_context"] = _tool_image_context(tool, user_sessions)
+    return data
 
 
 @router.put("/tools/{tool_id}", response_model=StatusResponse)
@@ -730,6 +849,8 @@ async def update_tool(request: Request, tool_id: str, req: ToolUpdateRequest, us
         tool.smoothed = req.smoothed
     if req.smooth_level is not None:
         tool.smooth_level = req.smooth_level
+    if req.source_image_transform is not None:
+        tool.source_image_transform = req.source_image_transform
     user_tools.set(tool_id, tool)
     return StatusResponse(status="ok")
 
@@ -827,6 +948,7 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
             continue
 
         tool_id = str(uuid.uuid4())
+        source_transform = _polygon_source_transform(poly, sf)
 
         thumbnail_path = None
         if src_img:
@@ -841,6 +963,17 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
             finger_holes=fholes,
             interior_rings=interior_rings,
             source_session_id=session_id,
+            source_polygon_id=poly.id,
+            source_image_path=session.corrected_image_path,
+            source_image_width=src_img.width if src_img else None,
+            source_image_height=src_img.height if src_img else None,
+            source_origin_x_mm=source_transform[0] if source_transform else None,
+            source_origin_y_mm=source_transform[1] if source_transform else None,
+            source_scale_factor=sf,
+            source_image_transform=(
+                [sf, 0.0, 0.0, sf, source_transform[0], source_transform[1]]
+                if source_transform else None
+            ),
             thumbnail_path=thumbnail_path,
             created_at=datetime.utcnow().isoformat(),
         ))

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -37,6 +37,7 @@ from app.models.schemas import (
     Polygon,
     FingerHole,
     Tool,
+    ToolDetailResponse,
     ToolSummary,
     ToolListResponse,
     ToolUpdateRequest,
@@ -62,6 +63,9 @@ from app.services.bin_store import BinStore
 from app.services.bin_service import sync_placed_tools
 from app.services.image_service import generate_tool_thumbnail
 router = APIRouter()
+
+# Heuristic mismatch score combining a label penalty with bbox and point deltas measured in mm.
+SOURCE_POLYGON_MATCH_MAX_SCORE = 80.0
 
 # register heif/heic support with pillow
 try:
@@ -208,10 +212,8 @@ def _source_polygon_score(tool: Tool, candidate: list[Point], label: str) -> flo
     tool_bounds = _bounds_mm(tool.points)
     candidate_bounds = _bounds_mm(candidate)
     if tool_bounds and candidate_bounds:
-        _, _, tool_max_x, tool_max_y = tool_bounds
-        tool_min_x, tool_min_y, _, _ = tool_bounds
-        _, _, cand_max_x, cand_max_y = candidate_bounds
-        cand_min_x, cand_min_y, _, _ = candidate_bounds
+        tool_min_x, tool_min_y, tool_max_x, tool_max_y = tool_bounds
+        cand_min_x, cand_min_y, cand_max_x, cand_max_y = candidate_bounds
         score += abs((tool_max_x - tool_min_x) - (cand_max_x - cand_min_x))
         score += abs((tool_max_y - tool_min_y) - (cand_max_y - cand_min_y))
     if len(tool.points) == len(candidate):
@@ -243,58 +245,66 @@ def _find_source_polygon(tool: Tool, session: Session) -> Polygon | None:
         if best is None or score < best[0]:
             best = (score, poly)
 
-    return best[1] if best and best[0] < 80 else None
+    return best[1] if best and best[0] < SOURCE_POLYGON_MATCH_MAX_SCORE else None
 
 
-def _tool_image_context(tool: Tool, sessions: SessionStore) -> dict | None:
+def _tool_image_context(tool: Tool, sessions: SessionStore, load_missing_dimensions: bool = True) -> tuple[dict, bool] | tuple[None, bool]:
+    updated = False
     image_path = tool.source_image_path
     width = tool.source_image_width
     height = tool.source_image_height
-    origin_x = tool.source_origin_x_mm
-    origin_y = tool.source_origin_y_mm
-    scale_factor = tool.source_scale_factor
+    transform = tool.source_image_transform if tool.source_image_transform and len(tool.source_image_transform) == 6 else None
 
     if (
-        (not image_path or origin_x is None or origin_y is None or scale_factor is None)
+        (not image_path or transform is None)
         and tool.source_session_id
     ):
         session = sessions.get(tool.source_session_id)
         if session and session.corrected_image_path and session.scale_factor:
             poly = _find_source_polygon(tool, session)
-            transform = _polygon_source_transform(poly, session.scale_factor) if poly else None
-            if transform:
+            source_origin = _polygon_source_transform(poly, session.scale_factor) if poly else None
+            if source_origin:
                 image_path = session.corrected_image_path
-                origin_x, origin_y = transform
-                scale_factor = session.scale_factor
+                if tool.source_image_path != image_path:
+                    tool.source_image_path = image_path
+                    updated = True
+                transform = [
+                    session.scale_factor, 0.0, 0.0, session.scale_factor,
+                    source_origin[0], source_origin[1],
+                ]
+                if tool.source_image_transform != transform:
+                    tool.source_image_transform = transform
+                    updated = True
 
-    if not image_path or origin_x is None or origin_y is None or scale_factor is None:
-        return None
+    if not image_path or transform is None:
+        return None, updated
 
     abs_path = _abs(image_path)
     if not abs_path or not Path(abs_path).exists():
-        return None
+        return None, updated
 
     if width is None or height is None:
+        if not load_missing_dimensions:
+            return None, updated
         try:
             with Image.open(abs_path) as img:
                 width, height = img.size
+            if tool.source_image_width != width or tool.source_image_height != height:
+                tool.source_image_width = width
+                tool.source_image_height = height
+                updated = True
         except Exception:
-            return None
-
-    transform = tool.source_image_transform
-    if transform is None or len(transform) != 6:
-        # baseline identity-orientation matrix derived from saved origin and scale
-        transform = [scale_factor, 0.0, 0.0, scale_factor, origin_x, origin_y]
+            return None, updated
 
     return {
         "image_url": f"/storage/{image_path}",
         "image_width": width,
         "image_height": height,
-        "origin_x_mm": origin_x,
-        "origin_y_mm": origin_y,
-        "scale_factor": scale_factor,
+        "origin_x_mm": transform[4],
+        "origin_y_mm": transform[5],
+        "scale_factor": math.hypot(transform[0], transform[1]),
         "transform": transform,
-    }
+    }, updated
 
 
 def _run_generate(
@@ -801,7 +811,7 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
         thumb_url = None
         if tool.thumbnail_path and Path(_abs(tool.thumbnail_path)).exists():
             thumb_url = f"/storage/{tool.thumbnail_path}"
-        image_context = _tool_image_context(tool, user_sessions)
+        image_context, _ = _tool_image_context(tool, user_sessions, load_missing_dimensions=False)
         summaries.append(ToolSummary(
             id=tid,
             name=tool.name,
@@ -819,14 +829,18 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
     return ToolListResponse(tools=summaries)
 
 
-@router.get("/tools/{tool_id}")
+@router.get("/tools/{tool_id}", response_model=ToolDetailResponse)
 async def get_tool(request: Request, tool_id: str, user_id: str = Depends(get_user_id)):
     user_sessions, user_tools, _ = get_stores(user_id)
     tool = user_tools.get(tool_id)
     if not tool:
         raise HTTPException(status_code=404, detail="tool not found")
     data = tool.model_dump()
-    data["image_context"] = _tool_image_context(tool, user_sessions)
+    image_context, updated = _tool_image_context(tool, user_sessions)
+    if updated:
+        user_tools.set(tool_id, tool)
+        data = tool.model_dump()
+    data["image_context"] = image_context
     return data
 
 
@@ -967,9 +981,6 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
             source_image_path=session.corrected_image_path,
             source_image_width=src_img.width if src_img else None,
             source_image_height=src_img.height if src_img else None,
-            source_origin_x_mm=source_transform[0] if source_transform else None,
-            source_origin_y_mm=source_transform[1] if source_transform else None,
-            source_scale_factor=sf,
             source_image_transform=(
                 [sf, 0.0, 0.0, sf, source_transform[0], source_transform[1]]
                 if source_transform else None

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -212,6 +212,14 @@ class Tool(BaseModel):
     smoothed: bool = False
     smooth_level: float = 0.0
     source_session_id: str | None = None
+    source_polygon_id: str | None = None
+    source_image_path: str | None = None
+    source_image_width: int | None = None
+    source_image_height: int | None = None
+    source_origin_x_mm: float | None = None
+    source_origin_y_mm: float | None = None
+    source_scale_factor: float | None = None
+    source_image_transform: list[float] | None = None  # 2D affine [a, b, c, d, e, f] mapping image-px to mm
     thumbnail_path: str | None = None
     created_at: str | None = None
 
@@ -226,6 +234,8 @@ class ToolSummary(BaseModel):
     smoothed: bool = False
     smooth_level: float = 0.5
     thumbnail_url: str | None = None
+    image_transform: list[float] | None = None
+    image_context: dict | None = None
 
 
 class ToolUpdateRequest(BaseModel):
@@ -235,6 +245,7 @@ class ToolUpdateRequest(BaseModel):
     interior_rings: list[list[Point]] | None = None
     smoothed: bool | None = None
     smooth_level: float | None = None
+    source_image_transform: list[float] | None = None
 
 
 class ToolListResponse(BaseModel):

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -216,12 +216,13 @@ class Tool(BaseModel):
     source_image_path: str | None = None
     source_image_width: int | None = None
     source_image_height: int | None = None
-    source_origin_x_mm: float | None = None
-    source_origin_y_mm: float | None = None
-    source_scale_factor: float | None = None
     source_image_transform: list[float] | None = None  # 2D affine [a, b, c, d, e, f] mapping image-px to mm
     thumbnail_path: str | None = None
     created_at: str | None = None
+
+
+class ToolDetailResponse(Tool):
+    image_context: dict | None = None
 
 
 class ToolSummary(BaseModel):

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -22,6 +22,8 @@
   --color-glass-bg: rgba(255, 255, 255, 0.035);
   --color-glass-border: rgba(255, 255, 255, 0.07);
   --color-glass-hover: rgba(255, 255, 255, 0.055);
+  --color-toolbar-solid-bg: #15181f;
+  --color-toolbar-solid-border: rgba(255, 255, 255, 0.12);
   color-scheme: dark;
 }
 
@@ -41,6 +43,8 @@
   --color-glass-bg: rgba(255, 255, 255, 0.65);
   --color-glass-border: rgba(0, 0, 0, 0.06);
   --color-glass-hover: rgba(255, 255, 255, 0.8);
+  --color-toolbar-solid-bg: #ffffff;
+  --color-toolbar-solid-border: rgba(0, 0, 0, 0.08);
   color-scheme: light;
 }
 
@@ -119,6 +123,12 @@ body {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-radius: 10px;
+  }
+  .editor-photo-active .glass-toolbar {
+    background: var(--color-toolbar-solid-bg);
+    border-color: var(--color-toolbar-solid-border);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
   .glass-card {
     background: var(--color-glass-bg);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,12 +5,23 @@ import { useRouter } from 'next/navigation'
 import { ImageUploader } from '@/components/ImageUploader'
 import { ConfirmModal } from '@/components/ConfirmModal'
 import { uploadImage, listTools, listBins, deleteTool, deleteBin, createBin, getImageUrl } from '@/lib/api'
-import type { ToolSummary, BinSummary, BinPreviewTool, Point } from '@/types'
+import type { ToolSummary, BinSummary, BinPreviewTool, Point, ToolImageContext, AffineMatrix } from '@/types'
 import { polygonPathData } from '@/lib/svg'
 import { Trash2, Package, Plus, Loader2, Grid3X3, Search, ArrowUpDown } from 'lucide-react'
 import { Alert } from '@/components/Alert'
 import { PhotoIllustration, CornersIllustration, TraceIllustration, OrganiseIllustration } from '@/components/OnboardingIllustrations'
 import { GRID_UNIT } from '@/lib/constants'
+
+function thumbnailRotationStyle(transform: AffineMatrix | null): React.CSSProperties | undefined {
+  if (!transform) return undefined
+  const [a, b, c, d] = transform
+  const s = Math.sqrt(a * a + b * b)
+  if (s < 1e-9) return undefined
+  return {
+    transform: `matrix(${a / s}, ${b / s}, ${c / s}, ${d / s}, 0, 0)`,
+    transformOrigin: 'center',
+  }
+}
 
 function ToolOutline({ points, interiorRings }: { points: Point[]; interiorRings?: Point[][] }) {
   if (points.length === 0) return null
@@ -41,6 +52,50 @@ function ToolOutline({ points, interiorRings }: { points: Point[]; interiorRings
         fill="#475569"
         stroke="#8b95a5"
         strokeWidth={Math.max(vw, vh) * 0.015}
+      />
+    </svg>
+  )
+}
+
+function toolViewBox(points: Point[]) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const p of points) {
+    minX = Math.min(minX, p.x)
+    minY = Math.min(minY, p.y)
+    maxX = Math.max(maxX, p.x)
+    maxY = Math.max(maxY, p.y)
+  }
+
+  const w = maxX - minX
+  const h = maxY - minY
+  const pad = Math.max(w, h) * 0.12
+  return {
+    x: minX - pad,
+    y: minY - pad,
+    width: w + pad * 2,
+    height: h + pad * 2,
+  }
+}
+
+function SourceImagePreview({ context, points }: { context: ToolImageContext; points: Point[] }) {
+  if (points.length === 0) return null
+  const vb = toolViewBox(points)
+  const [a, b, c, d, e, f] = context.transform
+
+  return (
+    <svg
+      viewBox={`${vb.x} ${vb.y} ${vb.width} ${vb.height}`}
+      className="absolute inset-0 w-full h-full p-4 transition-opacity duration-150 group-hover:opacity-30"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <image
+        href={getImageUrl(context.image_url)}
+        x={0}
+        y={0}
+        width={context.image_width}
+        height={context.image_height}
+        transform={`matrix(${a} ${b} ${c} ${d} ${e} ${f})`}
+        preserveAspectRatio="none"
       />
     </svg>
   )
@@ -337,12 +392,20 @@ export default function HomePage() {
                 className="glass-card overflow-hidden cursor-pointer group"
               >
                 <div className="aspect-square bg-inset relative overflow-hidden">
-                  {tool.thumbnail_url ? (
+                  {tool.image_context ? (
+                    <>
+                      <SourceImagePreview context={tool.image_context} points={tool.points} />
+                      <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                        <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
+                      </div>
+                    </>
+                  ) : tool.thumbnail_url ? (
                     <>
                       <img
                         src={getImageUrl(tool.thumbnail_url)}
                         alt=""
                         className="absolute inset-0 w-full h-full object-contain p-3 transition-opacity duration-150 group-hover:opacity-30"
+                        style={thumbnailRotationStyle(tool.image_transform)}
                       />
                       <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
                         <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />

--- a/frontend/src/app/tools/[id]/page.tsx
+++ b/frontend/src/app/tools/[id]/page.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams } from 'next/navigation'
 import { Loader2, Check, Download } from 'lucide-react'
 import Link from 'next/link'
-import { getTool, updateTool, getToolSvgUrl } from '@/lib/api'
+import { getTool, updateTool, getToolSvgUrl, getImageUrl } from '@/lib/api'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { ToolEditor } from '@/components/ToolEditor'
 import { Alert } from '@/components/Alert'
 import { Breadcrumb } from '@/components/Breadcrumb'
-import type { Tool, Point, FingerHole } from '@/types'
+import type { Tool, Point, FingerHole, AffineMatrix } from '@/types'
 
 export default function ToolPage() {
   const params = useParams()
@@ -19,6 +19,27 @@ export default function ToolPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [name, setName] = useState('')
+  const [showSourceImage, setShowSourceImage] = useState(false)
+  const [sourceImageOpacity, setSourceImageOpacity] = useState(0.45)
+
+  const sourceImageContext = useMemo(
+    () => tool?.image_context
+      ? { ...tool.image_context, image_url: getImageUrl(tool.image_context.image_url) }
+      : null,
+    [tool?.image_context]
+  )
+
+  const handleImageTransformChange = useCallback((transform: AffineMatrix) => {
+    setTool(prev => prev && prev.image_context
+      ? { ...prev, image_context: { ...prev.image_context, transform } }
+      : prev)
+  }, [])
+
+  useEffect(() => {
+    setShowSourceImage(Boolean(sourceImageContext))
+  }, [sourceImageContext])
+
+  const photoActive = Boolean(sourceImageContext) && showSourceImage
   useEffect(() => {
     async function load() {
       try {
@@ -37,7 +58,15 @@ export default function ToolPage() {
   const { saving, saved } = useDebouncedSave(
     async () => {
       if (!tool) return
-      await updateTool(toolId, { name, points: tool.points, finger_holes: tool.finger_holes, interior_rings: tool.interior_rings, smoothed: tool.smoothed, smooth_level: tool.smooth_level })
+      await updateTool(toolId, {
+        name,
+        points: tool.points,
+        finger_holes: tool.finger_holes,
+        interior_rings: tool.interior_rings,
+        smoothed: tool.smoothed,
+        smooth_level: tool.smooth_level,
+        ...(tool.image_context ? { source_image_transform: tool.image_context.transform } : {}),
+      })
     },
     [tool, name, toolId],
     150,
@@ -82,7 +111,7 @@ export default function ToolPage() {
   }
 
   return (
-    <div className="h-[calc(100vh-44px)] relative overflow-hidden">
+    <div className={`h-[calc(100vh-44px)] relative overflow-hidden${photoActive ? ' editor-photo-active' : ''}`}>
       {/* floating breadcrumb panel */}
       <div className="absolute top-3.5 left-3.5 z-20 glass-toolbar px-3 py-1.5 flex items-center gap-3">
         <Breadcrumb segments={[
@@ -111,6 +140,12 @@ export default function ToolPage() {
         interiorRings={tool.interior_rings}
         smoothed={tool.smoothed}
         smoothLevel={tool.smooth_level}
+        sourceImageContext={sourceImageContext}
+        showSourceImage={showSourceImage}
+        onShowSourceImageChange={setShowSourceImage}
+        sourceImageOpacity={sourceImageOpacity}
+        onSourceImageOpacityChange={setSourceImageOpacity}
+        onImageTransformChange={handleImageTransformChange}
         onPointsChange={handlePointsChange}
         onFingerHolesChange={handleFingerHolesChange}
         onSmoothedChange={handleSmoothedChange}

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
-import { Plus, Circle, Square, RectangleHorizontal, Fingerprint } from 'lucide-react'
-import type { Point, FingerHole } from '@/types'
+import { Plus, Circle, Square, RectangleHorizontal, Fingerprint, ImageIcon, Eye, EyeOff } from 'lucide-react'
+import type { Point, FingerHole, ToolImageContext, AffineMatrix } from '@/types'
 import { simplifyPolygon, smoothEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
+import { rotateAround, flipAround } from '@/lib/affine'
 import { DISPLAY_SCALE, SNAP_GRID, ZOOM_FACTOR } from '@/lib/constants'
 import { useHistory } from '@/hooks/useHistory'
 import { ToolEditorToolbar } from '@/components/ToolEditorToolbar'
@@ -16,6 +17,12 @@ interface Props {
   interiorRings?: Point[][]
   smoothed: boolean
   smoothLevel: number
+  sourceImageContext?: ToolImageContext | null
+  showSourceImage?: boolean
+  onShowSourceImageChange?: (show: boolean) => void
+  sourceImageOpacity?: number
+  onSourceImageOpacityChange?: (opacity: number) => void
+  onImageTransformChange?: (transform: AffineMatrix) => void
   onPointsChange: (points: Point[]) => void
   onFingerHolesChange: (holes: FingerHole[]) => void
   onSmoothedChange: (smoothed: boolean) => void
@@ -40,7 +47,7 @@ interface HistoryEntry {
   interiorRings: Point[][]
 }
 
-export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoothLevel, onPointsChange, onFingerHolesChange, onSmoothedChange, onSmoothLevelChange, onInteriorRingsChange }: Props) {
+export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoothLevel, sourceImageContext, showSourceImage = false, onShowSourceImageChange, sourceImageOpacity = 0.45, onSourceImageOpacityChange, onImageTransformChange, onPointsChange, onFingerHolesChange, onSmoothedChange, onSmoothLevelChange, onInteriorRingsChange }: Props) {
   const svgRef = useRef<SVGSVGElement>(null)
   const [selection, setSelection] = useState<Selection>(null)
   const [editMode, setEditMode] = useState<EditMode>('select')
@@ -84,12 +91,17 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   const dragHolesRef = useRef(dragHoles)
   const onPointsRef = useRef(onPointsChange)
   const onHolesRef = useRef(onFingerHolesChange)
+  const imageTransformRef = useRef<AffineMatrix | null>(sourceImageContext?.transform ?? null)
+  const onImageTransformRef = useRef(onImageTransformChange)
   useEffect(() => { pointsRef.current = points }, [points])
   useEffect(() => { holesRef.current = fingerHoles }, [fingerHoles])
   useEffect(() => { dragPointsRef.current = dragPoints }, [dragPoints])
   useEffect(() => { dragHolesRef.current = dragHoles }, [dragHoles])
   useEffect(() => { onPointsRef.current = onPointsChange }, [onPointsChange])
   useEffect(() => { onHolesRef.current = onFingerHolesChange }, [onFingerHolesChange])
+  useEffect(() => { imageTransformRef.current = sourceImageContext?.transform ?? null }, [sourceImageContext?.transform])
+  useEffect(() => { onImageTransformRef.current = onImageTransformChange }, [onImageTransformChange])
+  const rotateDragRef = useRef<{ delta: number; cx: number; cy: number } | null>(null)
   const currentRingsRef = useRef(currentRings)
   useEffect(() => { currentRingsRef.current = currentRings }, [currentRings])
   const zoomRef = useRef(zoom)
@@ -254,6 +266,12 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     pushHistory({ points: newPts, fingerHoles: newHoles, interiorRings: currentRings })
     onPointsRef.current(newPts)
     onHolesRef.current(newHoles)
+    const m = imageTransformRef.current
+    if (m && onImageTransformRef.current) {
+      const next = rotateAround(m, rad, cx, cy)
+      imageTransformRef.current = next
+      onImageTransformRef.current(next)
+    }
   }, [pushHistory, currentRings])
 
   const flipAll = useCallback((axis: 'horizontal' | 'vertical') => {
@@ -279,6 +297,12 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     onPointsRef.current(newPts)
     onHolesRef.current(newHoles)
     onInteriorRingsChange?.(newRings)
+    const m = imageTransformRef.current
+    if (m && onImageTransformRef.current) {
+      const next = flipAround(m, axis, cx, cy)
+      imageTransformRef.current = next
+      onImageTransformRef.current(next)
+    }
   }, [pushHistory, onInteriorRingsChange])
 
   const handleRotatePolygonMouseDown = (e: React.MouseEvent) => {
@@ -496,6 +520,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       })
       setDragPoints(newPts)
       setDragHoles(newHoles)
+      rotateDragRef.current = { delta, cx, cy }
     } else if (dragging.type === 'pan') {
       const dx = (e.clientX - dragging.startClientX) / dragging.svgScale
       const dy = (e.clientY - dragging.startClientY) / dragging.svgScale
@@ -515,6 +540,16 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       if (dragPointsRef.current) onPointsRef.current(finalPoints)
       if (dragHolesRef.current) onHolesRef.current(finalHoles)
       pushHistory({ points: finalPoints, fingerHoles: finalHoles, interiorRings: currentRingsRef.current })
+      if (dragging.type === 'rotate-polygon' && rotateDragRef.current) {
+        const { delta, cx, cy } = rotateDragRef.current
+        const m = imageTransformRef.current
+        if (m && delta !== 0 && onImageTransformRef.current) {
+          const next = rotateAround(m, delta, cx, cy)
+          imageTransformRef.current = next
+          onImageTransformRef.current(next)
+        }
+      }
+      rotateDragRef.current = null
       setDragPoints(null)
       setDragHoles(null)
     }
@@ -597,6 +632,9 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
         handleHoleRotateMouseDown={handleHoleRotateMouseDown}
         handleRotatePolygonMouseDown={handleRotatePolygonMouseDown}
         onRingClick={handleFillRing}
+        sourceImageContext={sourceImageContext}
+        showSourceImage={showSourceImage}
+        sourceImageOpacity={sourceImageOpacity}
       />
 
       {/* floating toolbar: top centre */}
@@ -655,6 +693,30 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
 
       {/* floating zoom controls: bottom right */}
       <div className="absolute bottom-3.5 right-3.5 z-20 glass-toolbar px-1 py-0.5 flex items-center gap-0.5 text-[11px]">
+        {sourceImageContext && (
+          <>
+            <button
+              onClick={() => onShowSourceImageChange?.(!showSourceImage)}
+              className={`p-1 rounded-[7px] transition-colors ${showSourceImage ? 'text-accent bg-accent-muted' : 'text-text-muted hover:text-text-secondary hover:bg-border/50'}`}
+              title={showSourceImage ? 'Hide source photo' : 'Show source photo'}
+            >
+              {showSourceImage ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+            </button>
+            <ImageIcon className={`w-3.5 h-3.5 mx-0.5 ${showSourceImage ? 'text-text-secondary' : 'text-text-muted opacity-50'}`} />
+            <input
+              type="range"
+              min={0.1}
+              max={1}
+              step={0.05}
+              value={sourceImageOpacity}
+              disabled={!showSourceImage}
+              onChange={e => onSourceImageOpacityChange?.(parseFloat(e.target.value))}
+              className="w-16 h-1 accent-accent disabled:opacity-40"
+              title={`Source photo opacity: ${Math.round(sourceImageOpacity * 100)}%`}
+            />
+            <div className="h-3.5 w-px bg-border-subtle mx-0.5" />
+          </>
+        )}
         <button
           onClick={() => setZoom(z => Math.max(0.5, z / ZOOM_FACTOR))}
           className="px-2 py-1 rounded-[7px] text-text-muted hover:text-text-primary hover:bg-border/50 transition-colors"

--- a/frontend/src/components/ToolEditorCanvas.tsx
+++ b/frontend/src/components/ToolEditorCanvas.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { RefObject, useState } from 'react'
-import type { Point, FingerHole } from '@/types'
+import type { Point, FingerHole, ToolImageContext } from '@/types'
 import { polygonPathData, smoothPathData } from '@/lib/svg'
 import { DISPLAY_SCALE } from '@/lib/constants'
 import { CutoutOverlay } from '@/components/CutoutOverlay'
@@ -44,6 +44,9 @@ interface Props {
   handleHoleRotateMouseDown: (holeId: string) => (e: React.MouseEvent) => void
   handleRotatePolygonMouseDown: (e: React.MouseEvent) => void
   onRingClick: (ringIndex: number) => void
+  sourceImageContext?: ToolImageContext | null
+  showSourceImage: boolean
+  sourceImageOpacity: number
 
 }
 
@@ -56,9 +59,21 @@ export function ToolEditorCanvas({
   handleEdgeClick, handleVertexMouseDown,
   displayHoles, handleHoleMouseDown, handleResizeMouseDown, handleHoleRotateMouseDown,
   handleRotatePolygonMouseDown, onRingClick,
+  sourceImageContext, showSourceImage, sourceImageOpacity,
 }: Props) {
   const stopClick = (e: React.MouseEvent) => e.stopPropagation()
   const [hoveredRing, setHoveredRing] = useState<number | null>(null)
+  const sourceImage = sourceImageContext && showSourceImage ? (() => {
+    const [a, b, c, d, e, f] = sourceImageContext.transform
+    const ds = DISPLAY_SCALE
+    return {
+      url: sourceImageContext.image_url,
+      width: sourceImageContext.image_width,
+      height: sourceImageContext.image_height,
+      // image-pixel coords -> display-mm coords (already includes scale + origin + rotation/flip)
+      transform: `matrix(${a * ds} ${b * ds} ${c * ds} ${d * ds} ${e * ds} ${f * ds})`,
+    }
+  })() : null
 
   return (
     <>
@@ -75,6 +90,20 @@ export function ToolEditorCanvas({
         >
           {/* background fill */}
           <rect x={zvbX} y={zvbY} width={zvbW} height={zvbH} fill="var(--color-inset)" />
+
+          {sourceImage && (
+            <image
+              href={sourceImage.url}
+              x={0}
+              y={0}
+              width={sourceImage.width}
+              height={sourceImage.height}
+              transform={sourceImage.transform}
+              preserveAspectRatio="none"
+              opacity={sourceImageOpacity}
+              className="pointer-events-none select-none"
+            />
+          )}
 
           {/* grid lines */}
           {Array.from({ length: Math.ceil((gridMaxX - gridMinX) / gridStep) + 1 }).map((_, i) => {
@@ -108,9 +137,9 @@ export function ToolEditorCanvas({
           <path
             d={smoothed ? smoothPathData(displayPoints, interiorRings, DISPLAY_SCALE) : polygonPathData(displayPoints, interiorRings, DISPLAY_SCALE)}
             fillRule="evenodd"
-            fill="rgb(71, 85, 105)"
-            stroke="rgb(148, 163, 184)"
-            strokeWidth={2 / zoom}
+            fill={sourceImage ? 'rgba(71, 85, 105, 0.18)' : 'rgb(71, 85, 105)'}
+            stroke={sourceImage ? 'rgb(226, 232, 240)' : 'rgb(148, 163, 184)'}
+            strokeWidth={(sourceImage ? 2.5 : 2) / zoom}
           />
 
           {/* per-ring hit areas for fill-ring mode */}

--- a/frontend/src/lib/affine.ts
+++ b/frontend/src/lib/affine.ts
@@ -1,0 +1,33 @@
+import type { AffineMatrix } from '@/types'
+
+// matrix(a, b, c, d, e, f) maps (x, y) -> (a*x + c*y + e, b*x + d*y + f)
+
+export function rotateAround(m: AffineMatrix, angleRad: number, cx: number, cy: number): AffineMatrix {
+  const cos = Math.cos(angleRad)
+  const sin = Math.sin(angleRad)
+  const [a, b, c, d, e, f] = m
+  return [
+    cos * a - sin * b,
+    sin * a + cos * b,
+    cos * c - sin * d,
+    sin * c + cos * d,
+    cos * e - sin * f + cx * (1 - cos) + sin * cy,
+    sin * e + cos * f - sin * cx + cy * (1 - cos),
+  ]
+}
+
+export function flipAround(m: AffineMatrix, axis: 'horizontal' | 'vertical', cx: number, cy: number): AffineMatrix {
+  const [a, b, c, d, e, f] = m
+  if (axis === 'horizontal') {
+    return [-a, b, -c, d, -e + 2 * cx, f]
+  }
+  return [a, -b, c, -d, e, -f + 2 * cy]
+}
+
+export function affineEquals(a: AffineMatrix | null | undefined, b: AffineMatrix | null | undefined): boolean {
+  if (!a || !b) return a === b
+  for (let i = 0; i < 6; i++) {
+    if (Math.abs(a[i] - b[i]) > 1e-9) return false
+  }
+  return true
+}

--- a/frontend/src/lib/affine.ts
+++ b/frontend/src/lib/affine.ts
@@ -23,11 +23,3 @@ export function flipAround(m: AffineMatrix, axis: 'horizontal' | 'vertical', cx:
   }
   return [a, -b, c, -d, e, -f + 2 * cy]
 }
-
-export function affineEquals(a: AffineMatrix | null | undefined, b: AffineMatrix | null | undefined): boolean {
-  if (!a || !b) return a === b
-  for (let i = 0; i < 6; i++) {
-    if (Math.abs(a[i] - b[i]) > 1e-9) return false
-  }
-  return true
-}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -188,7 +188,7 @@ export async function getTool(toolId: string): Promise<Tool> {
 
 export async function updateTool(
   toolId: string,
-  updates: { name?: string; points?: Point[]; finger_holes?: import('@/types').FingerHole[]; interior_rings?: Point[][]; smoothed?: boolean; smooth_level?: number }
+  updates: { name?: string; points?: Point[]; finger_holes?: import('@/types').FingerHole[]; interior_rings?: Point[][]; smoothed?: boolean; smooth_level?: number; source_image_transform?: import('@/types').AffineMatrix }
 ): Promise<void> {
   await fetchApi(`/api/tools/${toolId}`, {
     method: 'PUT',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -123,7 +123,20 @@ export interface Tool {
   smoothed: boolean
   smooth_level: number
   source_session_id: string | null
+  image_context: ToolImageContext | null
   created_at: string | null
+}
+
+export type AffineMatrix = [number, number, number, number, number, number]
+
+export interface ToolImageContext {
+  image_url: string
+  image_width: number
+  image_height: number
+  origin_x_mm: number
+  origin_y_mm: number
+  scale_factor: number
+  transform: AffineMatrix
 }
 
 export interface ToolSummary {
@@ -136,6 +149,8 @@ export interface ToolSummary {
   smoothed: boolean
   smooth_level: number
   thumbnail_url: string | null
+  image_transform: AffineMatrix | null
+  image_context: ToolImageContext | null
 }
 
 // --- bins ---


### PR DESCRIPTION
This PR makes the tool editor show the corrected source photo behind the editable outline so users can validate geometry against the image it came from. It also carries the source-image transform through saves and orientation edits, which keeps the overlay aligned and gives generated tools useful image context in downstream tiles.

Code and PR drafted by Codex

## Summary
- Persist source-image metadata and affine image-to-mm transforms on saved tools.
- Render original corrected photo behind the tool editor outline, aligned in the same mm coordinate space.
- Persist editor rotations/flips to the image transform so the photo stays aligned after outline edits.
- Use mapped source image context for home-page tool tiles, with rotated thumbnail fallback for older/stale summaries.

## Checks
- npm run build
- python -m py_compile backend\app\models\schemas.py backend\app\api\routes.py

## Notes
- Existing tools can derive image context from their source session when metadata is missing.
- Tools whose source session/image no longer exists still render without the photo layer.