### PR TITLE
[codex] Address PR 38 tracer review feedback

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -62,6 +62,7 @@ from app.services.tool_store import ToolStore
 from app.services.bin_store import BinStore
 from app.services.bin_service import sync_placed_tools
 from app.services.image_service import generate_tool_thumbnail
+from app.services.tracer_registry import TRACER_LABELS, validate_tracer_ids
 router = APIRouter()
 
 # Heuristic mismatch score combining a label penalty with bbox and point deltas measured in mm.
@@ -73,6 +74,9 @@ try:
     pillow_heif.register_heif_opener()
 except ImportError:
     pass
+
+# Fail fast for misspelled TRACERS values without loading local model weights.
+validate_tracer_ids(settings.available_tracers)
 
 # per-user store registry
 _store_cache: dict[str, tuple[SessionStore, ToolStore, BinStore]] = {}
@@ -479,15 +483,6 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
         corrected_image_url=f"/storage/{session.corrected_image_path}",
         scale_factor=scale_factor,
     )
-
-
-TRACER_LABELS = {
-    "gemini": "Gemini API",
-    "inspyrenet": "InSPyReNet",
-    "birefnet-general": "BiRefNet General",
-    "birefnet-lite": "BiRefNet Lite",
-    "isnet": "IS-Net",
-}
 
 
 @router.get("/api-keys")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,8 @@ from pydantic_settings import BaseSettings
 from pathlib import Path
 from typing import Optional
 
+from app.services.tracer_registry import DEFAULT_LOCAL_TRACERS, validate_tracer_ids
+
 
 class Settings(BaseSettings):
     storage_path: Path = Path("./storage")
@@ -29,11 +31,11 @@ class Settings(BaseSettings):
         or "gemini,birefnet-lite". if not set, auto-detects from API keys.
         """
         if self.tracers:
-            return [t.strip() for t in self.tracers.split(",") if t.strip()]
+            return validate_tracer_ids([t.strip() for t in self.tracers.split(",") if t.strip()])
         # auto-detect
         if self.google_api_key or self.openrouter_api_key:
             return ["gemini"]
-        return ["isnet", "birefnet-lite", "inspyrenet"]
+        return list(DEFAULT_LOCAL_TRACERS)
 
     @property
     def use_local_model(self) -> bool:

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -11,6 +11,7 @@ import cv2
 import numpy as np
 
 from app.models.schemas import Polygon, Point
+from app.services.tracer_registry import GPU_REQUIRED_TRACERS, LOCAL_MODEL_LABELS, REMBG_MODELS
 
 
 # gemini-3-pro respects output dimensions precisely, so a direct
@@ -131,40 +132,28 @@ class AITracer:
 
         return polygons, mask_output_path
 
-    # rembg model names for each local model option
-    _REMBG_MODELS = {
-        "birefnet-general": "birefnet-general",
-        "birefnet-lite": "birefnet-general-lite",
-        "isnet": "isnet-general-use",
-    }
-
-    _LOCAL_MODEL_LABELS = {
-        "inspyrenet": "InSPyReNet",
-        "birefnet-general": "BiRefNet General",
-        "birefnet-lite": "BiRefNet Lite",
-        "isnet": "IS-Net",
-    }
-
     def _load_local_model(self):
-        """load the local model weights at startup."""
+        """load local model weights when the tracer is first constructed."""
         if self._local_remover is not None:
             return
         name = self.local_model_name
-        label = self._LOCAL_MODEL_LABELS.get(name, name)
-        if name in self._REMBG_MODELS:
+        label = LOCAL_MODEL_LABELS.get(name, name)
+        if name in REMBG_MODELS:
             from rembg import new_session
             from app.services.ort_runtime import get_onnx_providers
-            providers = get_onnx_providers()
+            providers = get_onnx_providers(require_gpu=name in GPU_REQUIRED_TRACERS)
             logging.info("loading %s via rembg with providers: %s", label, providers)
-            session = new_session(self._REMBG_MODELS[name], providers=providers)
+            session = new_session(REMBG_MODELS[name], providers=providers)
             logging.info("%s actual ONNX providers: %s", label, session.inner_session.get_providers())
             self._local_remover = ("rembg", session)
-        else:
+        elif name == "inspyrenet":
             from transparent_background import Remover
             import torch
             device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
             logging.info("loading %s on %s", label, device)
             self._local_remover = ("inspyrenet", Remover(mode="base", device=device))
+        else:
+            raise ValueError(f"unsupported local tracer: {name}")
 
     @staticmethod
     def _detect_paper_rect(img: np.ndarray) -> tuple[int, int, int, int] | None:
@@ -221,7 +210,7 @@ class AITracer:
         paper, not the tool. cropped to the paper, the tool becomes salient."""
         from PIL import Image
 
