### PR TITLE
Add workflow metadata foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ storage/
 # ide
 .idea/
 .vscode/
+.planning/
 *.swp
 
 # os

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -816,6 +816,12 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
             thumbnail_url=thumb_url,
             image_transform=tool.source_image_transform,
             image_context=image_context,
+            category=tool.category,
+            drawer=tool.drawer,
+            tags=tool.tags,
+            project_ids=tool.project_ids,
+            review_status=tool.review_status,
+            needs_cleanup=tool.needs_cleanup,
         ))
     summaries.sort(key=lambda t: t.created_at or "", reverse=True)
     return ToolListResponse(tools=summaries)
@@ -857,6 +863,18 @@ async def update_tool(request: Request, tool_id: str, req: ToolUpdateRequest, us
         tool.smooth_level = req.smooth_level
     if req.source_image_transform is not None:
         tool.source_image_transform = req.source_image_transform
+    if "category" in req.model_fields_set:
+        tool.category = req.category
+    if "drawer" in req.model_fields_set:
+        tool.drawer = req.drawer
+    if req.tags is not None:
+        tool.tags = req.tags
+    if req.project_ids is not None:
+        tool.project_ids = req.project_ids
+    if "review_status" in req.model_fields_set:
+        tool.review_status = req.review_status
+    if req.needs_cleanup is not None:
+        tool.needs_cleanup = req.needs_cleanup
     user_tools.set(tool_id, tool)
     return StatusResponse(status="ok")
 
@@ -996,6 +1014,7 @@ async def list_bins(request: Request, user_id: str = Depends(get_user_id)):
         summaries.append(BinSummary(
             id=bid,
             name=bin_data.name,
+            project_id=bin_data.project_id,
             created_at=bin_data.created_at,
             tool_count=len(bin_data.placed_tools),
             has_stl=bin_data.stl_path is not None,
@@ -1073,6 +1092,7 @@ async def create_bin(request: Request, req: CreateBinRequest, user_id: str = Dep
     bin_data = BinModel(
         id=bin_id,
         name=req.name,
+        project_id=req.project_id,
         bin_config=bc,
         placed_tools=placed,
         created_at=datetime.utcnow().isoformat(),
@@ -1090,6 +1110,8 @@ async def update_bin(request: Request, bin_id: str, req: BinUpdateRequest, user_
 
     if req.name is not None:
         bin_data.name = req.name
+    if "project_id" in req.model_fields_set:
+        bin_data.project_id = req.project_id
     if req.bin_config is not None:
         bin_data.bin_config = req.bin_config
     if req.placed_tools is not None:

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -218,6 +218,12 @@ class Tool(BaseModel):
     source_image_width: int | None = None
     source_image_height: int | None = None
     source_image_transform: list[float] | None = None  # 2D affine [a, b, c, d, e, f] mapping image-px to mm
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] = []
+    project_ids: list[str] = []
+    review_status: str | None = None
+    needs_cleanup: bool = False
     thumbnail_path: str | None = None
     created_at: str | None = None
 
@@ -238,6 +244,12 @@ class ToolSummary(BaseModel):
     thumbnail_url: str | None = None
     image_transform: list[float] | None = None
     image_context: dict | None = None
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] = []
+    project_ids: list[str] = []
+    review_status: str | None = None
+    needs_cleanup: bool = False
 
 
 class ToolUpdateRequest(BaseModel):
@@ -248,6 +260,12 @@ class ToolUpdateRequest(BaseModel):
     smoothed: bool | None = None
     smooth_level: float | None = None
     source_image_transform: list[float] | None = None
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] | None = None
+    project_ids: list[str] | None = None
+    review_status: str | None = None
+    needs_cleanup: bool | None = None
 
 
 class ToolListResponse(BaseModel):
@@ -283,6 +301,7 @@ class BinConfig(BinParams):
 class BinModel(BaseModel):
     id: str
     name: str | None = None
+    project_id: str | None = None
     bin_config: BinConfig = BinConfig()
     placed_tools: list[PlacedTool] = []
     text_labels: list[TextLabel] = []
@@ -297,6 +316,7 @@ class BinPreviewTool(BaseModel):
 class BinSummary(BaseModel):
     id: str
     name: str | None
+    project_id: str | None = None
     created_at: str | None
     tool_count: int
     has_stl: bool
@@ -311,6 +331,7 @@ class BinListResponse(BaseModel):
 
 class BinUpdateRequest(BaseModel):
     name: str | None = None
+    project_id: str | None = None
     bin_config: BinConfig | None = None
     placed_tools: list[PlacedTool] | None = None
     text_labels: list[TextLabel] | None = None
@@ -318,4 +339,5 @@ class BinUpdateRequest(BaseModel):
 
 class CreateBinRequest(BaseModel):
     name: str | None = None
+    project_id: str | None = None
     tool_ids: list[str] = []  # pre-place these tools

--- a/backend/tests/test_workflow_metadata.py
+++ b/backend/tests/test_workflow_metadata.py
@@ -1,0 +1,115 @@
+"""Compatibility tests for workflow planning metadata fields."""
+
+from app.models.schemas import BinModel, BinUpdateRequest, CreateBinRequest, Tool, ToolUpdateRequest
+
+
+def test_old_tool_records_get_metadata_defaults():
+    tool = Tool.model_validate({
+        "id": "tool-1",
+        "name": "pliers",
+        "points": [
+            {"x": 0, "y": 0},
+            {"x": 10, "y": 0},
+            {"x": 10, "y": 10},
+            {"x": 0, "y": 10},
+        ],
+        "finger_holes": [],
+        "interior_rings": [],
+    })
+
+    assert tool.category is None
+    assert tool.drawer is None
+    assert tool.tags == []
+    assert tool.project_ids == []
+    assert tool.review_status is None
+    assert tool.needs_cleanup is False
+
+
+def test_tool_metadata_round_trips():
+    tool = Tool.model_validate({
+        "id": "tool-1",
+        "name": "pliers",
+        "points": [
+            {"x": 0, "y": 0},
+            {"x": 10, "y": 0},
+            {"x": 10, "y": 10},
+            {"x": 0, "y": 10},
+        ],
+        "category": "hand tools",
+        "drawer": "drawer 1",
+        "tags": ["cutting", "metal"],
+        "project_ids": ["project-1"],
+        "review_status": "reviewed",
+        "needs_cleanup": True,
+    })
+
+    data = tool.model_dump()
+
+    assert data["category"] == "hand tools"
+    assert data["drawer"] == "drawer 1"
+    assert data["tags"] == ["cutting", "metal"]
+    assert data["project_ids"] == ["project-1"]
+    assert data["review_status"] == "reviewed"
+    assert data["needs_cleanup"] is True
+
+
+def test_old_bin_records_get_project_default():
+    bin_data = BinModel.model_validate({
+        "id": "bin-1",
+        "name": "drawer 1 bin",
+        "placed_tools": [],
+        "text_labels": [],
+    })
+
+    assert bin_data.project_id is None
+
+
+def test_bin_project_id_round_trips():
+    bin_data = BinModel.model_validate({
+        "id": "bin-1",
+        "name": "drawer 1 bin",
+        "project_id": "project-1",
+        "placed_tools": [],
+        "text_labels": [],
+    })
+
+    assert bin_data.model_dump()["project_id"] == "project-1"
+
+
+def test_create_bin_request_accepts_project_id():
+    req = CreateBinRequest(name="drawer bin", project_id="project-1", tool_ids=["tool-1"])
+
+    assert req.project_id == "project-1"
+    assert req.tool_ids == ["tool-1"]
+
+
+def test_bin_update_request_can_clear_project_id():
+    req = BinUpdateRequest(project_id=None)
+
+    assert "project_id" in req.model_fields_set
+    assert req.project_id is None
+
+
+def test_bin_update_request_distinguishes_absent_project_id():
+    req = BinUpdateRequest()
+
+    assert "project_id" not in req.model_fields_set
+
+
+def test_tool_update_request_can_clear_nullable_metadata():
+    req = ToolUpdateRequest(category=None, drawer=None, review_status=None)
+
+    assert "category" in req.model_fields_set
+    assert "drawer" in req.model_fields_set
+    assert "review_status" in req.model_fields_set
+    assert req.category is None
+    assert req.drawer is None
+    assert req.review_status is None
+
+
+def test_tool_update_request_distinguishes_absent_metadata():
+    req = ToolUpdateRequest()
+
+    assert "category" not in req.model_fields_set
+    assert "drawer" not in req.model_fields_set
+    assert "review_status" not in req.model_fields_set

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -188,7 +188,21 @@ export async function getTool(toolId: string): Promise<Tool> {
 
 export async function updateTool(
   toolId: string,
-  updates: { name?: string; points?: Point[]; finger_holes?: import('@/types').FingerHole[]; interior_rings?: Point[][]; smoothed?: boolean; smooth_level?: number; source_image_transform?: import('@/types').AffineMatrix }
+  updates: {
+    name?: string
+    points?: Point[]
+    finger_holes?: import('@/types').FingerHole[]
+    interior_rings?: Point[][]
+    smoothed?: boolean
+    smooth_level?: number
+    source_image_transform?: import('@/types').AffineMatrix
+    category?: string | null
+    drawer?: string | null
+    tags?: string[]
+    project_ids?: string[]
+    review_status?: string | null
+    needs_cleanup?: boolean
+  }
 ): Promise<void> {
   await fetchApi(`/api/tools/${toolId}`, {
     method: 'PUT',
@@ -223,7 +237,7 @@ export async function getBin(binId: string): Promise<BinData> {
   return fetchApi(`/api/bins/${binId}`)
 }
 
-export async function createBin(opts: { name?: string; tool_ids?: string[] } = {}): Promise<BinData> {
+export async function createBin(opts: { name?: string; project_id?: string | null; tool_ids?: string[] } = {}): Promise<BinData> {
   return fetchApi('/api/bins', {
     method: 'POST',
     body: JSON.stringify(opts),
@@ -234,6 +248,7 @@ export async function updateBin(
   binId: string,
   updates: {
     name?: string
+    project_id?: string | null
     bin_config?: BinConfig
     placed_tools?: PlacedTool[]
     text_labels?: TextLabel[]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -125,6 +125,12 @@ export interface Tool {
   smooth_level: number
   source_session_id: string | null
   image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
   created_at: string | null
 }
 
@@ -152,6 +158,12 @@ export interface ToolSummary {
   thumbnail_url: string | null
   image_transform: AffineMatrix | null
   image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
 }
 
 // --- bins ---
@@ -170,6 +182,7 @@ export interface PlacedTool {
 export interface BinData {
   id: string
   name: string | null
+  project_id: string | null
   bin_config: BinConfig
   placed_tools: PlacedTool[]
   text_labels: TextLabel[]
@@ -185,6 +198,7 @@ export interface BinPreviewTool {
 export interface BinSummary {
   id: string
   name: string | null
+  project_id: string | null
   created_at: string | null
   tool_count: number
   has_stl: boolean


### PR DESCRIPTION
## Intent

This PR adds the small metadata foundation needed for tool/bin workflow organization without changing the main user workflow yet. The goal is to make existing tool and bin records forward-compatible with richer planning features in a follow-up PR.

## Summary

- Adds optional workflow metadata to tools.
- Adds project linkage support to bins.
- Keeps old JSON records compatible through defaults.
- Extends frontend API/types so future UI can consume the metadata safely.

## Technical changes by file

- `.gitignore`: ignores `.planning/` local planning artifacts.
- `backend/app/models/schemas.py`: adds tool metadata fields (`category`, `drawer`, `tags`, `project_ids`, `review_status`, `needs_cleanup`) and bin `project_id` fields with backwards-compatible defaults.
- `backend/app/api/routes.py`: includes new metadata in tool summaries/details and supports updating nullable/list metadata fields.
- `backend/tests/test_workflow_metadata.py`: covers backwards compatibility for older tool/bin records and metadata request behavior.
- `frontend/src/lib/api.ts`: extends API update/create types for the new metadata fields.
- `frontend/src/types/index.ts`: mirrors backend schema additions in frontend types.

## Verification

- Backend compatibility tests added for old records and nullable metadata behavior.

Code and PR drafted with Codex