-        label = self._LOCAL_MODEL_LABELS.get(self.local_model_name, self.local_model_name)
+        label = LOCAL_MODEL_LABELS.get(self.local_model_name, self.local_model_name)
         logging.info("generating mask with %s (local)", label)
         pil_img = Image.open(image_path).convert("RGB")
         np_bgr = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)

--- a/backend/app/services/ort_runtime.py
+++ b/backend/app/services/ort_runtime.py
@@ -68,14 +68,25 @@ def get_onnx_providers(require_gpu: bool = False):
     - cuda: require CUDAExecutionProvider
     - cpu: CPUExecutionProvider only
     """
-    import onnxruntime as ort
-
-    requested = os.getenv("TRACEFINITY_ONNX_PROVIDER", "auto").lower()
+    requested = os.getenv("TRACEFINITY_ONNX_PROVIDER", "auto").strip().lower()
     if requested not in {"auto", "cuda", "cpu"}:
         raise ValueError("TRACEFINITY_ONNX_PROVIDER must be one of: auto, cuda, cpu")
 
     if requested == "cpu":
+        if require_gpu:
+            raise RuntimeError(
+                "TRACEFINITY_ONNX_PROVIDER=cpu cannot be used with a GPU-required tracer. "
+                "Use TRACEFINITY_ONNX_PROVIDER=auto or cuda with onnxruntime-gpu installed."
+            )
         return ["CPUExecutionProvider"]
+
+    try:
+        import onnxruntime as ort
+    except ImportError as exc:
+        raise RuntimeError(
+            "onnxruntime is required for local rembg tracers. Install backend/requirements.txt, "
+            "or backend/requirements-gpu.txt for CUDA support."
+        ) from exc
 
     _add_nvidia_dll_dirs()
     _preload_onnxruntime_cuda_dlls()

--- a/backend/app/services/tracer_registry.py
+++ b/backend/app/services/tracer_registry.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+DEFAULT_LOCAL_TRACERS = ["isnet", "birefnet-lite", "inspyrenet"]
+
+REMBG_MODELS = {
+    "birefnet-general": "birefnet-general",
+    "birefnet-lite": "birefnet-general-lite",
+    "isnet": "isnet-general-use",
+}
+
+LOCAL_MODEL_LABELS = {
+    "inspyrenet": "InSPyReNet",
+    "birefnet-general": "BiRefNet General",
+    "birefnet-lite": "BiRefNet Lite",
+    "isnet": "IS-Net",
+}
+
+GPU_REQUIRED_TRACERS = frozenset({"birefnet-general"})
+
+TRACER_LABELS = {
+    "gemini": "Gemini API",
+    **LOCAL_MODEL_LABELS,
+}
+
+SUPPORTED_TRACERS = frozenset(TRACER_LABELS)
+
+
+def validate_tracer_ids(tracers: list[str]) -> list[str]:
+    unknown = [tracer for tracer in tracers if tracer not in SUPPORTED_TRACERS]
+    if unknown:
+        supported = ", ".join(sorted(SUPPORTED_TRACERS))
+        invalid = ", ".join(unknown)
+        raise ValueError(
+            f"TRACERS contains unsupported tracer(s): {invalid}. "
+            f"Supported tracers: {supported}"
+        )
+    return tracers

--- a/backend/tests/test_ort_runtime.py
+++ b/backend/tests/test_ort_runtime.py
@@ -1,0 +1,73 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import ort_runtime
+
+
+def _fake_ort(providers):
+    return SimpleNamespace(get_available_providers=lambda: providers)
+
+
+@pytest.fixture(autouse=True)
+def no_dll_preload(monkeypatch):
+    monkeypatch.setattr(ort_runtime, "_add_nvidia_dll_dirs", lambda: None)
+    monkeypatch.setattr(ort_runtime, "_preload_onnxruntime_cuda_dlls", lambda: None)
+
+
+def test_invalid_provider_mode_raises(monkeypatch):
+    monkeypatch.setenv("TRACEFINITY_ONNX_PROVIDER", "bogus")
+
+    with pytest.raises(ValueError, match="auto, cuda, cpu"):
+        ort_runtime.get_onnx_providers()
+
+
+def test_cpu_mode_returns_cpu_provider_without_ort_import(monkeypatch):
+    monkeypatch.setenv("TRACEFINITY_ONNX_PROVIDER", "cpu")
+
+    assert ort_runtime.get_onnx_providers() == ["CPUExecutionProvider"]
+
+
+def test_cpu_mode_rejected_for_gpu_required_tracer(monkeypatch):
+    monkeypatch.setenv("TRACEFINITY_ONNX_PROVIDER", "cpu")
+
+    with pytest.raises(RuntimeError, match="GPU-required"):
+        ort_runtime.get_onnx_providers(require_gpu=True)
+
+
+def test_auto_mode_uses_cpu_when_cuda_unavailable(monkeypatch):
+    monkeypatch.delenv("TRACEFINITY_ONNX_PROVIDER", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime",
+        _fake_ort(["CPUExecutionProvider"]),
+    )
+
+    assert ort_runtime.get_onnx_providers() == ["CPUExecutionProvider"]
+
+
+def test_auto_mode_uses_cuda_when_available(monkeypatch):
+    monkeypatch.delenv("TRACEFINITY_ONNX_PROVIDER", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime",
+        _fake_ort(["CUDAExecutionProvider", "CPUExecutionProvider"]),
+    )
+
+    providers = ort_runtime.get_onnx_providers()
+
+    assert providers[0][0] == "CUDAExecutionProvider"
+    assert providers[1] == "CPUExecutionProvider"
+
+
+def test_cuda_mode_requires_cuda_provider(monkeypatch):
+    monkeypatch.setenv("TRACEFINITY_ONNX_PROVIDER", "cuda")
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime",
+        _fake_ort(["CPUExecutionProvider"]),
+    )
+
+    with pytest.raises(RuntimeError, match="CUDAExecutionProvider is not available"):
+        ort_runtime.get_onnx_providers()

--- a/backend/tests/test_tracer_config.py
+++ b/backend/tests/test_tracer_config.py
@@ -1,5 +1,7 @@
 """Tests for tracer availability configuration."""
 
+import pytest
+
 from app.config import Settings
 
 
@@ -20,3 +22,10 @@ def test_cloud_key_still_prefers_gemini_when_tracers_unset():
     settings = Settings(_env_file=None, google_api_key="test-key")
 
     assert settings.available_tracers == ["gemini"]
+
+
+def test_invalid_tracer_config_fails_fast():
+    settings = Settings(_env_file=None, tracers="birefnet-lite,typo")
+
+    with pytest.raises(ValueError, match="unsupported tracer"):
+        settings.available_tracers


### PR DESCRIPTION
## Summary

Follow-up to the remaining review comments on #38.

- Wire `birefnet-general` through `get_onnx_providers(require_gpu=True)` so the GPU-only tracer enforces CUDA availability instead of silently falling back to CPU.
- Add focused `ort_runtime` coverage for invalid provider config, CPU mode, auto CPU/CUDA branches, CUDA-required failure, and CPU mode with a GPU-required tracer.
- Add lightweight tracer ID validation for configured `TRACERS` values so misspellings fail early without loading model weights.
- Normalize the missing `onnxruntime` path to raise a clearer runtime error.
- Update the stale `_load_local_model()` docstring after the eager preload loop was removed.
- Centralize tracer IDs, labels, rembg model names, defaults, and GPU-required status in one registry to keep future local/GPU tracer changes aligned.

## PR #38 comments addressed

- `require_gpu` was never passed `True`: now wired for `birefnet-general` and guarded against explicit CPU mode.
- `ort_runtime.py` had zero test coverage: added direct tests for the requested branches.
- Broken tracer config would surface only on first user request: added startup/config validation of tracer names.
- Bare `onnxruntime` import could crash inconsistently: changed to a clearer runtime error.
- `_load_local_model` docstring still said "at startup": updated to match lazy construction behavior.

## Validation

- `backend\venv\Scripts\python.exe -m pytest backend\tests`

Code and PR drafted by Codex.
