### PR TITLE
Add bin project planning workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ storage/
 # ide
 .idea/
 .vscode/
+.agents/
 .planning/
 *.swp
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ storage/
 # ide
 .idea/
 .vscode/
+.planning/
 *.swp
 
 # os

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tracefinity
 
-Tool tracing app that generates 3D-printable gridfinity bins from photos. Backend is Python/FastAPI with OpenCV and manifold3d; frontend is Next.js 16/React 19/TypeScript with react-three-fiber for 3D preview.
+Tool tracing app that generates 3D-printable gridfinity bins from photos. Backend is Python/FastAPI with OpenCV and manifold3d; frontend is Next.js 16/React 19/TypeScript with react-three-fiber for 3D preview. Bin projects group tools and bins for planning larger drawer/workspace workflows.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 3. Upload and adjust paper corners for scale calibration
 4. AI traces tool outlines automatically
 5. Save traced tools to your library
-6. Create bins, add tools from the library, arrange the layout
-7. Download STL/3MF for 3D printing
+6. Group tools into projects when planning a drawer or workspace
+7. Create bins from project tools, arrange the layout
+8. Download STL/3MF for 3D printing
 
 | Dashboard | Tool Editor | Bin Editor |
 |-|-|-|
@@ -127,6 +128,7 @@ No API key and prefer not to use the local model? Upload a mask manually:
 - **Manual mask upload** -- Use the Gemini web interface without an API key
 - **Selective saving** -- Choose which traced outlines to keep before saving to your library
 - **Tool library** -- Save traced tools and reuse them across multiple bins
+- **Bin projects** -- Plan a group of tools and bins together, track which tools still need bins, and create project-scoped bins
 - **Tool editor** -- Rotate tools, add/remove vertices, adjust outlines, snap to grid
 - **Smooth or accurate** -- Toggle Chaikin subdivision for smooth curves, or keep the raw trace; SVG and STL exports both respect this
 - **Finger holes** -- Circular, square, or rectangular cutouts for easy tool removal

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -43,6 +43,15 @@ from app.models.schemas import (
     ToolUpdateRequest,
     SaveToolsRequest,
     SaveToolsResponse,
+    BinProject,
+    BinProjectDetail,
+    BinProjectListResponse,
+    BinProjectCreateRequest,
+    BinProjectUpdateRequest,
+    BinProjectToolsRequest,
+    BinProjectCreateBinRequest,
+    BinProjectBinsRequest,
+    ProjectHealthResponse,
     PlacedTool,
     BinModel,
     BinConfig,
@@ -60,9 +69,22 @@ from app.services.stl_generator_manifold import ManifoldSTLGenerator
 from app.services.session_store import SessionStore
 from app.services.tool_store import ToolStore
 from app.services.bin_store import BinStore
+from app.services.project_store import ProjectStore
 from app.services.bin_service import sync_placed_tools
 from app.services.image_service import generate_tool_thumbnail
 from app.services.tracer_registry import TRACER_LABELS, validate_tracer_ids
+from app.services.project_service import (
+    add_bin_to_project,
+    add_project_to_tools,
+    health_response,
+    make_project_detail,
+    make_project_summary,
+    project_health,
+    remove_bin_from_all_projects,
+    remove_bin_from_project,
+    remove_project_from_tools,
+    repair_project_links,
+)
 router = APIRouter()
 
 # Heuristic mismatch score combining a label penalty with bbox and point deltas measured in mm.
@@ -80,6 +102,7 @@ validate_tracer_ids(settings.available_tracers)
 
 # per-user store registry
 _store_cache: dict[str, tuple[SessionStore, ToolStore, BinStore]] = {}
+_project_store_cache: dict[str, ProjectStore] = {}
 
 
 def get_stores(user_id: str) -> tuple[SessionStore, ToolStore, BinStore]:
@@ -92,6 +115,14 @@ def get_stores(user_id: str) -> tuple[SessionStore, ToolStore, BinStore]:
             BinStore(user_path),
         )
     return _store_cache[user_id]
+
+
+def get_project_store(user_id: str) -> ProjectStore:
+    if user_id not in _project_store_cache:
+        user_path = settings.storage_path / user_id
+        ensure_user_dirs(user_path)
+        _project_store_cache[user_id] = ProjectStore(user_path)
+    return _project_store_cache[user_id]
 
 
 def _user_path(user_id: str) -> Path:
@@ -182,6 +213,7 @@ def _translate_finger_holes(holes: list[FingerHole], dx: float, dy: float) -> li
             id=fh.id, x=fh.x + dx, y=fh.y + dy,
             radius=fh.radius, width=fh.width, height=fh.height,
             rotation=fh.rotation, shape=fh.shape,
+            depth_override=fh.depth_override,
         )
         for fh in holes
     ]
@@ -305,6 +337,72 @@ def _tool_image_context(tool: Tool, sessions: SessionStore, load_missing_dimensi
         "scale_factor": math.hypot(transform[0], transform[1]),
         "transform": transform,
     }, updated
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def _build_bin_from_tools(
+    bin_id: str,
+    name: str | None,
+    project_id: str | None,
+    tool_ids: list[str],
+    user_tools: ToolStore,
+    default_config: BinConfig | None = None,
+) -> BinModel:
+    placed: list[PlacedTool] = []
+    all_points_mm: list[tuple[float, float]] = []
+
+    for tool_id in tool_ids:
+        tool = user_tools.get(tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail=f"tool {tool_id} not found")
+
+        all_points_mm.extend([(p.x, p.y) for p in tool.points])
+        placed.append(PlacedTool(
+            id=str(uuid.uuid4()),
+            tool_id=tool_id,
+            name=tool.name,
+            points=list(tool.points),
+            finger_holes=list(tool.finger_holes),
+            interior_rings=list(tool.interior_rings),
+        ))
+
+    bc = BinConfig.model_validate(default_config.model_dump()) if default_config else BinConfig()
+    if all_points_mm:
+        all_xs = [p[0] for p in all_points_mm]
+        all_ys = [p[1] for p in all_points_mm]
+        tool_width = max(all_xs) - min(all_xs)
+        tool_height = max(all_ys) - min(all_ys)
+
+        clearance = bc.cutout_clearance
+        wall = bc.wall_thickness
+        needed_w = tool_width + 2 * clearance + 2 * wall + 0.5
+        needed_h = tool_height + 2 * clearance + 2 * wall + 0.5
+
+        grid_x = max(1, int((needed_w + GF_GRID - 1) // GF_GRID))
+        grid_y = max(1, int((needed_h + GF_GRID - 1) // GF_GRID))
+        bc.grid_x = min(grid_x, 10)
+        bc.grid_y = min(grid_y, 10)
+
+        bin_w = bc.grid_x * GF_GRID
+        bin_h = bc.grid_y * GF_GRID
+        offset_x = bin_w / 2
+        offset_y = bin_h / 2
+        for pt in placed:
+            pt.points = _translate_points(pt.points, offset_x, offset_y)
+            pt.finger_holes = _translate_finger_holes(pt.finger_holes, offset_x, offset_y)
+            pt.interior_rings = [_translate_points(ring, offset_x, offset_y) for ring in pt.interior_rings]
+
+    return BinModel(
+        id=bin_id,
+        name=name,
+        project_id=project_id,
+        bin_config=bc,
+        placed_tools=placed,
+        created_at=_now_iso(),
+    )
 
 
 def _run_generate(
@@ -1003,6 +1101,289 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
     return SaveToolsResponse(tool_ids=tool_ids)
 
 
+# --- bin projects ---
+
+@router.get("/bin-projects", response_model=BinProjectListResponse)
+async def list_bin_projects(request: Request, user_id: str = Depends(get_user_id)):
+    project_store = get_project_store(user_id)
+    _, _, user_bins = get_stores(user_id)
+    summaries = [
+        make_project_summary(project, user_bins)
+        for project in project_store.all().values()
+    ]
+    summaries.sort(key=lambda p: p.updated_at or p.created_at or "", reverse=True)
+    return BinProjectListResponse(projects=summaries)
+
+
+@router.post("/bin-projects", response_model=BinProject)
+async def create_bin_project(request: Request, req: BinProjectCreateRequest, user_id: str = Depends(get_user_id)):
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="project name is required")
+
+    project_store = get_project_store(user_id)
+    _, user_tools, _ = get_stores(user_id)
+    for tool_id in req.tool_ids:
+        if not user_tools.get(tool_id):
+            raise HTTPException(status_code=404, detail=f"tool {tool_id} not found")
+
+    project_id = str(uuid.uuid4())
+    now = _now_iso()
+    project = BinProject(
+        id=project_id,
+        name=name,
+        description=req.description,
+        status=req.status,
+        tool_ids=list(dict.fromkeys(req.tool_ids)),
+        target_grid_x=req.target_grid_x,
+        target_grid_y=req.target_grid_y,
+        default_bin_config=req.default_bin_config,
+        notes=req.notes,
+        created_at=now,
+        updated_at=now,
+    )
+    project_store.set(project_id, project)
+    add_project_to_tools(project_id, project.tool_ids, user_tools)
+    return project
+
+
+@router.get("/bin-projects/{project_id}", response_model=BinProjectDetail)
+async def get_bin_project(request: Request, project_id: str, user_id: str = Depends(get_user_id)):
+    project = get_project_store(user_id).get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+    _, _, user_bins = get_stores(user_id)
+    return make_project_detail(project, user_bins)
+
+
+@router.patch("/bin-projects/{project_id}", response_model=BinProjectDetail)
+async def update_bin_project(
+    request: Request,
+    project_id: str,
+    req: BinProjectUpdateRequest,
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    if req.name is not None:
+        name = req.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="project name is required")
+        project.name = name
+    if "description" in req.model_fields_set:
+        project.description = req.description
+    if "status" in req.model_fields_set and req.status is not None:
+        project.status = req.status
+    if "target_grid_x" in req.model_fields_set:
+        project.target_grid_x = req.target_grid_x
+    if "target_grid_y" in req.model_fields_set:
+        project.target_grid_y = req.target_grid_y
+    if "default_bin_config" in req.model_fields_set:
+        project.default_bin_config = req.default_bin_config
+    if "notes" in req.model_fields_set:
+        project.notes = req.notes
+
+    project.updated_at = _now_iso()
+    project_store.set(project_id, project)
+    _, _, user_bins = get_stores(user_id)
+    return make_project_detail(project, user_bins)
+
+
+@router.delete("/bin-projects/{project_id}", response_model=StatusResponse)
+async def delete_bin_project(request: Request, project_id: str, user_id: str = Depends(get_user_id)):
+    project_store = get_project_store(user_id)
+    _, user_tools, user_bins = get_stores(user_id)
+    project = project_store.delete(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    remove_project_from_tools(project_id, project.tool_ids, user_tools)
+    for bid, bin_data in user_bins.all().items():
+        if bin_data.project_id == project_id or bid in project.bin_ids:
+            bin_data.project_id = None
+            user_bins.set(bid, bin_data)
+
+    return StatusResponse(status="deleted")
+
+
+@router.post("/bin-projects/{project_id}/tools", response_model=BinProjectDetail)
+async def add_tools_to_bin_project(
+    request: Request,
+    project_id: str,
+    req: BinProjectToolsRequest,
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    _, user_tools, user_bins = get_stores(user_id)
+    for tool_id in req.tool_ids:
+        if not user_tools.get(tool_id):
+            raise HTTPException(status_code=404, detail=f"tool {tool_id} not found")
+
+    existing = set(project.tool_ids)
+    for tool_id in req.tool_ids:
+        if tool_id not in existing:
+            project.tool_ids.append(tool_id)
+            existing.add(tool_id)
+    project.updated_at = _now_iso()
+    project_store.set(project_id, project)
+    add_project_to_tools(project_id, req.tool_ids, user_tools)
+    return make_project_detail(project, user_bins)
+
+
+@router.delete("/bin-projects/{project_id}/tools/{tool_id}", response_model=BinProjectDetail)
+async def remove_tool_from_bin_project(
+    request: Request,
+    project_id: str,
+    tool_id: str,
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    if tool_id in project.tool_ids:
+        project.tool_ids = [tid for tid in project.tool_ids if tid != tool_id]
+        project.updated_at = _now_iso()
+        project_store.set(project_id, project)
+
+    _, user_tools, user_bins = get_stores(user_id)
+    remove_project_from_tools(project_id, [tool_id], user_tools)
+    return make_project_detail(project, user_bins)
+
+
+@router.get("/bin-projects/{project_id}/health", response_model=ProjectHealthResponse)
+async def get_bin_project_health(request: Request, project_id: str, user_id: str = Depends(get_user_id)):
+    project = get_project_store(user_id).get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+    _, user_tools, user_bins = get_stores(user_id)
+    return health_response(project_health(project, user_tools, user_bins))
+
+
+@router.post("/bin-projects/{project_id}/repair", response_model=ProjectHealthResponse)
+async def repair_bin_project(request: Request, project_id: str, user_id: str = Depends(get_user_id)):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+    _, user_tools, user_bins = get_stores(user_id)
+    repaired = repair_project_links(project_store, project, user_tools, user_bins)
+    return health_response(project_health(repaired, user_tools, user_bins))
+
+
+@router.post("/bin-projects/{project_id}/bins", response_model=BinProjectDetail)
+async def add_bins_to_bin_project(
+    request: Request,
+    project_id: str,
+    req: BinProjectBinsRequest,
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    _, user_tools, user_bins = get_stores(user_id)
+    bin_ids = list(dict.fromkeys(req.bin_ids))
+    for bin_id in bin_ids:
+        bin_data = user_bins.get(bin_id)
+        if not bin_data:
+            raise HTTPException(status_code=404, detail=f"bin {bin_id} not found")
+        if bin_data.project_id and bin_data.project_id != project_id and not req.allow_reassign:
+            raise HTTPException(status_code=400, detail=f"bin {bin_id} already belongs to another project")
+
+    existing_tools = set(project.tool_ids)
+    for bin_id in bin_ids:
+        bin_data = user_bins.get(bin_id)
+        if bin_data.project_id and bin_data.project_id != project_id:
+            remove_bin_from_project(project_store, bin_data.project_id, bin_id)
+        bin_data.project_id = project_id
+        user_bins.set(bin_id, bin_data)
+        if bin_id not in project.bin_ids:
+            project.bin_ids.append(bin_id)
+
+        if req.import_tools:
+            importable_tool_ids: list[str] = []
+            for placed in bin_data.placed_tools:
+                if placed.tool_id and placed.tool_id not in existing_tools:
+                    if not user_tools.get(placed.tool_id):
+                        continue
+                    project.tool_ids.append(placed.tool_id)
+                    existing_tools.add(placed.tool_id)
+                if placed.tool_id and user_tools.get(placed.tool_id):
+                    importable_tool_ids.append(placed.tool_id)
+            add_project_to_tools(project_id, importable_tool_ids, user_tools)
+
+    project.updated_at = _now_iso()
+    project_store.set(project_id, project)
+    return make_project_detail(project, user_bins)
+
+
+@router.delete("/bin-projects/{project_id}/bins/{bin_id}", response_model=BinProjectDetail)
+async def detach_bin_from_bin_project(
+    request: Request,
+    project_id: str,
+    bin_id: str,
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    _, _, user_bins = get_stores(user_id)
+    bin_data = user_bins.get(bin_id)
+    if bin_id in project.bin_ids:
+        project.bin_ids = [bid for bid in project.bin_ids if bid != bin_id]
+    if bin_data and bin_data.project_id == project_id:
+        bin_data.project_id = None
+        user_bins.set(bin_id, bin_data)
+
+    project.updated_at = _now_iso()
+    project_store.set(project_id, project)
+    return make_project_detail(project, user_bins)
+
+
+@router.post("/bin-projects/{project_id}/create-bin", response_model=BinModel)
+async def create_bin_from_project(
+    request: Request,
+    project_id: str,
+    req: BinProjectCreateBinRequest = BinProjectCreateBinRequest(),
+    user_id: str = Depends(get_user_id),
+):
+    project_store = get_project_store(user_id)
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    _, user_tools, user_bins = get_stores(user_id)
+    tool_ids = project.tool_ids if req.tool_ids is None else req.tool_ids
+    outside_project = [tid for tid in tool_ids if tid not in project.tool_ids]
+    if outside_project:
+        raise HTTPException(status_code=400, detail="all tools must belong to project")
+
+    bin_id = str(uuid.uuid4())
+    bin_data = _build_bin_from_tools(
+        bin_id=bin_id,
+        name=req.name or project.name,
+        project_id=project_id,
+        tool_ids=tool_ids,
+        user_tools=user_tools,
+        default_config=project.default_bin_config,
+    )
+    user_bins.set(bin_id, bin_data)
+    add_bin_to_project(project_store, project_id, bin_id)
+    return bin_data
+
+
 # --- bins ---
 
 @router.get("/bins", response_model=BinListResponse)
@@ -1016,6 +1397,7 @@ async def list_bins(request: Request, user_id: str = Depends(get_user_id)):
             name=bin_data.name,
             project_id=bin_data.project_id,
             created_at=bin_data.created_at,
+            tool_ids=[pt.tool_id for pt in bin_data.placed_tools],
             tool_count=len(bin_data.placed_tools),
             has_stl=bin_data.stl_path is not None,
             grid_x=bin_data.bin_config.grid_x,
@@ -1042,75 +1424,36 @@ async def get_bin(request: Request, bin_id: str, user_id: str = Depends(get_user
 @router.post("/bins", response_model=BinModel)
 async def create_bin(request: Request, req: CreateBinRequest, user_id: str = Depends(get_user_id)):
     _, user_tools, user_bins = get_stores(user_id)
+    project_store = get_project_store(user_id)
+    if req.project_id and not project_store.get(req.project_id):
+        raise HTTPException(status_code=404, detail=f"project {req.project_id} not found")
     bin_id = str(uuid.uuid4())
-
-    placed: list[PlacedTool] = []
-    all_points_mm: list[tuple[float, float]] = []
-
-    for tool_id in req.tool_ids:
-        tool = user_tools.get(tool_id)
-        if not tool:
-            raise HTTPException(status_code=404, detail=f"tool {tool_id} not found")
-
-        all_points_mm.extend([(p.x, p.y) for p in tool.points])
-
-        placed.append(PlacedTool(
-            id=str(uuid.uuid4()),
-            tool_id=tool_id,
-            name=tool.name,
-            points=list(tool.points),
-            finger_holes=list(tool.finger_holes),
-            interior_rings=list(tool.interior_rings),
-        ))
-
-    bc = BinConfig()
-    if all_points_mm:
-        all_xs = [p[0] for p in all_points_mm]
-        all_ys = [p[1] for p in all_points_mm]
-        tool_width = max(all_xs) - min(all_xs)
-        tool_height = max(all_ys) - min(all_ys)
-
-        clearance = bc.cutout_clearance
-        wall = bc.wall_thickness
-        needed_w = tool_width + 2 * clearance + 2 * wall + 0.5
-        needed_h = tool_height + 2 * clearance + 2 * wall + 0.5
-
-        grid_x = max(1, int((needed_w + GF_GRID - 1) // GF_GRID))
-        grid_y = max(1, int((needed_h + GF_GRID - 1) // GF_GRID))
-        bc.grid_x = min(grid_x, 10)
-        bc.grid_y = min(grid_y, 10)
-
-        bin_w = bc.grid_x * GF_GRID
-        bin_h = bc.grid_y * GF_GRID
-        offset_x = bin_w / 2
-        offset_y = bin_h / 2
-        for pt in placed:
-            pt.points = _translate_points(pt.points, offset_x, offset_y)
-            pt.finger_holes = _translate_finger_holes(pt.finger_holes, offset_x, offset_y)
-            pt.interior_rings = [_translate_points(ring, offset_x, offset_y) for ring in pt.interior_rings]
-
-    bin_data = BinModel(
-        id=bin_id,
+    bin_data = _build_bin_from_tools(
+        bin_id=bin_id,
         name=req.name,
         project_id=req.project_id,
-        bin_config=bc,
-        placed_tools=placed,
-        created_at=datetime.utcnow().isoformat(),
+        tool_ids=req.tool_ids,
+        user_tools=user_tools,
     )
     user_bins.set(bin_id, bin_data)
+    add_bin_to_project(project_store, req.project_id, bin_id)
     return bin_data
 
 
 @router.put("/bins/{bin_id}", response_model=StatusResponse)
 async def update_bin(request: Request, bin_id: str, req: BinUpdateRequest, user_id: str = Depends(get_user_id)):
     _, _, user_bins = get_stores(user_id)
+    project_store = get_project_store(user_id)
     bin_data = user_bins.get(bin_id)
     if not bin_data:
         raise HTTPException(status_code=404, detail="bin not found")
 
+    old_project_id = bin_data.project_id
     if req.name is not None:
         bin_data.name = req.name
     if "project_id" in req.model_fields_set:
+        if req.project_id and not project_store.get(req.project_id):
+            raise HTTPException(status_code=404, detail=f"project {req.project_id} not found")
         bin_data.project_id = req.project_id
     if req.bin_config is not None:
         bin_data.bin_config = req.bin_config
@@ -1119,16 +1462,22 @@ async def update_bin(request: Request, bin_id: str, req: BinUpdateRequest, user_
     if req.text_labels is not None:
         bin_data.text_labels = req.text_labels
     user_bins.set(bin_id, bin_data)
+    if old_project_id != bin_data.project_id:
+        remove_bin_from_project(project_store, old_project_id, bin_id)
+        add_bin_to_project(project_store, bin_data.project_id, bin_id)
     return StatusResponse(status="ok")
 
 
 @router.delete("/bins/{bin_id}", response_model=StatusResponse)
 async def delete_bin(request: Request, bin_id: str, user_id: str = Depends(get_user_id)):
     _, _, user_bins = get_stores(user_id)
+    project_store = get_project_store(user_id)
     up = _user_path(user_id)
     bin_data = user_bins.delete(bin_id)
     if not bin_data:
         raise HTTPException(status_code=404, detail="bin not found")
+    remove_bin_from_project(project_store, bin_data.project_id, bin_id)
+    remove_bin_from_all_projects(project_store, bin_id)
 
     if bin_data.stl_path:
         stl_abs = Path(_abs(bin_data.stl_path))

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -816,6 +816,12 @@ async def list_tools(request: Request, user_id: str = Depends(get_user_id)):
             thumbnail_url=thumb_url,
             image_transform=tool.source_image_transform,
             image_context=image_context,
+            category=tool.category,
+            drawer=tool.drawer,
+            tags=tool.tags,
+            project_ids=tool.project_ids,
+            review_status=tool.review_status,
+            needs_cleanup=tool.needs_cleanup,
         ))
     summaries.sort(key=lambda t: t.created_at or "", reverse=True)
     return ToolListResponse(tools=summaries)
@@ -857,6 +863,18 @@ async def update_tool(request: Request, tool_id: str, req: ToolUpdateRequest, us
         tool.smooth_level = req.smooth_level
     if req.source_image_transform is not None:
         tool.source_image_transform = req.source_image_transform
+    if "category" in req.model_fields_set:
+        tool.category = req.category
+    if "drawer" in req.model_fields_set:
+        tool.drawer = req.drawer
+    if req.tags is not None:
+        tool.tags = req.tags
+    if req.project_ids is not None:
+        tool.project_ids = req.project_ids
+    if "review_status" in req.model_fields_set:
+        tool.review_status = req.review_status
+    if req.needs_cleanup is not None:
+        tool.needs_cleanup = req.needs_cleanup
     user_tools.set(tool_id, tool)
     return StatusResponse(status="ok")
 
@@ -996,6 +1014,7 @@ async def list_bins(request: Request, user_id: str = Depends(get_user_id)):
         summaries.append(BinSummary(
             id=bid,
             name=bin_data.name,
+            project_id=bin_data.project_id,
             created_at=bin_data.created_at,
             tool_count=len(bin_data.placed_tools),
             has_stl=bin_data.stl_path is not None,
@@ -1073,6 +1092,7 @@ async def create_bin(request: Request, req: CreateBinRequest, user_id: str = Dep
     bin_data = BinModel(
         id=bin_id,
         name=req.name,
+        project_id=req.project_id,
         bin_config=bc,
         placed_tools=placed,
         created_at=datetime.utcnow().isoformat(),
@@ -1090,6 +1110,8 @@ async def update_bin(request: Request, bin_id: str, req: BinUpdateRequest, user_
 
     if req.name is not None:
         bin_data.name = req.name
+    if "project_id" in req.model_fields_set:
+        bin_data.project_id = req.project_id
     if req.bin_config is not None:
         bin_data.bin_config = req.bin_config
     if req.placed_tools is not None:

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -280,6 +280,110 @@ class SaveToolsResponse(BaseModel):
     tool_ids: list[str]
 
 
+# --- bin projects ---
+
+ProjectStatus = Literal["active", "ready_to_print", "printed", "archived"]
+ProjectHealthSeverity = Literal["warning", "error"]
+ProjectHealthCode = Literal[
+    "missing_tool",
+    "missing_bin",
+    "bin_missing_project_id",
+    "bin_project_mismatch",
+    "outside_tool",
+    "tool_missing_project_id",
+    "tool_extra_project_id",
+]
+
+class BinProject(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    status: ProjectStatus = "active"
+    tool_ids: list[str] = []
+    bin_ids: list[str] = []
+    target_grid_x: int | None = None
+    target_grid_y: int | None = None
+    default_bin_config: BinParams | None = None
+    notes: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+class BinProjectDetail(BinProject):
+    placed_tool_ids: list[str] = []
+    unplaced_tool_ids: list[str] = []
+
+
+class BinProjectSummary(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    status: ProjectStatus = "active"
+    tool_count: int = 0
+    bin_count: int = 0
+    placed_count: int = 0
+    unplaced_count: int = 0
+    target_grid_x: int | None = None
+    target_grid_y: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class BinProjectListResponse(BaseModel):
+    projects: list[BinProjectSummary]
+
+
+class BinProjectCreateRequest(BaseModel):
+    name: str
+    description: str | None = None
+    status: ProjectStatus = "active"
+    target_grid_x: int | None = None
+    target_grid_y: int | None = None
+    default_bin_config: BinParams | None = None
+    notes: str | None = None
+    tool_ids: list[str] = []
+
+
+class BinProjectUpdateRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    status: ProjectStatus | None = None
+    target_grid_x: int | None = None
+    target_grid_y: int | None = None
+    default_bin_config: BinParams | None = None
+    notes: str | None = None
+
+
+class BinProjectToolsRequest(BaseModel):
+    tool_ids: list[str]
+
+
+class BinProjectCreateBinRequest(BaseModel):
+    name: str | None = None
+    tool_ids: list[str] | None = None
+
+
+class BinProjectBinsRequest(BaseModel):
+    bin_ids: list[str]
+    import_tools: bool = False
+    allow_reassign: bool = False
+
+
+class ProjectHealthIssue(BaseModel):
+    code: ProjectHealthCode
+    severity: ProjectHealthSeverity
+    message: str
+    tool_id: str | None = None
+    bin_id: str | None = None
+    other_project_id: str | None = None
+    repairable: bool = False
+
+
+class ProjectHealthResponse(BaseModel):
+    issues: list[ProjectHealthIssue]
+    repairable_count: int = 0
+    manual_count: int = 0
+
+
 # --- bins ---
 
 class PlacedTool(BaseModel):
@@ -318,6 +422,7 @@ class BinSummary(BaseModel):
     name: str | None
     project_id: str | None = None
     created_at: str | None
+    tool_ids: list[str] = []
     tool_count: int
     has_stl: bool
     grid_x: int = 2

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -218,6 +218,12 @@ class Tool(BaseModel):
     source_image_width: int | None = None
     source_image_height: int | None = None
     source_image_transform: list[float] | None = None  # 2D affine [a, b, c, d, e, f] mapping image-px to mm
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] = []
+    project_ids: list[str] = []
+    review_status: str | None = None
+    needs_cleanup: bool = False
     thumbnail_path: str | None = None
     created_at: str | None = None
 
@@ -238,6 +244,12 @@ class ToolSummary(BaseModel):
     thumbnail_url: str | None = None
     image_transform: list[float] | None = None
     image_context: dict | None = None
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] = []
+    project_ids: list[str] = []
+    review_status: str | None = None
+    needs_cleanup: bool = False
 
 
 class ToolUpdateRequest(BaseModel):
@@ -248,6 +260,12 @@ class ToolUpdateRequest(BaseModel):
     smoothed: bool | None = None
     smooth_level: float | None = None
     source_image_transform: list[float] | None = None
+    category: str | None = None
+    drawer: str | None = None
+    tags: list[str] | None = None
+    project_ids: list[str] | None = None
+    review_status: str | None = None
+    needs_cleanup: bool | None = None
 
 
 class ToolListResponse(BaseModel):
@@ -283,6 +301,7 @@ class BinConfig(BinParams):
 class BinModel(BaseModel):
     id: str
     name: str | None = None
+    project_id: str | None = None
     bin_config: BinConfig = BinConfig()
     placed_tools: list[PlacedTool] = []
     text_labels: list[TextLabel] = []
@@ -297,6 +316,7 @@ class BinPreviewTool(BaseModel):
 class BinSummary(BaseModel):
     id: str
     name: str | None
+    project_id: str | None = None
     created_at: str | None
     tool_count: int
     has_stl: bool
@@ -311,6 +331,7 @@ class BinListResponse(BaseModel):
 
 class BinUpdateRequest(BaseModel):
     name: str | None = None
+    project_id: str | None = None
     bin_config: BinConfig | None = None
     placed_tools: list[PlacedTool] | None = None
     text_labels: list[TextLabel] | None = None
@@ -318,4 +339,5 @@ class BinUpdateRequest(BaseModel):
 
 class CreateBinRequest(BaseModel):
     name: str | None = None
+    project_id: str | None = None
     tool_ids: list[str] = []  # pre-place these tools

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,0 +1,255 @@
+from datetime import datetime
+
+from fastapi import HTTPException
+
+from app.models.schemas import (
+    BinModel,
+    BinProject,
+    BinProjectDetail,
+    BinProjectSummary,
+    ProjectHealthIssue,
+    ProjectHealthResponse,
+)
+from app.services.bin_store import BinStore
+from app.services.project_store import ProjectStore
+from app.services.tool_store import ToolStore
+
+
+def now_iso() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def project_linked_bins(project: BinProject, user_bins: BinStore) -> list[BinModel]:
+    linked: list[BinModel] = []
+    linked_bin_ids = set(project.bin_ids)
+    for bid, bin_data in user_bins.all().items():
+        if bin_data.project_id == project.id or bid in linked_bin_ids:
+            linked.append(bin_data)
+    return linked
+
+
+def project_status(project: BinProject, linked_bins: list[BinModel]) -> dict[str, list[str]]:
+    project_tool_ids = list(dict.fromkeys(project.tool_ids))
+    project_tool_set = set(project_tool_ids)
+    placement_counts: dict[str, int] = {}
+    for bin_data in linked_bins:
+        for placed in bin_data.placed_tools:
+            if placed.tool_id in project_tool_set:
+                placement_counts[placed.tool_id] = placement_counts.get(placed.tool_id, 0) + 1
+
+    placed = [tool_id for tool_id in project_tool_ids if placement_counts.get(tool_id, 0) > 0]
+    unplaced = [tool_id for tool_id in project_tool_ids if placement_counts.get(tool_id, 0) == 0]
+    return {
+        "placed_tool_ids": placed,
+        "unplaced_tool_ids": unplaced,
+    }
+
+
+def make_project_summary(project: BinProject, user_bins: BinStore) -> BinProjectSummary:
+    linked_bins = project_linked_bins(project, user_bins)
+    status = project_status(project, linked_bins)
+    return BinProjectSummary(
+        id=project.id,
+        name=project.name,
+        description=project.description,
+        status=project.status,
+        tool_count=len(project.tool_ids),
+        bin_count=len(linked_bins),
+        placed_count=len(status["placed_tool_ids"]),
+        unplaced_count=len(status["unplaced_tool_ids"]),
+        target_grid_x=project.target_grid_x,
+        target_grid_y=project.target_grid_y,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+    )
+
+
+def make_project_detail(project: BinProject, user_bins: BinStore) -> BinProjectDetail:
+    return BinProjectDetail(
+        **project.model_dump(),
+        **project_status(project, project_linked_bins(project, user_bins)),
+    )
+
+
+def add_project_to_tools(project_id: str, tool_ids: list[str], user_tools: ToolStore):
+    for tool_id in tool_ids:
+        tool = user_tools.get(tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail=f"tool {tool_id} not found")
+        if project_id not in tool.project_ids:
+            tool.project_ids.append(project_id)
+            user_tools.set(tool_id, tool)
+
+
+def remove_project_from_tools(project_id: str, tool_ids: list[str], user_tools: ToolStore):
+    for tool_id in tool_ids:
+        tool = user_tools.get(tool_id)
+        if tool and project_id in tool.project_ids:
+            tool.project_ids = [pid for pid in tool.project_ids if pid != project_id]
+            user_tools.set(tool_id, tool)
+
+
+def add_bin_to_project(project_store: ProjectStore, project_id: str | None, bin_id: str):
+    if not project_id:
+        return
+    project = project_store.get(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail=f"project {project_id} not found")
+    if bin_id not in project.bin_ids:
+        project.bin_ids.append(bin_id)
+        project.updated_at = now_iso()
+        project_store.set(project_id, project)
+
+
+def remove_bin_from_project(project_store: ProjectStore, project_id: str | None, bin_id: str):
+    if not project_id:
+        return
+    project = project_store.get(project_id)
+    if project and bin_id in project.bin_ids:
+        project.bin_ids = [bid for bid in project.bin_ids if bid != bin_id]
+        project.updated_at = now_iso()
+        project_store.set(project_id, project)
+
+
+def remove_bin_from_all_projects(project_store: ProjectStore, bin_id: str):
+    for project_id, project in project_store.all().items():
+        if bin_id in project.bin_ids:
+            project.bin_ids = [bid for bid in project.bin_ids if bid != bin_id]
+            project.updated_at = now_iso()
+            project_store.set(project_id, project)
+
+
+def project_health(
+    project: BinProject,
+    user_tools: ToolStore,
+    user_bins: BinStore,
+) -> list[ProjectHealthIssue]:
+    issues: list[ProjectHealthIssue] = []
+    all_tools = user_tools.all()
+    all_bins = user_bins.all()
+    linked_bin_ids = set(project.bin_ids)
+    project_tool_ids = set(project.tool_ids)
+
+    for tool_id in project.tool_ids:
+        tool = all_tools.get(tool_id)
+        if not tool:
+            issues.append(ProjectHealthIssue(
+                code="missing_tool",
+                severity="error",
+                message=f"project references missing tool {tool_id}",
+                tool_id=tool_id,
+                repairable=True,
+            ))
+        elif project.id not in tool.project_ids:
+            issues.append(ProjectHealthIssue(
+                code="tool_missing_project_id",
+                severity="warning",
+                message=f"tool {tool.name} is in the project but is missing the project backlink",
+                tool_id=tool_id,
+                repairable=True,
+            ))
+
+    for tool_id, tool in all_tools.items():
+        if project.id in tool.project_ids and tool_id not in project_tool_ids:
+            issues.append(ProjectHealthIssue(
+                code="tool_extra_project_id",
+                severity="warning",
+                message=f"tool {tool.name} has a stale project backlink",
+                tool_id=tool_id,
+                repairable=True,
+            ))
+
+    for bin_id in project.bin_ids:
+        bin_data = all_bins.get(bin_id)
+        if not bin_data:
+            issues.append(ProjectHealthIssue(
+                code="missing_bin",
+                severity="error",
+                message=f"project references missing bin {bin_id}",
+                bin_id=bin_id,
+                repairable=True,
+            ))
+        elif bin_data.project_id is None:
+            issues.append(ProjectHealthIssue(
+                code="bin_missing_project_id",
+                severity="warning",
+                message=f"bin {bin_data.name or bin_id} is listed in the project but is missing the project link",
+                bin_id=bin_id,
+                repairable=True,
+            ))
+        elif bin_data.project_id != project.id:
+            issues.append(ProjectHealthIssue(
+                code="bin_project_mismatch",
+                severity="warning",
+                message=f"bin {bin_data.name or bin_id} is linked to another project",
+                bin_id=bin_id,
+                other_project_id=bin_data.project_id,
+                repairable=False,
+            ))
+
+    for bin_id, bin_data in all_bins.items():
+        if bin_data.project_id == project.id:
+            if bin_id not in linked_bin_ids:
+                issues.append(ProjectHealthIssue(
+                    code="bin_missing_project_id",
+                    severity="warning",
+                    message=f"bin {bin_data.name or bin_id} links to this project but is missing from the project bin list",
+                    bin_id=bin_id,
+                    repairable=True,
+                ))
+            for placed in bin_data.placed_tools:
+                if placed.tool_id and placed.tool_id not in project_tool_ids:
+                    issues.append(ProjectHealthIssue(
+                        code="outside_tool",
+                        severity="warning",
+                        message=f"bin {bin_data.name or bin_id} contains outside-project tool {placed.name}",
+                        bin_id=bin_id,
+                        tool_id=placed.tool_id,
+                        repairable=False,
+                    ))
+
+    return issues
+
+
+def health_response(issues: list[ProjectHealthIssue]) -> ProjectHealthResponse:
+    repairable = sum(1 for issue in issues if issue.repairable)
+    return ProjectHealthResponse(
+        issues=issues,
+        repairable_count=repairable,
+        manual_count=len(issues) - repairable,
+    )
+
+
+def repair_project_links(
+    project_store: ProjectStore,
+    project: BinProject,
+    user_tools: ToolStore,
+    user_bins: BinStore,
+) -> BinProject:
+    all_tools = user_tools.all()
+    all_bins = user_bins.all()
+
+    project.tool_ids = [tid for tid in dict.fromkeys(project.tool_ids) if tid in all_tools]
+    project.bin_ids = [bid for bid in dict.fromkeys(project.bin_ids) if bid in all_bins]
+
+    project_tool_ids = set(project.tool_ids)
+    for tool_id, tool in all_tools.items():
+        if tool_id in project_tool_ids and project.id not in tool.project_ids:
+            tool.project_ids.append(project.id)
+            user_tools.set(tool_id, tool)
+        elif tool_id not in project_tool_ids and project.id in tool.project_ids:
+            tool.project_ids = [pid for pid in tool.project_ids if pid != project.id]
+            user_tools.set(tool_id, tool)
+
+    linked_bin_ids = set(project.bin_ids)
+    for bin_id, bin_data in all_bins.items():
+        if bin_data.project_id == project.id and bin_id not in linked_bin_ids:
+            project.bin_ids.append(bin_id)
+            linked_bin_ids.add(bin_id)
+        elif bin_id in linked_bin_ids and bin_data.project_id is None:
+            bin_data.project_id = project.id
+            user_bins.set(bin_id, bin_data)
+
+    project.updated_at = now_iso()
+    project_store.set(project.id, project)
+    return project

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+from app.models.schemas import BinProject
+
+
+class ProjectStore:
+    def __init__(self, storage_path: Path):
+        self.file_path = storage_path / "bin-projects.json"
+        self._projects: dict[str, BinProject] = {}
+        self._lock = threading.Lock()
+        self._load()
+
+    def _load(self):
+        if self.file_path.exists():
+            try:
+                data = json.loads(self.file_path.read_text())
+                for pid, pdata in data.items():
+                    self._projects[pid] = BinProject.model_validate(pdata)
+            except Exception:
+                self._projects = {}
+
+    def _save(self):
+        data = {pid: p.model_dump() for pid, p in self._projects.items()}
+        temp_fd, temp_path = tempfile.mkstemp(
+            dir=self.file_path.parent,
+            prefix=".bin-projects_",
+            suffix=".tmp",
+        )
+        try:
+            with open(temp_fd, "w") as f:
+                json.dump(data, f, indent=2)
+            Path(temp_path).replace(self.file_path)
+        except Exception:
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+    def get(self, project_id: str) -> Optional[BinProject]:
+        with self._lock:
+            return self._projects.get(project_id)
+
+    def set(self, project_id: str, project: BinProject):
+        with self._lock:
+            self._projects[project_id] = project
+            self._save()
+
+    def delete(self, project_id: str) -> Optional[BinProject]:
+        with self._lock:
+            project = self._projects.pop(project_id, None)
+            if project:
+                self._save()
+            return project
+
+    def all(self) -> dict[str, BinProject]:
+        with self._lock:
+            return self._projects.copy()

--- a/backend/tests/test_bin_projects.py
+++ b/backend/tests/test_bin_projects.py
@@ -1,0 +1,249 @@
+from fastapi.testclient import TestClient
+
+from app.config import ensure_user_dirs, settings
+from app.main import app
+from app.models.schemas import (
+    BinConfig,
+    BinModel,
+    BinProject,
+    BinProjectBinsRequest,
+    BinProjectCreateBinRequest,
+    BinProjectCreateRequest,
+    BinProjectToolsRequest,
+    BinProjectUpdateRequest,
+    Tool,
+    PlacedTool,
+)
+from app.services.project_service import project_health, project_status, repair_project_links
+from app.services.bin_store import BinStore
+from app.services.project_store import ProjectStore
+from app.services.tool_store import ToolStore
+import app.api.routes as routes
+
+
+def test_old_project_records_get_defaults():
+    project = BinProject.model_validate({
+        "id": "project-1",
+        "name": "Top drawer",
+    })
+
+    assert project.description is None
+    assert project.tool_ids == []
+    assert project.bin_ids == []
+    assert project.status == "active"
+    assert project.target_grid_x is None
+    assert project.target_grid_y is None
+    assert project.default_bin_config is None
+    assert project.notes is None
+
+
+def test_project_metadata_round_trips():
+    project = BinProject.model_validate({
+        "id": "project-1",
+        "name": "Top drawer",
+        "description": "Metric tools",
+        "status": "ready_to_print",
+        "tool_ids": ["tool-1", "tool-2"],
+        "bin_ids": ["bin-1"],
+        "target_grid_x": 4,
+        "target_grid_y": 5,
+        "default_bin_config": {"grid_x": 3, "grid_y": 2},
+        "notes": "print first bin as test",
+        "created_at": "2026-05-10T00:00:00",
+        "updated_at": "2026-05-10T00:00:01",
+    })
+    data = project.model_dump()
+
+    assert data["tool_ids"] == ["tool-1", "tool-2"]
+    assert data["bin_ids"] == ["bin-1"]
+    assert data["status"] == "ready_to_print"
+    assert data["target_grid_x"] == 4
+    assert data["default_bin_config"]["grid_x"] == 3
+    assert data["notes"] == "print first bin as test"
+
+
+def test_project_requests_support_clearable_fields():
+    create_req = BinProjectCreateRequest(
+        name="Top drawer",
+        tool_ids=["tool-1"],
+        default_bin_config=BinConfig(grid_x=4, grid_y=3),
+    )
+    update_req = BinProjectUpdateRequest(description=None, notes=None, target_grid_x=None)
+    tools_req = BinProjectToolsRequest(tool_ids=["tool-1", "tool-2"])
+    bins_req = BinProjectBinsRequest(bin_ids=["bin-1"], import_tools=True)
+    bin_req = BinProjectCreateBinRequest(name="Top drawer bin", tool_ids=["tool-1"])
+
+    assert create_req.tool_ids == ["tool-1"]
+    assert create_req.default_bin_config.grid_x == 4
+    assert "description" in update_req.model_fields_set
+    assert "notes" in update_req.model_fields_set
+    assert "target_grid_x" in update_req.model_fields_set
+    assert tools_req.tool_ids == ["tool-1", "tool-2"]
+    assert bins_req.import_tools is True
+    assert bin_req.tool_ids == ["tool-1"]
+
+
+def test_project_store_round_trips(tmp_path):
+    store = ProjectStore(tmp_path)
+    project = BinProject(id="project-1", name="Top drawer", tool_ids=["tool-1"])
+
+    store.set(project.id, project)
+    reloaded = ProjectStore(tmp_path)
+
+    assert reloaded.get("project-1").name == "Top drawer"
+    assert reloaded.get("project-1").tool_ids == ["tool-1"]
+
+
+def test_project_store_delete_keeps_other_projects(tmp_path):
+    store = ProjectStore(tmp_path)
+    store.set("project-1", BinProject(id="project-1", name="Top drawer"))
+    store.set("project-2", BinProject(id="project-2", name="Bottom drawer"))
+
+    deleted = store.delete("project-1")
+
+    assert deleted.name == "Top drawer"
+    assert store.get("project-1") is None
+    assert store.get("project-2").name == "Bottom drawer"
+
+
+def test_project_status_tracks_placed_and_unplaced():
+    project = BinProject(id="project-1", name="Top drawer", tool_ids=["tool-1", "tool-2", "tool-3"])
+    linked_bins = [
+        BinModel(
+            id="bin-1",
+            placed_tools=[
+                PlacedTool(id="pt-1", tool_id="tool-1", name="Tool 1", points=[]),
+                PlacedTool(id="pt-2", tool_id="tool-2", name="Tool 2", points=[]),
+            ],
+        ),
+        BinModel(
+            id="bin-2",
+            placed_tools=[
+                PlacedTool(id="pt-3", tool_id="tool-2", name="Tool 2 duplicate", points=[]),
+                PlacedTool(id="pt-4", tool_id="other-tool", name="Other", points=[]),
+            ],
+        ),
+    ]
+
+    status = project_status(project, linked_bins)
+
+    assert status["placed_tool_ids"] == ["tool-1", "tool-2"]
+    assert status["unplaced_tool_ids"] == ["tool-3"]
+
+
+def _tool(tool_id: str, project_ids: list[str] | None = None) -> Tool:
+    return Tool(
+        id=tool_id,
+        name=tool_id,
+        points=[
+            {"x": 0, "y": 0},
+            {"x": 10, "y": 0},
+            {"x": 10, "y": 10},
+        ],
+        project_ids=project_ids or [],
+    )
+
+
+def _api_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def _seed_tool(tool_id: str):
+    _, tool_store, _ = routes.get_stores("default")
+    tool_store.set(tool_id, _tool(tool_id))
+
+
+def test_project_create_bin_derives_placed_status_without_persisting_state(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    _seed_tool("tool-1")
+
+    project_resp = client.post("/api/bin-projects", json={"name": "Top drawer", "tool_ids": ["tool-1"]})
+    assert project_resp.status_code == 200
+    project_id = project_resp.json()["id"]
+
+    bin_resp = client.post(f"/api/bin-projects/{project_id}/create-bin", json={"tool_ids": ["tool-1"]})
+    assert bin_resp.status_code == 200
+
+    detail = client.get(f"/api/bin-projects/{project_id}").json()
+
+    assert detail["placed_tool_ids"] == ["tool-1"]
+    assert detail["unplaced_tool_ids"] == []
+
+
+def test_project_placed_status_updates_when_bin_contents_change(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    _seed_tool("tool-1")
+
+    project = client.post("/api/bin-projects", json={"name": "Top drawer", "tool_ids": ["tool-1"]}).json()
+    bin_data = client.post("/api/bins", json={"name": "Working bin", "project_id": project["id"], "tool_ids": ["tool-1"]}).json()
+
+    assert client.get(f"/api/bin-projects/{project['id']}").json()["placed_tool_ids"] == ["tool-1"]
+
+    update_resp = client.put(f"/api/bins/{bin_data['id']}", json={"placed_tools": []})
+    assert update_resp.status_code == 200
+    detail = client.get(f"/api/bin-projects/{project['id']}").json()
+
+    assert detail["placed_tool_ids"] == []
+    assert detail["unplaced_tool_ids"] == ["tool-1"]
+
+
+def test_project_health_reports_and_repairs_safe_link_mismatches(tmp_path):
+    project_store = ProjectStore(tmp_path)
+    tool_store = ToolStore(tmp_path)
+    bin_store = BinStore(tmp_path)
+
+    tool_store.set("tool-1", _tool("tool-1"))
+    tool_store.set("tool-extra", _tool("tool-extra", ["project-1"]))
+    bin_store.set("bin-1", BinModel(id="bin-1", project_id=None))
+    bin_store.set("bin-2", BinModel(id="bin-2", project_id="project-1"))
+    project = BinProject(
+        id="project-1",
+        name="Top drawer",
+        tool_ids=["tool-1", "missing-tool"],
+        bin_ids=["bin-1", "missing-bin"],
+    )
+    project_store.set(project.id, project)
+
+    issues = project_health(project, tool_store, bin_store)
+
+    assert {issue.code for issue in issues} >= {
+        "missing_tool",
+        "missing_bin",
+        "tool_missing_project_id",
+        "tool_extra_project_id",
+        "bin_missing_project_id",
+    }
+
+    repaired = repair_project_links(project_store, project, tool_store, bin_store)
+
+    assert repaired.tool_ids == ["tool-1"]
+    assert "missing-bin" not in repaired.bin_ids
+    assert "bin-2" in repaired.bin_ids
+    assert tool_store.get("tool-1").project_ids == ["project-1"]
+    assert tool_store.get("tool-extra").project_ids == []
+    assert bin_store.get("bin-1").project_id == "project-1"
+
+
+def test_project_health_reports_outside_bin_tools():
+    project = BinProject(id="project-1", name="Top drawer", tool_ids=["tool-1"], bin_ids=["bin-1"])
+    class ToolStoreStub:
+        def all(self):
+            return {"tool-1": _tool("tool-1", ["project-1"]), "tool-2": _tool("tool-2")}
+    class BinStoreStub:
+        def all(self):
+            return {
+                "bin-1": BinModel(
+                    id="bin-1",
+                    project_id="project-1",
+                    placed_tools=[PlacedTool(id="pt-1", tool_id="tool-2", name="Tool 2", points=[])],
+                )
+            }
+
+    issues = project_health(project, ToolStoreStub(), BinStoreStub())
+
+    assert any(issue.code == "outside_tool" and not issue.repairable for issue in issues)

--- a/backend/tests/test_workflow_metadata.py
+++ b/backend/tests/test_workflow_metadata.py
@@ -1,0 +1,115 @@
+"""Compatibility tests for workflow planning metadata fields."""
+
+from app.models.schemas import BinModel, BinUpdateRequest, CreateBinRequest, Tool, ToolUpdateRequest
+
+
+def test_old_tool_records_get_metadata_defaults():
+    tool = Tool.model_validate({
+        "id": "tool-1",
+        "name": "pliers",
+        "points": [
+            {"x": 0, "y": 0},
+            {"x": 10, "y": 0},
+            {"x": 10, "y": 10},
+            {"x": 0, "y": 10},
+        ],
+        "finger_holes": [],
+        "interior_rings": [],
+    })
+
+    assert tool.category is None
+    assert tool.drawer is None
+    assert tool.tags == []
+    assert tool.project_ids == []
+    assert tool.review_status is None
+    assert tool.needs_cleanup is False
+
+
+def test_tool_metadata_round_trips():
+    tool = Tool.model_validate({
+        "id": "tool-1",
+        "name": "pliers",
+        "points": [
+            {"x": 0, "y": 0},
+            {"x": 10, "y": 0},
+            {"x": 10, "y": 10},
+            {"x": 0, "y": 10},
+        ],
+        "category": "hand tools",
+        "drawer": "drawer 1",
+        "tags": ["cutting", "metal"],
+        "project_ids": ["project-1"],
+        "review_status": "reviewed",
+        "needs_cleanup": True,
+    })
+
+    data = tool.model_dump()
+
+    assert data["category"] == "hand tools"
+    assert data["drawer"] == "drawer 1"
+    assert data["tags"] == ["cutting", "metal"]
+    assert data["project_ids"] == ["project-1"]
+    assert data["review_status"] == "reviewed"
+    assert data["needs_cleanup"] is True
+
+
+def test_old_bin_records_get_project_default():
+    bin_data = BinModel.model_validate({
+        "id": "bin-1",
+        "name": "drawer 1 bin",
+        "placed_tools": [],
+        "text_labels": [],
+    })
+
+    assert bin_data.project_id is None
+
+
+def test_bin_project_id_round_trips():
+    bin_data = BinModel.model_validate({
+        "id": "bin-1",
+        "name": "drawer 1 bin",
+        "project_id": "project-1",
+        "placed_tools": [],
+        "text_labels": [],
+    })
+
+    assert bin_data.model_dump()["project_id"] == "project-1"
+
+
+def test_create_bin_request_accepts_project_id():
+    req = CreateBinRequest(name="drawer bin", project_id="project-1", tool_ids=["tool-1"])
+
+    assert req.project_id == "project-1"
+    assert req.tool_ids == ["tool-1"]
+
+
+def test_bin_update_request_can_clear_project_id():
+    req = BinUpdateRequest(project_id=None)
+
+    assert "project_id" in req.model_fields_set
+    assert req.project_id is None
+
+
+def test_bin_update_request_distinguishes_absent_project_id():
+    req = BinUpdateRequest()
+
+    assert "project_id" not in req.model_fields_set
+
+
+def test_tool_update_request_can_clear_nullable_metadata():
+    req = ToolUpdateRequest(category=None, drawer=None, review_status=None)
+
+    assert "category" in req.model_fields_set
+    assert "drawer" in req.model_fields_set
+    assert "review_status" in req.model_fields_set
+    assert req.category is None
+    assert req.drawer is None
+    assert req.review_status is None
+
+
+def test_tool_update_request_distinguishes_absent_metadata():
+    req = ToolUpdateRequest()
+
+    assert "category" not in req.model_fields_set
+    assert "drawer" not in req.model_fields_set
+    assert "review_status" not in req.model_fields_set

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,20 @@
 - `DELETE /api/bins/{id}` - delete bin + output files
 - `POST /api/bins/{id}/generate` - generate STL/3MF from bin
 
+## Bin projects
+- `GET /api/bin-projects` - list project summaries with tool/bin/placement counts
+- `POST /api/bin-projects` - create a project, optionally seeded with tool ids
+- `GET /api/bin-projects/{id}` - get project detail with derived placed/unplaced tool ids
+- `PATCH /api/bin-projects/{id}` - update project metadata and status
+- `DELETE /api/bin-projects/{id}` - delete project metadata; tools and bins are retained
+- `POST /api/bin-projects/{id}/tools` - add tools to a project
+- `DELETE /api/bin-projects/{id}/tools/{tool_id}` - remove a tool from a project
+- `POST /api/bin-projects/{id}/bins` - link existing bins to a project
+- `DELETE /api/bin-projects/{id}/bins/{bin_id}` - detach a bin from a project
+- `POST /api/bin-projects/{id}/create-bin` - create a new bin from selected project tools
+- `GET /api/bin-projects/{id}/health` - report project/tool/bin link mismatches
+- `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
+
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL
 - `GET /api/files/{session_id}/bin.3mf` - session 3MF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,15 +6,16 @@
 - Tool tracing via local models (BiRefNet Lite, IS-Net, InSPyReNet) or Gemini API
 - Manual mask upload as alternative
 - Session persistence (JSON files)
-- Tool library + bin persistence (JSON files)
+- Tool library, bin, and bin project persistence (JSON files)
 - STL/3MF generation with manifold3d
 
 ## Frontend (Next.js 16/React/TypeScript)
-- Dashboard with tool library + bin management
+- Dashboard with project, tool library, and bin management
 - Paper corner editor with draggable handles
 - Polygon editor with vertex editing, undo/redo
 - Tool editor for editing saved tools (vertices, finger holes)
 - Bin editor for positioning tools in bins, adding text labels
+- Project screen for planning a group of tools/bins and tracking placed vs unplaced tools
 - 3D STL preview (react-three-fiber)
 - Shows user what prompts are sent to Gemini
 
@@ -37,14 +38,17 @@ tracefinity/
 │   │       ├── image_service.py           # tool thumbnail generation
 │   │       ├── session_store.py
 │   │       ├── tool_store.py              # tool library persistence
-│   │       └── bin_store.py               # bin persistence
+│   │       ├── bin_store.py               # bin persistence
+│   │       ├── project_store.py           # bin project persistence
+│   │       └── project_service.py         # project summaries, health, repair
 │   └── requirements.txt
 ├── frontend/
 │   ├── src/
 │   │   ├── app/
-│   │   │   ├── page.tsx               # dashboard (tools + bins)
+│   │   │   ├── page.tsx               # dashboard (projects + tools + bins)
 │   │   │   ├── trace/[id]/            # corner + polygon editing
 │   │   │   ├── tools/[id]/            # tool vertex/hole editor
+│   │   │   ├── projects/[id]/         # project planning workflow
 │   │   │   └── bins/[id]/             # bin builder + 3D preview
 │   │   ├── components/
 │   │   │   ├── BinEditor.tsx          # bin layout orchestrator
@@ -80,9 +84,12 @@ tracefinity/
 - **Tool**: a single traced polygon + finger holes, stored in mm, centred at origin. Lives in a persistent library (`tools.json`).
 - **PlacedTool**: a positioned copy of a tool in a bin. Points/holes in bin-space mm. Has `tool_id` linking back to source.
 - **Bin**: bin config + placed tools + text labels. Used for STL generation (`bins.json`).
+- **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`).
 - **Session**: ephemeral, used only for upload/trace workflow. Output is tools saved to library via `save-tools`.
 
 PlacedTools sync with their library source on bin load (`GET /bins/{id}`) via `bin_service.sync_placed_tools()`. Edits to a tool's points, finger holes, or name propagate to all bins that use it. The position offset is preserved.
+
+Projects do not own tools or bins. Tools keep `project_ids`, bins keep `project_id`, and project health/repair endpoints keep those links consistent when records are renamed, deleted, or manually edited.
 
 ## Backend route helpers
 

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Download, Loader2, Package, ChevronDown, Check } from 'lucide-react'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { Alert } from '@/components/Alert'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
+import { useProjectSource } from '@/hooks/useProjectSource'
 import { GRID_UNIT } from '@/lib/constants'
 
 function InfoBanner({ children }: { children: React.ReactNode }) {
@@ -48,6 +49,7 @@ export default function BinPage() {
   const router = useRouter()
   const params = useParams()
   const binId = params.id as string
+  const projectSource = useProjectSource('Bins')
 
   const [binData, setBinData] = useState<BinData | null>(null)
   const [placedTools, setPlacedTools] = useState<PlacedTool[]>([])
@@ -362,7 +364,7 @@ export default function BinPage() {
           <div className="glass rounded-[10px] px-3 py-3">
             <div className="flex items-center gap-2 mb-3">
               <Breadcrumb segments={[
-                { label: 'Bins', href: '/' },
+                { label: projectSource.rootLabel, href: projectSource.rootHref },
                 { label: name || 'Untitled', editable: true, onEdit: (v) => setName(v) },
               ]} />
               {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
@@ -454,6 +456,8 @@ export default function BinPage() {
             binWidthMm={binW}
             binHeightMm={binH}
             layout="horizontal"
+            projectId={projectSource.projectId}
+            currentToolIds={placedTools.map(tool => tool.tool_id)}
           />
         </div>
 
@@ -472,7 +476,7 @@ export default function BinPage() {
                 wallThickness={config.wall_thickness}
                 defaultCutoutDepth={config.cutout_depth}
                 maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
-                onEditTool={(toolId) => router.push(`/tools/${toolId}`)}
+                onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
                 smoothedToolIds={smoothedToolIds}
                 onToggleSmoothed={handleToggleSmoothed}
                 smoothLevels={smoothLevels}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,6 +24,10 @@
   --color-glass-hover: rgba(255, 255, 255, 0.055);
   --color-toolbar-solid-bg: #15181f;
   --color-toolbar-solid-border: rgba(255, 255, 255, 0.12);
+  --color-tool-fill: #475569;
+  --color-tool-stroke: #8b95a5;
+  --color-bin-preview-fill: #1e293b;
+  --color-bin-preview-grid: rgba(255, 255, 255, 0.08);
   color-scheme: dark;
 }
 
@@ -45,6 +49,10 @@
   --color-glass-hover: rgba(255, 255, 255, 0.8);
   --color-toolbar-solid-bg: #ffffff;
   --color-toolbar-solid-border: rgba(0, 0, 0, 0.08);
+  --color-tool-fill: #64748b;
+  --color-tool-stroke: #334155;
+  --color-bin-preview-fill: #e2e8f0;
+  --color-bin-preview-grid: rgba(15, 23, 42, 0.12);
   color-scheme: light;
 }
 
@@ -72,7 +80,7 @@ body {
 /* buttons */
 @layer components {
   .btn-primary {
-    @apply relative overflow-hidden font-medium rounded-[10px] transition-all duration-150 disabled:opacity-50 cursor-pointer;
+    @apply relative overflow-hidden font-medium rounded-[7px] transition-all duration-150 disabled:opacity-50 cursor-pointer;
     background: var(--color-accent);
     color: white;
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -83,7 +91,7 @@ body {
   .btn-primary:hover:not(:disabled) { background: var(--color-accent-hover); }
 
   .btn-secondary {
-    @apply relative overflow-hidden font-medium rounded-[10px] transition-all duration-150 cursor-pointer;
+    @apply relative overflow-hidden font-medium rounded-[7px] transition-all duration-150 cursor-pointer;
     background: var(--color-glass-bg);
     color: var(--color-text-secondary);
     border: 1px solid var(--color-glass-border);
@@ -93,7 +101,7 @@ body {
   .btn-secondary:hover { background: var(--color-glass-hover); color: var(--color-text-primary); }
 
   .btn-icon {
-    @apply flex items-center justify-center rounded-lg transition-all duration-150 cursor-pointer;
+    @apply flex items-center justify-center rounded-[7px] transition-all duration-150 cursor-pointer;
     width: 32px;
     height: 32px;
     background: transparent;
@@ -101,6 +109,14 @@ body {
   }
   .btn-icon:hover { background: var(--color-glass-hover); color: var(--color-text-primary); }
   .btn-icon.active { background: var(--color-accent-muted); color: var(--color-accent); }
+
+  .btn-danger-icon {
+    @apply p-1 rounded-[7px] text-text-muted transition-colors cursor-pointer;
+  }
+  .btn-danger-icon:hover {
+    color: #f87171;
+    background: rgba(127, 29, 29, 0.2);
+  }
 }
 
 /* glass panels */
@@ -122,7 +138,7 @@ body {
     border: 1px solid var(--color-glass-border);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-radius: 10px;
+    border-radius: 8px;
   }
   .editor-photo-active .glass-toolbar {
     background: var(--color-toolbar-solid-bg);
@@ -135,7 +151,7 @@ body {
     border: 1px solid var(--color-glass-border);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    border-radius: 10px;
+    border-radius: 8px;
     transition: all 150ms ease;
   }
   .glass-card:hover {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,13 +4,16 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { ImageUploader } from '@/components/ImageUploader'
 import { ConfirmModal } from '@/components/ConfirmModal'
-import { uploadImage, listTools, listBins, deleteTool, deleteBin, createBin, getImageUrl } from '@/lib/api'
-import type { ToolSummary, BinSummary, BinPreviewTool, Point, ToolImageContext, AffineMatrix } from '@/types'
+import { SectionHeader } from '@/components/SectionHeader'
+import { uploadImage, listTools, listBins, listProjects, deleteTool, deleteBin, deleteProject, createBin, createProject, getImageUrl } from '@/lib/api'
+import type { ToolSummary, BinSummary, BinPreviewTool, BinProjectSummary, Point, ToolImageContext, AffineMatrix, ProjectStatus } from '@/types'
 import { polygonPathData } from '@/lib/svg'
-import { Trash2, Package, Plus, Loader2, Grid3X3, Search, ArrowUpDown } from 'lucide-react'
+import { Trash2, Package, Plus, Loader2, Grid3X3, Folder } from 'lucide-react'
 import { Alert } from '@/components/Alert'
 import { PhotoIllustration, CornersIllustration, TraceIllustration, OrganiseIllustration } from '@/components/OnboardingIllustrations'
 import { GRID_UNIT } from '@/lib/constants'
+import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
+import { projectNameMap, projectStatusLabels, toolProjectLabel, toolProjectTitle } from '@/lib/projectSelectors'
 
 function thumbnailRotationStyle(transform: AffineMatrix | null): React.CSSProperties | undefined {
   if (!transform) return undefined
@@ -49,8 +52,8 @@ function ToolOutline({ points, interiorRings }: { points: Point[]; interiorRings
       <path
         d={pathData}
         fillRule="evenodd"
-        fill="#475569"
-        stroke="#8b95a5"
+        fill="var(--color-tool-fill)"
+        stroke="var(--color-tool-stroke)"
         strokeWidth={Math.max(vw, vh) * 0.015}
       />
     </svg>
@@ -112,33 +115,36 @@ function BinPreview({ gridX, gridY, tools }: { gridX: number; gridY: number; too
       className="w-full h-full"
       preserveAspectRatio="xMidYMid meet"
     >
-      <rect x={0} y={0} width={binW} height={binH} fill="rgb(30, 41, 59)" rx={2} />
+      <rect x={0} y={0} width={binW} height={binH} fill="var(--color-bin-preview-fill)" rx={2} />
       {Array.from({ length: gridX + 1 }).map((_, i) => (
         <line
           key={`v${i}`}
           x1={i * GRID_UNIT} y1={0} x2={i * GRID_UNIT} y2={binH}
-          stroke="rgba(255,255,255,0.08)" strokeWidth={0.5}
+          stroke="var(--color-bin-preview-grid)" strokeWidth={0.5}
         />
       ))}
       {Array.from({ length: gridY + 1 }).map((_, i) => (
         <line
           key={`h${i}`}
           x1={0} y1={i * GRID_UNIT} x2={binW} y2={i * GRID_UNIT}
-          stroke="rgba(255,255,255,0.08)" strokeWidth={0.5}
+          stroke="var(--color-bin-preview-grid)" strokeWidth={0.5}
         />
       ))}
       {tools.map((tool, ti) => {
         const d = polygonPathData(tool.points, tool.interior_rings)
         return (
-          <path key={ti} d={d} fillRule="evenodd" fill="#475569" stroke="#8b95a5" strokeWidth={0.8} />
+          <path key={ti} d={d} fillRule="evenodd" fill="var(--color-tool-fill)" stroke="var(--color-tool-stroke)" strokeWidth={0.8} />
         )
       })}
     </svg>
   )
 }
 
-function NameModal({ open, onConfirm, onCancel }: {
+function NameModal({ open, title = 'New bin', description = 'Give your bin a name.', placeholder = 'e.g. Screwdrivers tray', onConfirm, onCancel }: {
   open: boolean
+  title?: string
+  description?: string
+  placeholder?: string
   onConfirm: (name: string) => void
   onCancel: () => void
 }) {
@@ -165,17 +171,17 @@ function NameModal({ open, onConfirm, onCancel }: {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onCancel} />
-      <div className="relative glass rounded-[10px] shadow-xl max-w-sm w-full mx-4 p-6">
-        <h3 className="text-sm font-semibold text-text-primary">New bin</h3>
-        <p className="mt-1.5 text-xs text-text-secondary">Give your bin a name.</p>
+      <div className="relative glass rounded-[8px] shadow-xl max-w-sm w-full mx-4 p-6">
+        <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+        <p className="mt-1.5 text-xs text-text-secondary">{description}</p>
         <input
           ref={inputRef}
           type="text"
           value={value}
           onChange={e => setValue(e.target.value)}
           onKeyDown={e => { if (e.key === 'Enter') onConfirm(value.trim() || 'Untitled') }}
-          placeholder="e.g. Screwdrivers tray"
-          className="mt-3 w-full px-3 py-2 text-xs bg-elevated border border-border-subtle rounded-lg text-text-primary outline-none focus:border-accent"
+          placeholder={placeholder}
+          className="mt-3 w-full px-3 py-2 text-xs bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
         />
         <div className="mt-4 flex justify-end gap-2">
           <button
@@ -196,69 +202,26 @@ function NameModal({ open, onConfirm, onCancel }: {
   )
 }
 
-function SectionHeader({ title, count, search, onSearchChange, sortKey, onSortChange, children }: {
-  title: string
-  count?: number
-  search?: string
-  onSearchChange?: (v: string) => void
-  sortKey?: string
-  onSortChange?: (v: string) => void
-  children?: React.ReactNode
-}) {
-  const [searchOpen, setSearchOpen] = useState(false)
-  const searchRef = useRef<HTMLInputElement>(null)
+const SECTION_COLLAPSE_KEY = 'tracefinity.home.collapsedSections'
+type MainSectionId = 'projects' | 'tools' | 'bins' | 'howItWorks'
+type MainSectionCollapseState = Record<MainSectionId, boolean>
 
-  useEffect(() => {
-    if (searchOpen) searchRef.current?.focus()
-  }, [searchOpen])
+const defaultSectionCollapse: MainSectionCollapseState = {
+  projects: false,
+  tools: false,
+  bins: false,
+  howItWorks: false,
+}
 
-  return (
-    <div className="flex items-center justify-between mb-3 gap-2">
-      <div className="flex items-center gap-2 flex-shrink-0">
-        <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">{title}</h3>
-        {count !== undefined && count > 0 && (
-          <span className="text-[10px] text-text-muted bg-elevated px-1.5 py-px rounded-full">{count}</span>
-        )}
-      </div>
-      <div className="flex items-center gap-1.5">
-        {onSearchChange && (
-          searchOpen ? (
-            <div className="relative">
-              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted" />
-              <input
-                ref={searchRef}
-                type="text"
-                value={search || ''}
-                onChange={e => onSearchChange(e.target.value)}
-                onBlur={() => { if (!search) setSearchOpen(false) }}
-                onKeyDown={e => { if (e.key === 'Escape') { onSearchChange(''); setSearchOpen(false) } }}
-                placeholder="Filter..."
-                className="w-36 pl-6 pr-2 py-1 text-[11px] bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
-              />
-            </div>
-          ) : (
-            <button
-              onClick={() => setSearchOpen(true)}
-              className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
-            >
-              <Search className="w-3 h-3" />
-              Search
-            </button>
-          )
-        )}
-        {onSortChange && (
-          <button
-            onClick={() => onSortChange(sortKey === 'name' ? 'date' : 'name')}
-            className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
-          >
-            <ArrowUpDown className="w-3 h-3" />
-            {sortKey === 'name' ? 'A-Z' : 'Recent'}
-          </button>
-        )}
-        {children}
-      </div>
-    </div>
-  )
+function loadSectionCollapseState(): MainSectionCollapseState {
+  if (typeof window === 'undefined') return defaultSectionCollapse
+  try {
+    const raw = window.localStorage.getItem(SECTION_COLLAPSE_KEY)
+    if (!raw) return defaultSectionCollapse
+    return { ...defaultSectionCollapse, ...JSON.parse(raw) }
+  } catch {
+    return defaultSectionCollapse
+  }
 }
 
 export default function HomePage() {
@@ -267,14 +230,58 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null)
   const [toolsList, setToolsList] = useState<ToolSummary[]>([])
   const [binsList, setBinsList] = useState<BinSummary[]>([])
+  const [projectsList, setProjectsList] = useState<BinProjectSummary[]>([])
   const [loading, setLoading] = useState(true)
-  const [deleteModal, setDeleteModal] = useState<{ type: 'tool' | 'bin'; id: string } | null>(null)
+  const { deleteTarget: deleteModal, requestDelete, clearDelete } = useDeleteConfirmation<{ type: 'tool' | 'bin' | 'project'; id: string }>()
   const [creatingBin, setCreatingBin] = useState<string | null>(null)
   const [nameModal, setNameModal] = useState<{ toolIds?: string[] } | null>(null)
+  const [projectModalOpen, setProjectModalOpen] = useState(false)
+  const [projectSearch, setProjectSearch] = useState('')
+  const [projectStatusFilter, setProjectStatusFilter] = useState<ProjectStatus | 'all'>('all')
   const [toolSearch, setToolSearch] = useState('')
   const [toolSort, setToolSort] = useState('date')
+  const [collapsedSections, setCollapsedSections] = useState<MainSectionCollapseState>(loadSectionCollapseState)
 
-  const hasData = toolsList.length > 0 || binsList.length > 0
+  const hasData = toolsList.length > 0 || binsList.length > 0 || projectsList.length > 0
+
+  const projectNameById = useMemo(() => projectNameMap(projectsList), [projectsList])
+
+  const projectStatusFilterOptions = useMemo(() => {
+    const counts = new Map<ProjectStatus, number>()
+    for (const project of projectsList) {
+      counts.set(project.status, (counts.get(project.status) || 0) + 1)
+    }
+    const statuses: ProjectStatus[] = ['active', 'ready_to_print', 'printed', 'archived']
+    return [
+      { value: 'all' as const, label: 'All', count: projectsList.length },
+      ...statuses.map(status => ({
+        value: status,
+        label: projectStatusLabels[status],
+        count: counts.get(status) || 0,
+      })),
+    ]
+  }, [projectsList])
+
+  const filteredProjects = useMemo(() => {
+    let list = projectsList
+    if (projectStatusFilter !== 'all') {
+      list = list.filter(project => project.status === projectStatusFilter)
+    }
+    if (projectSearch.trim()) {
+      const q = projectSearch.toLowerCase()
+      list = list.filter(project => project.name.toLowerCase().includes(q))
+    }
+    return list
+  }, [projectsList, projectSearch, projectStatusFilter])
+
+  const projectBinToolIds = useMemo(() => {
+    const placed = new Set<string>()
+    for (const bin of binsList) {
+      if (!bin.project_id) continue
+      for (const toolId of bin.tool_ids || []) placed.add(toolId)
+    }
+    return placed
+  }, [binsList])
 
   const filteredTools = useMemo(() => {
     let list = toolsList
@@ -288,15 +295,24 @@ export default function HomePage() {
     return list
   }, [toolsList, toolSearch, toolSort])
 
+  function setSectionCollapsed(section: MainSectionId, collapsed: boolean) {
+    setCollapsedSections(prev => {
+      const next = { ...prev, [section]: collapsed }
+      window.localStorage.setItem(SECTION_COLLAPSE_KEY, JSON.stringify(next))
+      return next
+    })
+  }
+
   useEffect(() => {
     loadData()
   }, [])
 
   async function loadData() {
     try {
-      const [t, b] = await Promise.all([listTools(), listBins()])
+      const [t, b, p] = await Promise.all([listTools(), listBins(), listProjects()])
       setToolsList(t)
       setBinsList(b)
+      setProjectsList(p)
     } catch {
       // ignore
     } finally {
@@ -322,7 +338,7 @@ export default function HomePage() {
       await deleteTool(id)
       setToolsList(prev => prev.filter(t => t.id !== id))
     } catch { /* ignore */ }
-    setDeleteModal(null)
+    clearDelete()
   }
 
   async function handleDeleteBin(id: string) {
@@ -330,7 +346,20 @@ export default function HomePage() {
       await deleteBin(id)
       setBinsList(prev => prev.filter(b => b.id !== id))
     } catch { /* ignore */ }
-    setDeleteModal(null)
+    clearDelete()
+  }
+
+  async function handleDeleteProject(id: string) {
+    try {
+      await deleteProject(id)
+      setProjectsList(prev => prev.filter(p => p.id !== id))
+      setToolsList(prev => prev.map(t => ({
+        ...t,
+        project_ids: t.project_ids.filter(pid => pid !== id),
+      })))
+      setBinsList(prev => prev.map(b => b.project_id === id ? { ...b, project_id: null } : b))
+    } catch { /* ignore */ }
+    clearDelete()
   }
 
   async function handleCreateBin(name: string, toolIds?: string[]) {
@@ -344,6 +373,16 @@ export default function HomePage() {
       setError(err instanceof Error ? err.message : 'failed to create bin')
     } finally {
       setCreatingBin(null)
+    }
+  }
+
+  async function handleCreateProject(name: string) {
+    setProjectModalOpen(false)
+    try {
+      const project = await createProject({ name })
+      router.push(`/projects/${project.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to create project')
     }
   }
 
@@ -376,6 +415,118 @@ export default function HomePage() {
         </div>
       )}
 
+      {/* projects */}
+      {(projectsList.length > 0 || toolsList.length > 0) && (
+        <div>
+          <SectionHeader
+            title="Projects"
+            count={filteredProjects.length}
+            search={projectSearch}
+            onSearchChange={setProjectSearch}
+            collapsed={collapsedSections.projects}
+            onToggleCollapsed={() => setSectionCollapsed('projects', !collapsedSections.projects)}
+          >
+            <button
+              onClick={() => setProjectModalOpen(true)}
+              className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
+            >
+              <Plus className="w-3 h-3" />
+              New project
+            </button>
+          </SectionHeader>
+          {!collapsedSections.projects && (
+            <>
+              {projectsList.length > 0 && (
+                <div className="mb-3 flex min-w-0 items-center gap-1.5 overflow-x-auto pb-0.5">
+                  {projectStatusFilterOptions.map(option => {
+                    const isActive = projectStatusFilter === option.value
+                    return (
+                      <button
+                        key={option.value}
+                        onClick={() => setProjectStatusFilter(option.value)}
+                        className={`flex-shrink-0 rounded-[7px] px-2.5 py-1 text-[11px] transition-colors cursor-pointer ${
+                          isActive
+                            ? 'bg-accent-muted text-accent'
+                            : 'glass-sm text-text-secondary hover:bg-glass-hover'
+                        }`}
+                      >
+                        {option.label}
+                        <span className="ml-1 text-[10px] text-text-muted">{option.count}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+              {projectsList.length > 0 ? (
+                filteredProjects.length > 0 ? (
+                  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+                    {filteredProjects.map(project => (
+                    <div
+                      key={project.id}
+                      onClick={() => router.push(`/projects/${project.id}`)}
+                      className="glass-card p-3 cursor-pointer group relative flex flex-col"
+                    >
+                      <div className="absolute right-2 top-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); requestDelete({ type: 'project', id: project.id }) }}
+                          className="btn-danger-icon"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+
+                      <div className="min-w-0 pr-8">
+                        <p className="text-[12px] font-medium text-text-primary truncate leading-tight" title={project.name}>{project.name}</p>
+                        <p className="text-[10px] text-text-muted mt-1">
+                          {project.tool_count} tool{project.tool_count !== 1 ? 's' : ''} assigned
+                        </p>
+                      </div>
+
+                      <div className="space-y-1">
+                        {(project.status !== 'active' || project.unplaced_count > 0) && (
+                          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
+                            {project.status !== 'active' && (
+                              <span className="min-w-0 text-[10px] text-text-secondary truncate">{projectStatusLabels[project.status]}</span>
+                            )}
+                            {project.status !== 'active' && project.unplaced_count > 0 && (
+                              <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
+                            )}
+                            {project.unplaced_count > 0 && (
+                              <span className="text-[10px] text-amber-300 flex-shrink-0">{project.unplaced_count} need bin</span>
+                            )}
+                          </div>
+                        )}
+                        <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
+                          <span className="text-[10px] text-text-muted flex-shrink-0">{project.placed_count} placed</span>
+                          <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
+                          <span className="text-[10px] text-text-muted flex-shrink-0">{project.bin_count} bin{project.bin_count !== 1 ? 's' : ''}</span>
+                        </div>
+                      </div>
+                    </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="glass rounded-[8px] p-6 text-center">
+                    <p className="text-xs text-text-muted">No projects match this filter.</p>
+                  </div>
+                )
+              ) : (
+                <div className="glass rounded-[8px] p-6 text-center">
+                  <Folder className="w-6 h-6 text-text-muted/20 mx-auto mb-2" />
+                  <p className="text-xs text-text-muted mb-3">No projects yet</p>
+                  <button
+                    onClick={() => setProjectModalOpen(true)}
+                    className="btn-primary px-4 py-1.5 text-xs"
+                  >
+                    Create project
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
       {/* tools */}
       {toolsList.length > 0 && (
         <div>
@@ -383,78 +534,119 @@ export default function HomePage() {
             title="Tools" count={toolsList.length}
             search={toolSearch} onSearchChange={setToolSearch}
             sortKey={toolSort} onSortChange={setToolSort}
+            collapsed={collapsedSections.tools}
+            onToggleCollapsed={() => setSectionCollapsed('tools', !collapsedSections.tools)}
           />
+          {!collapsedSections.tools && (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-            {filteredTools.map(tool => (
-              <div
-                key={tool.id}
-                onClick={() => router.push(`/tools/${tool.id}`)}
-                className="glass-card overflow-hidden cursor-pointer group"
-              >
-                <div className="aspect-square bg-inset relative overflow-hidden">
-                  {tool.image_context ? (
-                    <>
-                      <SourceImagePreview context={tool.image_context} points={tool.points} />
-                      <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-                        <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
-                      </div>
-                    </>
-                  ) : tool.thumbnail_url ? (
-                    <>
-                      <img
-                        src={getImageUrl(tool.thumbnail_url)}
-                        alt=""
-                        className="absolute inset-0 w-full h-full object-contain p-3 transition-opacity duration-150 group-hover:opacity-30"
-                        style={thumbnailRotationStyle(tool.image_transform)}
-                      />
-                      <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-                        <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
-                      </div>
-                    </>
-                  ) : (
-                    <div className="w-full h-full p-4 flex items-center justify-center">
-                      <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
+            {filteredTools.map(tool => {
+                const projectLabel = toolProjectLabel(tool.project_ids, projectNameById)
+                const projectTitle = toolProjectTitle(tool.project_ids, projectNameById)
+                const primaryProjectId = tool.project_ids[0]
+                return (
+                  <div
+                    key={tool.id}
+                    onClick={() => router.push(`/tools/${tool.id}`)}
+                    className="glass-card overflow-hidden cursor-pointer group"
+                  >
+                    <div className="aspect-square bg-inset relative overflow-hidden">
+                      {tool.image_context ? (
+                        <>
+                          <SourceImagePreview context={tool.image_context} points={tool.points} />
+                          <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                            <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
+                          </div>
+                        </>
+                      ) : tool.thumbnail_url ? (
+                        <>
+                          <img
+                            src={getImageUrl(tool.thumbnail_url)}
+                            alt=""
+                            className="absolute inset-0 w-full h-full object-contain p-3 transition-opacity duration-150 group-hover:opacity-30"
+                            style={thumbnailRotationStyle(tool.image_transform)}
+                          />
+                          <div className="absolute inset-0 p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                            <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
+                          </div>
+                        </>
+                      ) : (
+                        <div className="w-full h-full p-4 flex items-center justify-center">
+                          <ToolOutline points={tool.points} interiorRings={tool.interior_rings} />
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-                <div className="px-3 py-[10px]">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <p className="text-[12px] font-medium text-text-primary truncate leading-tight">{tool.name}</p>
-                      <p className="text-[10px] text-text-muted mt-0.5">{formatDate(tool.created_at)}</p>
-                    </div>
-                    <div className="flex items-center gap-0.5 flex-shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setNameModal({ toolIds: [tool.id] }) }}
-                        disabled={creatingBin === tool.id}
-                        className="p-1 text-text-muted hover:text-accent hover:bg-accent-muted rounded transition-colors cursor-pointer"
-                        title="Create bin"
-                      >
-                        {creatingBin === tool.id ? (
-                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        ) : (
-                          <Package className="w-3.5 h-3.5" />
-                        )}
-                      </button>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setDeleteModal({ type: 'tool', id: tool.id }) }}
-                        className="p-1 text-text-muted hover:text-red-400 hover:bg-red-900/20 rounded transition-colors cursor-pointer"
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
+                    <div className="px-3 py-[10px]">
+                      <div className="relative">
+                        <div className="min-w-0 pr-12 md:pr-0">
+                          <p className="text-[12px] font-medium text-text-primary truncate leading-tight">{tool.name}</p>
+                          <div className="flex min-w-0 items-center gap-1.5 mt-0.5 overflow-hidden whitespace-nowrap">
+                            <span className="text-[10px] text-text-muted flex-shrink-0">{formatDate(tool.created_at)}</span>
+                            <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
+                            {projectLabel ? (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  if (primaryProjectId) router.push(`/projects/${primaryProjectId}`)
+                                }}
+                                className="min-w-0 text-[10px] text-text-secondary hover:text-accent transition-colors truncate cursor-pointer"
+                                title={projectTitle}
+                              >
+                                {projectLabel}
+                              </button>
+                            ) : (
+                              <span className="min-w-0 text-[10px] text-text-muted truncate">Unassigned</span>
+                            )}
+                            {projectLabel && (
+                              <>
+                                <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
+                                {projectBinToolIds.has(tool.id) ? (
+                                  <span className="text-[10px] text-text-muted flex-shrink-0">Placed</span>
+                                ) : (
+                                  <span className="text-[10px] text-amber-300 flex-shrink-0">Needs bin</span>
+                                )}
+                              </>
+                            )}
+                          </div>
+                        </div>
+                        <div className="absolute right-0 top-0 flex items-center gap-0.5 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); setNameModal({ toolIds: [tool.id] }) }}
+                            disabled={creatingBin === tool.id}
+                            className="p-1 text-text-muted hover:text-accent hover:bg-accent-muted rounded-[7px] transition-colors cursor-pointer"
+                            title="Create bin"
+                          >
+                            {creatingBin === tool.id ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Package className="w-3.5 h-3.5" />
+                            )}
+                          </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); requestDelete({ type: 'tool', id: tool.id }) }}
+                            className="btn-danger-icon"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </div>
-            ))}
+                )
+              })}
           </div>
+          )}
         </div>
       )}
 
       {/* bins */}
       {(binsList.length > 0 || toolsList.length > 0) && (
         <div>
-          <SectionHeader title="Bins" count={binsList.length}>
+          <SectionHeader
+            title="Bins"
+            count={binsList.length}
+            collapsed={collapsedSections.bins}
+            onToggleCollapsed={() => setSectionCollapsed('bins', !collapsedSections.bins)}
+          >
             <button
               onClick={() => setNameModal({})}
               className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
@@ -463,60 +655,77 @@ export default function HomePage() {
               New bin
             </button>
           </SectionHeader>
-          {binsList.length > 0 ? (
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-              {binsList.map(bin => (
-                <div
-                  key={bin.id}
-                  onClick={() => router.push(`/bins/${bin.id}`)}
-                  className="glass-card overflow-hidden cursor-pointer group"
-                >
-                  <div className="aspect-[4/3] bg-inset flex items-center justify-center p-4 relative">
-                    {bin.preview_tools.length > 0 ? (
-                      <BinPreview gridX={bin.grid_x} gridY={bin.grid_y} tools={bin.preview_tools} />
-                    ) : (
-                      <Package className="w-6 h-6 text-text-muted/20" />
-                    )}
-                    <div className="absolute top-2 right-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setDeleteModal({ type: 'bin', id: bin.id }) }}
-                        className="p-1 text-text-muted hover:text-red-400 hover:bg-red-900/20 rounded transition-colors cursor-pointer"
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
-                    </div>
-                  </div>
-                  <div className="px-3 py-[10px]">
-                    <p className="text-[12px] font-medium text-text-primary truncate leading-tight">
-                      {bin.name || `Bin ${bin.id.slice(0, 8)}`}
-                    </p>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-[10px] text-text-muted">{formatDate(bin.created_at)}</span>
-                      <span className="text-[10px] text-text-muted flex items-center gap-0.5">
-                        <Grid3X3 className="w-2.5 h-2.5" />
-                        {bin.grid_x}x{bin.grid_y}
-                      </span>
-                      {bin.tool_count > 0 && (
-                        <span className="text-[10px] text-text-muted">
-                          {bin.tool_count} tool{bin.tool_count !== 1 ? 's' : ''}
-                        </span>
+          {!collapsedSections.bins && (
+            binsList.length > 0 ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+                {binsList.map(bin => (
+                  <div
+                    key={bin.id}
+                    onClick={() => router.push(`/bins/${bin.id}`)}
+                    className="glass-card overflow-hidden cursor-pointer group"
+                  >
+                    <div className="aspect-[4/3] bg-inset flex items-center justify-center p-4 relative">
+                      {bin.preview_tools.length > 0 ? (
+                        <BinPreview gridX={bin.grid_x} gridY={bin.grid_y} tools={bin.preview_tools} />
+                      ) : (
+                        <Package className="w-6 h-6 text-text-muted/20" />
                       )}
+                      <div className="absolute top-2 right-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); requestDelete({ type: 'bin', id: bin.id }) }}
+                          className="btn-danger-icon"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                    <div className="px-3 py-[10px]">
+                      <p className="text-[12px] font-medium text-text-primary truncate leading-tight">
+                        {bin.name || `Bin ${bin.id.slice(0, 8)}`}
+                      </p>
+                      <div className="flex min-w-0 items-center gap-1.5 mt-0.5 overflow-hidden whitespace-nowrap">
+                        <span className="text-[10px] text-text-muted flex-shrink-0">{formatDate(bin.created_at)}</span>
+                        {bin.project_id && projectNameById.get(bin.project_id) && (
+                          <>
+                            <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                if (bin.project_id) router.push(`/projects/${bin.project_id}`)
+                              }}
+                              className="min-w-0 text-[10px] text-text-secondary hover:text-accent transition-colors truncate cursor-pointer"
+                              title={projectNameById.get(bin.project_id)}
+                            >
+                              {projectNameById.get(bin.project_id)}
+                            </button>
+                          </>
+                        )}
+                        <span className="text-[10px] text-text-muted flex items-center gap-0.5 flex-shrink-0">
+                          <Grid3X3 className="w-2.5 h-2.5" />
+                          {bin.grid_x}x{bin.grid_y}
+                        </span>
+                        {bin.tool_count > 0 && (
+                          <span className="text-[10px] text-text-muted flex-shrink-0">
+                            {bin.tool_count} tool{bin.tool_count !== 1 ? 's' : ''}
+                          </span>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="glass rounded-[10px] p-8 text-center">
-              <Package className="w-6 h-6 text-text-muted/20 mx-auto mb-2" />
-              <p className="text-xs text-text-muted mb-3">No bins yet</p>
-              <button
-                onClick={() => setNameModal({})}
-                className="btn-primary px-4 py-1.5 text-xs"
-              >
-                Create your first bin
-              </button>
-            </div>
+                ))}
+              </div>
+            ) : (
+              <div className="glass rounded-[8px] p-8 text-center">
+                <Package className="w-6 h-6 text-text-muted/20 mx-auto mb-2" />
+                <p className="text-xs text-text-muted mb-3">No bins yet</p>
+                <button
+                  onClick={() => setNameModal({})}
+                  className="btn-primary px-4 py-1.5 text-xs"
+                >
+                  Create your first bin
+                </button>
+              </div>
+            )
           )}
         </div>
       )}
@@ -524,7 +733,12 @@ export default function HomePage() {
       {/* empty state onboarding */}
       {!loading && !hasData && (
         <div data-tour="how-it-works">
-          <SectionHeader title="How it works" />
+          <SectionHeader
+            title="How it works"
+            collapsed={collapsedSections.howItWorks}
+            onToggleCollapsed={() => setSectionCollapsed('howItWorks', !collapsedSections.howItWorks)}
+          />
+          {!collapsedSections.howItWorks && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
             {[
               { Illustration: PhotoIllustration, label: '1. Photograph', caption: 'Place tools on A4 or Letter paper and photograph from above' },
@@ -532,7 +746,7 @@ export default function HomePage() {
               { Illustration: TraceIllustration, label: '3. Trace', caption: 'AI traces tool outlines into precise silhouettes' },
               { Illustration: OrganiseIllustration, label: '4. Organise', caption: 'Arrange tools in a bin and export the STL for printing' },
             ].map(({ Illustration, label, caption }) => (
-              <div key={label} className="glass rounded-[10px] overflow-hidden">
+              <div key={label} className="glass rounded-[8px] overflow-hidden">
                 <div className="p-3 pb-2">
                   <Illustration />
                 </div>
@@ -543,31 +757,49 @@ export default function HomePage() {
               </div>
             ))}
           </div>
+          )}
         </div>
       )}
 
       <ConfirmModal
         open={deleteModal !== null}
-        title={deleteModal?.type === 'tool' ? 'Delete tool?' : 'Delete bin?'}
+        title={
+          deleteModal?.type === 'tool'
+            ? 'Delete tool?'
+            : deleteModal?.type === 'project'
+              ? 'Delete project?'
+              : 'Delete bin?'
+        }
         message={
           deleteModal?.type === 'tool'
             ? 'This will permanently delete the tool from your library.'
-            : 'This will permanently delete the bin and all associated files.'
+            : deleteModal?.type === 'project'
+              ? 'This will remove the project. Tools and bins will stay in your library.'
+              : 'This will permanently delete the bin and all associated files.'
         }
         confirmText="Delete"
         variant="danger"
         onConfirm={() => {
           if (!deleteModal) return
           if (deleteModal.type === 'tool') handleDeleteTool(deleteModal.id)
+          else if (deleteModal.type === 'project') handleDeleteProject(deleteModal.id)
           else handleDeleteBin(deleteModal.id)
         }}
-        onCancel={() => setDeleteModal(null)}
+        onCancel={() => clearDelete()}
       />
 
       <NameModal
         open={nameModal !== null}
         onConfirm={(name) => handleCreateBin(name, nameModal?.toolIds)}
         onCancel={() => setNameModal(null)}
+      />
+      <NameModal
+        open={projectModalOpen}
+        title="New project"
+        description="Name this drawer or multi-bin plan."
+        placeholder="e.g. Top drawer sockets"
+        onConfirm={handleCreateProject}
+        onCancel={() => setProjectModalOpen(false)}
       />
     </div>
   )

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -1,0 +1,830 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  addToolsToProject,
+  addBinsToProject,
+  createProjectBin,
+  getProject,
+  getProjectHealth,
+  listProjects,
+  listBins,
+  listTools,
+  deleteBin,
+  detachBinFromProject,
+  removeToolFromProject,
+  repairProject,
+  updateProject,
+} from '@/lib/api'
+import type { BinProject, BinProjectSummary, BinSummary, ProjectHealthIssue, ProjectStatus, ToolSummary } from '@/types'
+import { Alert } from '@/components/Alert'
+import { ConfirmModal } from '@/components/ConfirmModal'
+import { SectionHeader } from '@/components/SectionHeader'
+import { ToolSummaryButton, ToolSummaryItem } from '@/components/ToolSummaryItem'
+import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
+import { projectScopedHref } from '@/lib/projectNavigation'
+import {
+  binLabel,
+  getProjectCollections,
+  projectStatusLabels,
+  projectNameMap,
+  toolProjectLabel,
+  type ProjectToolFilter,
+} from '@/lib/projectSelectors'
+import { AlertTriangle, ArrowLeft, CheckSquare, ChevronDown, ChevronRight, Loader2, Package, Plus, Search, Square, Trash2, Unlink } from 'lucide-react'
+
+const PROJECT_SECTION_COLLAPSE_KEY = 'tracefinity.project.collapsedSections'
+type ProjectSectionId = 'projectTools' | 'linkedBins'
+type ProjectSectionCollapseState = Record<ProjectSectionId, boolean>
+
+const defaultProjectSectionCollapse: ProjectSectionCollapseState = {
+  projectTools: false,
+  linkedBins: false,
+}
+
+function loadProjectSectionCollapseState(): ProjectSectionCollapseState {
+  if (typeof window === 'undefined') return defaultProjectSectionCollapse
+  try {
+    const raw = window.localStorage.getItem(PROJECT_SECTION_COLLAPSE_KEY)
+    if (!raw) return defaultProjectSectionCollapse
+    return { ...defaultProjectSectionCollapse, ...JSON.parse(raw) }
+  } catch {
+    return defaultProjectSectionCollapse
+  }
+}
+
+export default function ProjectPage() {
+  const params = useParams()
+  const router = useRouter()
+  const projectId = params.id as string
+
+  const [project, setProject] = useState<BinProject | null>(null)
+  const [projects, setProjects] = useState<BinProjectSummary[]>([])
+  const [tools, setTools] = useState<ToolSummary[]>([])
+  const [bins, setBins] = useState<BinSummary[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [selectedBinToolIds, setSelectedBinToolIds] = useState<Set<string>>(new Set())
+  const [expandedBinIds, setExpandedBinIds] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState('')
+  const [projectSearch, setProjectSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<ProjectToolFilter>('all')
+  const [addToolsOpen, setAddToolsOpen] = useState(true)
+  const [addBinsOpen, setAddBinsOpen] = useState(false)
+  const [selectedExistingBinIds, setSelectedExistingBinIds] = useState<Set<string>>(new Set())
+  const [importExistingBinTools, setImportExistingBinTools] = useState(false)
+  const [allowReassignBins, setAllowReassignBins] = useState(false)
+  const [collapsedSections, setCollapsedSections] = useState<ProjectSectionCollapseState>(loadProjectSectionCollapseState)
+  const [healthIssues, setHealthIssues] = useState<ProjectHealthIssue[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [creatingBin, setCreatingBin] = useState(false)
+  const { deleteTarget: deleteBinId, requestDelete: requestBinDelete, clearDelete: clearBinDelete } = useDeleteConfirmation<string>()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadData()
+  }, [projectId])
+
+  async function loadData() {
+    setLoading(true)
+    setError(null)
+    try {
+      const [p, t, b, allProjects, h] = await Promise.all([
+        getProject(projectId),
+        listTools(),
+        listBins(),
+        listProjects(),
+        getProjectHealth(projectId).catch(() => null),
+      ])
+      const savedAddToolsOpen = window.localStorage.getItem('tracefinity.project.addToolsOpen')
+      setProject(p)
+      setProjects(allProjects)
+      setTools(t)
+      setBins(b)
+      setHealthIssues(h?.issues || [])
+      setAddToolsOpen(p.tool_ids.length === 0 ? true : savedAddToolsOpen !== null ? savedAddToolsOpen === 'true' : true)
+      setSelectedBinToolIds(new Set())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load project')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const {
+    projectToolIds,
+    projectTools,
+    unplacedToolIds,
+    filteredProjectTools,
+    projectBins,
+    toolById,
+    toolBins,
+    existingBinOptions,
+    actionableVisibleToolIds,
+    availableTools,
+  } = useMemo(() => getProjectCollections(project, tools, bins, {
+    projectSearch,
+    addToolSearch: search,
+    statusFilter,
+    allowReassignBins,
+  }), [project, tools, bins, projectSearch, search, statusFilter, allowReassignBins])
+  const projectNameById = useMemo(() => projectNameMap(projects), [projects])
+
+  function toggleSelected(toolId: string) {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(toolId)) next.delete(toolId)
+      else next.add(toolId)
+      return next
+    })
+  }
+
+  function toggleBinTool(toolId: string) {
+    setSelectedBinToolIds(prev => {
+      const next = new Set(prev)
+      if (next.has(toolId)) next.delete(toolId)
+      else next.add(toolId)
+      return next
+    })
+  }
+
+  function toggleExpandedBin(binId: string) {
+    setExpandedBinIds(prev => {
+      const next = new Set(prev)
+      if (next.has(binId)) next.delete(binId)
+      else next.add(binId)
+      return next
+    })
+  }
+
+  function setAddToolsOpenPersisted(open: boolean) {
+    setAddToolsOpen(open)
+    window.localStorage.setItem('tracefinity.project.addToolsOpen', String(open))
+  }
+
+  function setSectionCollapsed(section: ProjectSectionId, collapsed: boolean) {
+    setCollapsedSections(prev => {
+      const next = { ...prev, [section]: collapsed }
+      window.localStorage.setItem(PROJECT_SECTION_COLLAPSE_KEY, JSON.stringify(next))
+      return next
+    })
+  }
+
+  async function handleAddSelected() {
+    if (!project || selected.size === 0) return
+    setSaving(true)
+    setError(null)
+    try {
+      const toolIds = Array.from(selected)
+      const updated = await addToolsToProject(project.id, toolIds)
+      setProject(updated)
+      setTools(prev => prev.map(tool => (
+        toolIds.includes(tool.id) && !tool.project_ids.includes(project.id)
+          ? { ...tool, project_ids: [...tool.project_ids, project.id] }
+          : tool
+      )))
+      setSelectedBinToolIds(prev => new Set([...Array.from(prev), ...toolIds]))
+      setSelected(new Set())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to add tools')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleProjectStatusChange(status: ProjectStatus) {
+    if (!project) return
+    const previous = project
+    setProject({ ...project, status })
+    try {
+      const updated = await updateProject(project.id, { status })
+      setProject(updated)
+    } catch (err) {
+      setProject(previous)
+      setError(err instanceof Error ? err.message : 'failed to update project status')
+    }
+  }
+
+  async function handleRepairHealth() {
+    if (!project) return
+    setSaving(true)
+    setError(null)
+    try {
+      const health = await repairProject(project.id)
+      const [updated, refreshedBins, refreshedTools] = await Promise.all([getProject(project.id), listBins(), listTools()])
+      setProject(updated)
+      setBins(refreshedBins)
+      setTools(refreshedTools)
+      setHealthIssues(health.issues)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to repair project links')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRemoveTool(toolId: string) {
+    if (!project) return
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await removeToolFromProject(project.id, toolId)
+      setProject(updated)
+      setTools(prev => prev.map(tool => (
+        tool.id === toolId
+          ? { ...tool, project_ids: tool.project_ids.filter(pid => pid !== project.id) }
+          : tool
+      )))
+      setSelectedBinToolIds(prev => {
+        const next = new Set(prev)
+        next.delete(toolId)
+        return next
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to remove tool')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleCreateBin() {
+    if (!project || selectedBinToolIds.size === 0) return
+    setCreatingBin(true)
+    setError(null)
+    try {
+      const bin = await createProjectBin(project.id, {
+        name: `${project.name} bin ${projectBins.length + 1}`,
+        tool_ids: Array.from(selectedBinToolIds),
+      })
+      router.push(projectScopedHref(project.id, `/bins/${bin.id}`))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to create bin')
+    } finally {
+      setCreatingBin(false)
+    }
+  }
+
+  async function handleDeleteBin() {
+    if (!project || !deleteBinId) return
+    setSaving(true)
+    setError(null)
+    try {
+      await deleteBin(deleteBinId)
+      setBins(prev => prev.filter(bin => bin.id !== deleteBinId))
+      setProject({ ...project, bin_ids: project.bin_ids.filter(id => id !== deleteBinId) })
+      clearBinDelete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to delete bin')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDetachBin(binId: string) {
+    if (!project) return
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await detachBinFromProject(project.id, binId)
+      setProject(updated)
+      setBins(prev => prev.map(bin => bin.id === binId ? { ...bin, project_id: null } : bin))
+      setHealthIssues((await getProjectHealth(project.id)).issues)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to detach bin')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAddExistingBins() {
+    if (!project || selectedExistingBinIds.size === 0) return
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await addBinsToProject(project.id, {
+        bin_ids: Array.from(selectedExistingBinIds),
+        import_tools: importExistingBinTools,
+        allow_reassign: allowReassignBins,
+      })
+      const [refreshedBins, refreshedTools, health] = await Promise.all([listBins(), listTools(), getProjectHealth(project.id)])
+      setProject(updated)
+      setBins(refreshedBins)
+      setTools(refreshedTools)
+      setHealthIssues(health.issues)
+      setSelectedExistingBinIds(new Set())
+      setAddBinsOpen(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to add existing bins')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleSelectVisible() {
+    setSelectedBinToolIds(new Set(actionableVisibleToolIds))
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-6xl mx-auto py-4">
+        <div className="flex items-center gap-2 text-xs text-text-muted">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          Loading project...
+        </div>
+      </div>
+    )
+  }
+
+  if (!project) {
+    return (
+      <div className="max-w-6xl mx-auto py-4">
+        <Alert variant="error">{error || 'project not found'}</Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto py-4 space-y-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <button
+            onClick={() => router.push('/')}
+            className="mb-3 glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
+          >
+            <ArrowLeft className="w-3 h-3" />
+            Dashboard
+          </button>
+          <h1 className="text-xl font-semibold text-text-primary">{project.name}</h1>
+          {project.description && (
+            <p className="mt-1 text-xs text-text-secondary">{project.description}</p>
+          )}
+          <div className="mt-2 flex items-center gap-3 text-[11px] text-text-muted">
+            <span>{projectTools.length} tool{projectTools.length !== 1 ? 's' : ''}</span>
+            <span>{projectBins.length} bin{projectBins.length !== 1 ? 's' : ''}</span>
+            <span>{projectStatusLabels[project.status]}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={project.status}
+            onChange={e => handleProjectStatusChange(e.target.value as ProjectStatus)}
+            className="h-8 bg-elevated border border-border-subtle rounded-[7px] px-2 text-xs text-text-secondary outline-none focus:border-accent"
+          >
+            {Object.entries(projectStatusLabels).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleCreateBin}
+            disabled={creatingBin || selectedBinToolIds.size === 0}
+            className="btn-primary px-3 py-2 text-xs flex items-center gap-1.5"
+          >
+            {creatingBin ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Package className="w-3.5 h-3.5" />}
+            Create bin{selectedBinToolIds.size > 0 ? ` (${selectedBinToolIds.size})` : ''}
+          </button>
+        </div>
+      </div>
+
+      {error && <Alert variant="error">{error}</Alert>}
+
+      {healthIssues.length > 0 && (
+        <section className="glass rounded-[8px] px-3 py-2">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-xs text-amber-300">
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+                <span>{healthIssues.length} project health issue{healthIssues.length !== 1 ? 's' : ''}</span>
+              </div>
+              <div className="mt-1 space-y-0.5">
+                {healthIssues.slice(0, 3).map((issue, index) => (
+                  <p key={`${issue.code}-${issue.tool_id || issue.bin_id || index}`} className="text-[11px] text-text-muted truncate">
+                    {issue.message}
+                  </p>
+                ))}
+                {healthIssues.length > 3 && (
+                  <p className="text-[11px] text-text-muted">{healthIssues.length - 3} more issue{healthIssues.length - 3 !== 1 ? 's' : ''}</p>
+                )}
+              </div>
+            </div>
+            {healthIssues.some(issue => issue.repairable) && (
+              <button
+                onClick={handleRepairHealth}
+                disabled={saving}
+                className="btn-secondary px-3 py-1.5 text-xs flex-shrink-0"
+              >
+                Repair links
+              </button>
+            )}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <SectionHeader
+          title="Project tools"
+          count={projectTools.length}
+          collapsed={collapsedSections.projectTools}
+          onToggleCollapsed={() => setSectionCollapsed('projectTools', !collapsedSections.projectTools)}
+        >
+          {!collapsedSections.projectTools && projectTools.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap justify-end">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted" />
+                <input
+                  value={projectSearch}
+                  onChange={e => setProjectSearch(e.target.value)}
+                  placeholder="Find in project..."
+                  className="w-36 pl-6 pr-2 py-1 text-[11px] bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
+                />
+              </div>
+              {[
+                ['all', `All ${projectTools.length}`],
+                ['unplaced', `Unplaced ${project.unplaced_tool_ids.length}`],
+                ['placed', `Placed ${project.placed_tool_ids.length}`],
+              ].map(([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => setStatusFilter(key as ProjectToolFilter)}
+                  className={`rounded-[7px] px-2 py-1 text-[11px] transition-colors cursor-pointer ${
+                    statusFilter === key
+                      ? 'bg-accent-muted text-accent'
+                      : 'glass-sm text-text-secondary hover:bg-glass-hover'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+              <span className="text-[11px] text-text-muted">{selectedBinToolIds.size} selected for bin</span>
+              <button
+                onClick={() => setSelectedBinToolIds(new Set(project.tool_ids))}
+                className="btn-secondary px-2 py-1 text-[11px]"
+              >
+                Select all
+              </button>
+              {(filteredProjectTools.length !== projectTools.length || projectSearch.trim()) && (
+                <button
+                  onClick={handleSelectVisible}
+                  className="btn-secondary px-2 py-1 text-[11px]"
+                >
+                  Select visible ({actionableVisibleToolIds.length})
+                </button>
+              )}
+              <button
+                onClick={() => setSelectedBinToolIds(new Set())}
+                className="btn-secondary px-2 py-1 text-[11px]"
+              >
+                Select none
+              </button>
+            </div>
+          )}
+        </SectionHeader>
+        {!collapsedSections.projectTools && (
+          projectTools.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {filteredProjectTools.map(tool => {
+                const isSelectedForBin = selectedBinToolIds.has(tool.id)
+                const projectLabel = toolProjectLabel(tool.project_ids, projectNameById)
+                const binsForTool = toolBins.get(tool.id) || []
+                const metadataItems = [
+                  ...(projectLabel ? [{ key: 'project', label: projectLabel, title: projectLabel, className: 'text-text-secondary' }] : []),
+                  ...(binsForTool.length > 0
+                    ? binsForTool.slice(0, 2).map(bin => ({
+                      key: bin.id,
+                      label: binLabel(bin),
+                      title: binLabel(bin),
+                      className: 'text-text-secondary',
+                    }))
+                    : [{ key: 'needs-bin', label: 'Needs bin', title: 'Needs bin', className: 'text-amber-300' }]),
+                ]
+                return (
+                <div key={tool.id} className="glass rounded-[8px] px-3 py-2 min-h-[72px] flex items-start justify-between gap-2">
+                  <button
+                    onClick={() => toggleBinTool(tool.id)}
+                    className="mt-5 text-text-muted hover:text-accent transition-colors cursor-pointer flex-shrink-0"
+                    title={isSelectedForBin ? 'Exclude from next bin' : 'Include in next bin'}
+                  >
+                    {isSelectedForBin ? (
+                      <CheckSquare className="w-4 h-4 text-accent" />
+                    ) : (
+                      <Square className="w-4 h-4" />
+                    )}
+                  </button>
+                  <button
+                    onClick={() => router.push(projectScopedHref(project.id, `/tools/${tool.id}`))}
+                    className="min-w-0 flex-1 flex items-start gap-2 text-left cursor-pointer"
+                  >
+                    <ToolSummaryItem tool={tool} className="flex-1 items-start">
+                      <span className="mt-0.5 flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
+                        {metadataItems.map((item, index) => (
+                          <span key={item.key} className="min-w-0 contents">
+                            {index > 0 && <span className="text-[10px] text-text-muted flex-shrink-0">·</span>}
+                            <span className={`min-w-0 text-[10px] truncate ${item.className}`} title={item.title}>
+                              {item.label}
+                            </span>
+                          </span>
+                        ))}
+                      </span>
+                    </ToolSummaryItem>
+                  </button>
+                  <button
+                    onClick={() => handleRemoveTool(tool.id)}
+                    disabled={saving}
+                    className="btn-danger-icon flex-shrink-0"
+                    title="Remove from project"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                )
+              })}
+              {filteredProjectTools.length === 0 && (
+                <div className="glass rounded-[8px] p-6 text-center sm:col-span-2 lg:col-span-3">
+                  <p className="text-xs text-text-muted">No tools match this filter.</p>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="glass rounded-[8px] p-6 text-center">
+              <p className="text-xs text-text-muted">No tools assigned.</p>
+            </div>
+          )
+        )}
+      </section>
+
+      <section>
+        <div className="flex h-[32px] items-center justify-between gap-3 mb-3">
+          <button
+            onClick={() => setAddToolsOpenPersisted(!addToolsOpen)}
+            className="flex items-center gap-1.5 text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px] hover:text-text-secondary transition-colors cursor-pointer"
+          >
+            {addToolsOpen ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            Add tools
+            <span className="tracking-normal normal-case font-normal">({availableTools.length})</span>
+          </button>
+          {addToolsOpen && (
+            <div className="flex items-center gap-2 flex-wrap justify-end">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted" />
+                <input
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  placeholder="Filter tools..."
+                  className="w-40 pl-6 pr-2 py-1 text-[11px] bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
+                />
+              </div>
+              <button
+                onClick={() => setSelected(new Set(availableTools.map(tool => tool.id)))}
+                disabled={availableTools.length === 0}
+                className="btn-secondary px-2 py-1 text-[11px]"
+              >
+                Select all
+              </button>
+              <button
+                onClick={() => setSelected(new Set())}
+                disabled={selected.size === 0}
+                className="btn-secondary px-2 py-1 text-[11px]"
+              >
+                Select none
+              </button>
+              <button
+                onClick={handleAddSelected}
+                disabled={saving || selected.size === 0}
+                className="btn-secondary px-3 py-1.5 text-xs flex items-center gap-1.5"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add {selected.size || ''}
+              </button>
+            </div>
+          )}
+        </div>
+        {addToolsOpen && (
+          <>
+            {availableTools.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                {availableTools.map(tool => {
+                  const isSelected = selected.has(tool.id)
+                  const projectLabel = toolProjectLabel(tool.project_ids, projectNameById)
+                  return (
+                    <button
+                      key={tool.id}
+                      onClick={() => toggleSelected(tool.id)}
+                      className="glass rounded-[8px] px-3 py-2 h-[72px] flex items-center gap-2 text-left hover:bg-glass-hover transition-colors cursor-pointer"
+                    >
+                      {isSelected ? (
+                        <CheckSquare className="w-4 h-4 text-accent flex-shrink-0" />
+                      ) : (
+                        <Square className="w-4 h-4 text-text-muted flex-shrink-0" />
+                      )}
+                      <ToolSummaryItem tool={tool} className="flex-1">
+                        {projectLabel && (
+                          <span
+                            className="mt-0.5 block max-w-[160px] text-[10px] text-text-secondary truncate"
+                            title={projectLabel}
+                          >
+                            {projectLabel}
+                          </span>
+                        )}
+                      </ToolSummaryItem>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <div className="glass rounded-[8px] p-6 text-center">
+                <p className="text-xs text-text-muted">No available tools.</p>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader
+          title="Linked bins"
+          count={projectBins.length}
+          collapsed={collapsedSections.linkedBins}
+          onToggleCollapsed={() => setSectionCollapsed('linkedBins', !collapsedSections.linkedBins)}
+        >
+          <button
+            onClick={() => setAddBinsOpen(prev => !prev)}
+            className="btn-secondary px-2 py-1 text-[11px] inline-flex items-center gap-1"
+          >
+            <Plus className="w-3 h-3" />
+            Add existing bin
+          </button>
+        </SectionHeader>
+        {!collapsedSections.linkedBins && addBinsOpen && (
+          <div className="glass rounded-[8px] px-3 py-2 mb-3 space-y-2">
+            <div className="flex items-center gap-3 flex-wrap">
+              <label className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={importExistingBinTools}
+                  onChange={e => setImportExistingBinTools(e.target.checked)}
+                />
+                Import bin tools
+              </label>
+              <label className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={allowReassignBins}
+                  onChange={e => setAllowReassignBins(e.target.checked)}
+                />
+                Show assigned bins
+              </label>
+              <button
+                onClick={handleAddExistingBins}
+                disabled={saving || selectedExistingBinIds.size === 0}
+                className="btn-primary px-3 py-1.5 text-xs"
+              >
+                Add {selectedExistingBinIds.size || ''}
+              </button>
+            </div>
+            {existingBinOptions.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                {existingBinOptions.map(bin => {
+                  const selectedExisting = selectedExistingBinIds.has(bin.id)
+                  return (
+                    <button
+                      key={bin.id}
+                      onClick={() => setSelectedExistingBinIds(prev => {
+                        const next = new Set(prev)
+                        if (next.has(bin.id)) next.delete(bin.id)
+                        else next.add(bin.id)
+                        return next
+                      })}
+                      className="glass-sm rounded-[7px] px-2 py-1.5 text-left flex items-center gap-2 hover:bg-glass-hover transition-colors"
+                    >
+                      {selectedExisting ? <CheckSquare className="w-3.5 h-3.5 text-accent" /> : <Square className="w-3.5 h-3.5 text-text-muted" />}
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-[11px] text-text-primary truncate">{binLabel(bin)}</span>
+                        <span className="block text-[10px] text-text-muted">{bin.grid_x}x{bin.grid_y} · {bin.tool_count} tool{bin.tool_count !== 1 ? 's' : ''}</span>
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-[11px] text-text-muted">No available bins to add.</p>
+            )}
+          </div>
+        )}
+        {!collapsedSections.linkedBins && (
+          projectBins.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {projectBins.map(bin => {
+                const isExpanded = expandedBinIds.has(bin.id)
+                const binTools = (bin.tool_ids || []).map(toolId => toolById.get(toolId)).filter(Boolean) as ToolSummary[]
+                const outsideTools = binTools.filter(tool => !projectToolIds.has(tool.id))
+                const projectToolsInBin = binTools.filter(tool => projectToolIds.has(tool.id))
+                const stillNeedsTools = projectTools.filter(tool => unplacedToolIds.has(tool.id))
+                return (
+                <div
+                  key={bin.id}
+                  className="glass rounded-[8px] px-3 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <button
+                      onClick={() => toggleExpandedBin(bin.id)}
+                      className="p-1 text-text-muted hover:text-accent rounded-[7px] transition-colors cursor-pointer flex-shrink-0"
+                      title={isExpanded ? 'Hide tools' : 'Show tools'}
+                    >
+                      {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+                    </button>
+                    <button
+                      onClick={() => router.push(projectScopedHref(project.id, `/bins/${bin.id}`))}
+                      className="min-w-0 flex-1 text-left cursor-pointer"
+                    >
+                      <span className="min-w-0">
+                        <span className="block text-xs text-text-primary truncate">{binLabel(bin)}</span>
+                        <span className="block text-[10px] text-text-muted">{bin.grid_x}x{bin.grid_y} · {bin.tool_count} tool{bin.tool_count !== 1 ? 's' : ''}</span>
+                      </span>
+                    </button>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      {outsideTools.length > 0 && (
+                        <AlertTriangle className="w-4 h-4 text-amber-300" />
+                      )}
+                      <Package className="w-4 h-4 text-text-muted" />
+                      <button
+                        onClick={() => handleDetachBin(bin.id)}
+                        disabled={saving}
+                        className="p-1 text-text-muted hover:text-accent hover:bg-accent-muted rounded-[7px] transition-colors cursor-pointer"
+                        title="Detach bin"
+                      >
+                        <Unlink className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        onClick={() => requestBinDelete(bin.id)}
+                        disabled={saving}
+                        className="btn-danger-icon"
+                        title="Delete bin"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                  {isExpanded && (
+                    <div className="mt-2 space-y-1 border-t border-border-subtle pt-2">
+                      {outsideTools.length > 0 && (
+                        <div className="glass-sm rounded-[7px] border border-border-subtle px-2 py-1">
+                          <p className="text-[10px] text-amber-300">{outsideTools.length} outside-project tool{outsideTools.length !== 1 ? 's' : ''} in this bin</p>
+                        </div>
+                      )}
+                      <p className="text-[10px] text-text-muted px-1">In this bin</p>
+                      {projectToolsInBin.length > 0 ? (
+                        projectToolsInBin.map(tool => (
+                          <ToolSummaryButton
+                            key={tool.id}
+                            tool={tool}
+                            onClick={() => router.push(projectScopedHref(project.id, `/tools/${tool.id}`))}
+                            size="sm"
+                          />
+                        ))
+                      ) : (
+                        <p className="text-[10px] text-text-muted px-1">No tools in this bin.</p>
+                      )}
+                      {outsideTools.length > 0 && (
+                        <>
+                          <p className="text-[10px] text-text-muted px-1 pt-1">Outside project</p>
+                          {outsideTools.map(tool => (
+                            <ToolSummaryButton
+                              key={tool.id}
+                              tool={tool}
+                              onClick={() => router.push(projectScopedHref(project.id, `/tools/${tool.id}`))}
+                              size="xs"
+                            />
+                          ))}
+                        </>
+                      )}
+                      {stillNeedsTools.length > 0 && (
+                        <p className="text-[10px] text-text-muted px-1 pt-1">
+                          {stillNeedsTools.length} project tool{stillNeedsTools.length !== 1 ? 's' : ''} still need bin
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="glass rounded-[8px] p-6 text-center">
+              <p className="text-xs text-text-muted">No linked bins yet.</p>
+            </div>
+          )
+        )}
+      </section>
+
+      <ConfirmModal
+        open={deleteBinId !== null}
+        title="Delete bin?"
+        message="This will permanently delete the bin and all associated files."
+        confirmText="Delete"
+        variant="danger"
+        onConfirm={handleDeleteBin}
+        onCancel={clearBinDelete}
+      />
+    </div>
+  )
+}

--- a/frontend/src/app/tools/[id]/page.tsx
+++ b/frontend/src/app/tools/[id]/page.tsx
@@ -2,20 +2,24 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams } from 'next/navigation'
-import { Loader2, Check, Download } from 'lucide-react'
 import Link from 'next/link'
-import { getTool, updateTool, getToolSvgUrl, getImageUrl } from '@/lib/api'
+import { Loader2, Check, Download, Folder } from 'lucide-react'
+import { getTool, updateTool, getToolSvgUrl, getImageUrl, listProjects } from '@/lib/api'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
+import { useProjectSource } from '@/hooks/useProjectSource'
+import { projectNameMap } from '@/lib/projectSelectors'
 import { ToolEditor } from '@/components/ToolEditor'
 import { Alert } from '@/components/Alert'
 import { Breadcrumb } from '@/components/Breadcrumb'
-import type { Tool, Point, FingerHole, AffineMatrix } from '@/types'
+import type { Tool, Point, FingerHole, AffineMatrix, BinProjectSummary } from '@/types'
 
 export default function ToolPage() {
   const params = useParams()
   const toolId = params.id as string
+  const projectSource = useProjectSource('Tools')
 
   const [tool, setTool] = useState<Tool | null>(null)
+  const [projects, setProjects] = useState<BinProjectSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [name, setName] = useState('')
@@ -43,8 +47,9 @@ export default function ToolPage() {
   useEffect(() => {
     async function load() {
       try {
-        const t = await getTool(toolId)
+        const [t, p] = await Promise.all([getTool(toolId), listProjects().catch(() => [])])
         setTool(t)
+        setProjects(p)
         setName(t.name)
       } catch {
         setError('Tool not found')
@@ -93,6 +98,21 @@ export default function ToolPage() {
     setTool(prev => prev ? { ...prev, interior_rings } : null)
   }, [])
 
+  const projectNameById = useMemo(() => projectNameMap(projects), [projects])
+  const toolProjects = useMemo(() => {
+    if (!tool) return []
+    const projectById = new Map(projects.map(project => [project.id, project]))
+    return tool.project_ids.map(projectId => {
+      const project = projectById.get(projectId)
+      return {
+        id: projectId,
+        name: project?.name || projectNameById.get(projectId) || 'Project',
+        toolCount: project?.tool_count,
+        binCount: project?.bin_count,
+      }
+    })
+  }, [tool, projects, projectNameById])
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
@@ -115,7 +135,7 @@ export default function ToolPage() {
       {/* floating breadcrumb panel */}
       <div className="absolute top-3.5 left-3.5 z-20 glass-toolbar px-3 py-1.5 flex items-center gap-3">
         <Breadcrumb segments={[
-          { label: 'Tools', href: '/' },
+          { label: projectSource.rootLabel, href: projectSource.rootHref },
           { label: name || 'Untitled', editable: true, onEdit: (v) => setName(v) },
         ]} />
         <div className="flex items-center gap-1 text-[11px] text-text-muted">
@@ -131,6 +151,34 @@ export default function ToolPage() {
           <Download className="w-3 h-3" />
           Export SVG
         </a>
+      </div>
+
+      <div className="absolute top-14 left-3.5 z-20 glass-toolbar px-3 py-2 min-w-[220px] max-w-[280px]">
+        <div className="flex items-center gap-1.5 text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">
+          <Folder className="w-3 h-3" />
+          Projects
+        </div>
+        <div className="mt-1.5 space-y-1">
+          {toolProjects.length > 0 ? (
+            toolProjects.map(project => (
+              <Link
+                key={project.id}
+                href={`/projects/${project.id}`}
+                className="block rounded-[7px] px-2 py-1 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors truncate"
+                title={project.name}
+              >
+                <span className="block truncate">{project.name}</span>
+                {project.toolCount !== undefined && project.binCount !== undefined && (
+                  <span className="block text-[10px] text-text-muted">
+                    {project.toolCount} tool{project.toolCount !== 1 ? 's' : ''} · {project.binCount} bin{project.binCount !== 1 ? 's' : ''}
+                  </span>
+                )}
+              </Link>
+            ))
+          ) : (
+            <p className="px-2 py-1 text-[11px] text-text-muted">No projects assigned</p>
+          )}
+        </div>
       </div>
 
       {/* editor fills the entire area */}

--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { ArrowUpDown, ChevronDown, ChevronRight, Search } from 'lucide-react'
+
+export function SectionHeader({ title, count, search, onSearchChange, sortKey, onSortChange, collapsed, onToggleCollapsed, children }: {
+  title: string
+  count?: number
+  search?: string
+  onSearchChange?: (v: string) => void
+  sortKey?: string
+  onSortChange?: (v: string) => void
+  collapsed?: boolean
+  onToggleCollapsed?: () => void
+  children?: ReactNode
+}) {
+  const [searchOpen, setSearchOpen] = useState(false)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (searchOpen) searchRef.current?.focus()
+  }, [searchOpen])
+
+  return (
+    <div className="flex items-center justify-between mb-3 gap-2">
+      {onToggleCollapsed ? (
+        <button
+          onClick={onToggleCollapsed}
+          className="flex items-center gap-1.5 flex-shrink-0 text-text-muted hover:text-text-secondary transition-colors cursor-pointer"
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? <ChevronRight className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+          <h3 className="text-[10px] font-semibold uppercase tracking-[1.5px]">{title}</h3>
+          {count !== undefined && count > 0 && (
+            <span className="text-[10px] text-text-muted bg-elevated px-1.5 py-px rounded-full tracking-normal">{count}</span>
+          )}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">{title}</h3>
+          {count !== undefined && count > 0 && (
+            <span className="text-[10px] text-text-muted bg-elevated px-1.5 py-px rounded-full">{count}</span>
+          )}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5">
+        {onSearchChange && (
+          searchOpen ? (
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted" />
+              <input
+                ref={searchRef}
+                type="text"
+                value={search || ''}
+                onChange={e => onSearchChange(e.target.value)}
+                onBlur={() => { if (!search) setSearchOpen(false) }}
+                onKeyDown={e => { if (e.key === 'Escape') { onSearchChange(''); setSearchOpen(false) } }}
+                placeholder="Filter..."
+                className="w-36 pl-6 pr-2 py-1 text-[11px] bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setSearchOpen(true)}
+              className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
+            >
+              <Search className="w-3 h-3" />
+              Search
+            </button>
+          )
+        )}
+        {onSortChange && (
+          <button
+            onClick={() => onSortChange(sortKey === 'name' ? 'date' : 'name')}
+            className="glass-sm rounded-[7px] px-2.5 py-1 text-[11px] text-text-secondary flex items-center gap-1.5 hover:bg-glass-hover transition-colors cursor-pointer"
+          >
+            <ArrowUpDown className="w-3 h-3" />
+            {sortKey === 'name' ? 'A-Z' : 'Recent'}
+          </button>
+        )}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ToolBrowser.tsx
+++ b/frontend/src/components/ToolBrowser.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { Plus, Loader2, Search } from 'lucide-react'
-import { listTools } from '@/lib/api'
-import type { ToolSummary, PlacedTool, Point } from '@/types'
+import { getProject, listTools } from '@/lib/api'
+import type { BinProject, ToolSummary, PlacedTool, Point } from '@/types'
 import { getTool } from '@/lib/api'
 import { polygonPathData } from '@/lib/svg'
 
@@ -12,6 +12,8 @@ interface Props {
   binWidthMm: number
   binHeightMm: number
   layout?: 'grid' | 'horizontal'
+  projectId?: string | null
+  currentToolIds?: string[]
 }
 
 function ToolThumbnail({ points, interiorRings }: { points: Point[]; interiorRings?: Point[][] }) {
@@ -40,29 +42,52 @@ function ToolThumbnail({ points, interiorRings }: { points: Point[]; interiorRin
       <path
         d={pathData}
         fillRule="evenodd"
-        fill="rgb(100, 116, 139)"
-        stroke="rgb(148, 163, 184)"
+        fill="var(--color-tool-fill)"
+        stroke="var(--color-tool-stroke)"
         strokeWidth={Math.max(vw, vh) * 0.015}
       />
     </svg>
   )
 }
 
-export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid' }: Props) {
+export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid', projectId, currentToolIds = [] }: Props) {
   const [tools, setTools] = useState<ToolSummary[]>([])
+  const [project, setProject] = useState<BinProject | null>(null)
   const [loading, setLoading] = useState(true)
   const [adding, setAdding] = useState<string | null>(null)
   const [search, setSearch] = useState('')
+  const [showPlaced, setShowPlaced] = useState(false)
+
+  const projectToolIds = useMemo(() => new Set(project?.tool_ids || []), [project])
+  const placedToolIds = useMemo(() => {
+    return new Set([...(project?.placed_tool_ids || []), ...currentToolIds])
+  }, [project, currentToolIds])
+
+  const visibleTools = useMemo(() => {
+    let list = projectId ? tools.filter(tool => projectToolIds.has(tool.id)) : tools
+    if (projectId && !showPlaced) list = list.filter(tool => !placedToolIds.has(tool.id))
+    return list
+  }, [tools, projectId, projectToolIds, placedToolIds, showPlaced])
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return tools
+    if (!search.trim()) return visibleTools
     const q = search.toLowerCase()
-    return tools.filter(t => t.name.toLowerCase().includes(q))
-  }, [tools, search])
+    return visibleTools.filter(t => t.name.toLowerCase().includes(q))
+  }, [visibleTools, search])
 
   useEffect(() => {
-    listTools().then(setTools).catch(() => {}).finally(() => setLoading(false))
-  }, [])
+    setLoading(true)
+    Promise.all([
+      listTools(),
+      projectId ? getProject(projectId).catch(() => null) : Promise.resolve(null),
+    ])
+      .then(([toolList, projectData]) => {
+        setTools(toolList)
+        setProject(projectData)
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [projectId])
 
   async function handleAdd(toolSummary: ToolSummary) {
     setAdding(toolSummary.id)
@@ -126,7 +151,16 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
         {/* header with label + inline filter */}
         <div className="flex items-center gap-2">
           <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">Library</h3>
-          <span className="text-[10px] text-text-muted bg-elevated px-1.5 py-px rounded-full">{tools.length}</span>
+          <span className="text-[10px] text-text-muted bg-elevated px-1.5 py-px rounded-full">{visibleTools.length}</span>
+          {projectId && (
+            <button
+              onClick={() => setShowPlaced(prev => !prev)}
+              className="text-[10px] text-text-secondary glass-sm rounded-[7px] px-1.5 py-px hover:bg-glass-hover transition-colors cursor-pointer"
+              title="Show project tools already placed in bins."
+            >
+              {showPlaced ? 'Hide placed' : 'Show placed'}
+            </button>
+          )}
           {tools.length > 4 && (
             <div className="relative ml-auto">
               <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted" />
@@ -135,7 +169,7 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
                 value={search}
                 onChange={e => setSearch(e.target.value)}
                 placeholder="Filter..."
-                className="w-24 pl-6 pr-2 py-1 text-[10px] bg-elevated border border-border-subtle rounded text-text-primary outline-none focus:border-accent focus:w-36 transition-all"
+                className="w-24 pl-6 pr-2 py-1 text-[10px] bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent focus:w-36 transition-all"
               />
             </div>
           )}
@@ -147,7 +181,7 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
               key={tool.id}
               onClick={() => handleAdd(tool)}
               disabled={adding === tool.id}
-              className="group flex-shrink-0 w-[90px] glass-sm rounded-lg overflow-hidden text-left transition-all duration-150 hover:bg-glass-hover cursor-pointer"
+              className="group flex-shrink-0 w-[90px] glass-sm rounded-[8px] overflow-hidden text-left transition-all duration-150 hover:bg-glass-hover cursor-pointer"
             >
               <div className="h-[52px] p-1.5 flex items-center justify-center bg-inset/30 relative">
                 {adding === tool.id ? (
@@ -155,6 +189,9 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
                 ) : (
                   <>
                     <ToolThumbnail points={tool.points} interiorRings={tool.interior_rings} />
+                    {projectId && placedToolIds.has(tool.id) && (
+                      <span className="absolute top-1 left-1 rounded-[7px] bg-accent-muted px-1 py-px text-[9px] text-accent">Placed</span>
+                    )}
                     <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/30">
                       <Plus className="w-4 h-4 text-white" />
                     </div>
@@ -168,6 +205,9 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
           ))}
           {filtered.length === 0 && search && (
             <span className="text-[10px] text-text-muted py-2 flex-shrink-0">No matches</span>
+          )}
+          {filtered.length === 0 && !search && projectId && (
+            <span className="text-[10px] text-text-muted py-2 flex-shrink-0">No unplaced project tools</span>
           )}
         </div>
       </div>
@@ -184,7 +224,7 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Filter tools..."
-            className="w-full pl-6 pr-2 py-1.5 text-xs bg-elevated border border-border-subtle rounded text-text-primary outline-none focus:border-accent"
+            className="w-full pl-6 pr-2 py-1.5 text-xs bg-elevated border border-border-subtle rounded-[7px] text-text-primary outline-none focus:border-accent"
           />
         </div>
       )}
@@ -194,13 +234,18 @@ export function ToolBrowser({ onAddTool, binWidthMm, binHeightMm, layout = 'grid
           key={tool.id}
           onClick={() => handleAdd(tool)}
           disabled={adding === tool.id}
-          className="group relative bg-elevated hover:bg-border rounded overflow-hidden text-left transition-colors cursor-pointer"
+          className="group relative bg-elevated hover:bg-border rounded-[8px] overflow-hidden text-left transition-colors cursor-pointer"
         >
           <div className="aspect-square p-2 flex items-center justify-center bg-inset/50">
             {adding === tool.id ? (
               <Loader2 className="w-5 h-5 animate-spin text-text-muted" />
             ) : (
-              <ToolThumbnail points={tool.points} interiorRings={tool.interior_rings} />
+              <>
+                <ToolThumbnail points={tool.points} interiorRings={tool.interior_rings} />
+                {projectId && placedToolIds.has(tool.id) && (
+                  <span className="absolute top-1 left-1 rounded-[7px] bg-accent-muted px-1 py-px text-[9px] text-accent">Placed</span>
+                )}
+              </>
             )}
           </div>
           <div className="px-1.5 py-1 flex items-center justify-between gap-1">

--- a/frontend/src/components/ToolSummaryItem.tsx
+++ b/frontend/src/components/ToolSummaryItem.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { Wrench } from 'lucide-react'
+import { getImageUrl } from '@/lib/api'
+import type { ToolSummary } from '@/types'
+import type { ReactNode } from 'react'
+
+type ThumbnailSize = 'xs' | 'sm' | 'md'
+
+const thumbnailClasses: Record<ThumbnailSize, string> = {
+  xs: 'w-7 h-7 rounded-[8px]',
+  sm: 'w-8 h-8 rounded-[8px]',
+  md: 'w-14 h-14 rounded-[8px]',
+}
+
+const iconClasses: Record<ThumbnailSize, string> = {
+  xs: 'w-3.5 h-3.5',
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+}
+
+export function ToolSummaryItem({ tool, size = 'md', showPoints = true, className = '', children }: {
+  tool: ToolSummary
+  size?: ThumbnailSize
+  showPoints?: boolean
+  className?: string
+  children?: ReactNode
+}) {
+  return (
+    <span className={`min-w-0 flex items-center gap-2 ${className}`}>
+      <span className={`${thumbnailClasses[size]} bg-inset flex items-center justify-center overflow-hidden flex-shrink-0`}>
+        {tool.thumbnail_url ? (
+          <img src={getImageUrl(tool.thumbnail_url)} alt="" className="w-full h-full object-contain p-0.5" />
+        ) : (
+          <Wrench className={`${iconClasses[size]} text-text-muted`} />
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className={`${size === 'xs' ? 'text-[10px] text-text-secondary' : size === 'sm' ? 'text-[11px]' : 'text-xs'} block text-text-primary truncate`}>
+          {tool.name}
+        </span>
+        {showPoints && size !== 'xs' && (
+          <span className="block text-[10px] text-text-muted">{tool.point_count} points</span>
+        )}
+        {children}
+      </span>
+    </span>
+  )
+}
+
+export function ToolSummaryButton({ tool, onClick, size = 'sm', className = '' }: {
+  tool: ToolSummary
+  onClick: () => void
+  size?: ThumbnailSize
+  className?: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-2 text-left rounded-[7px] hover:bg-glass-hover transition-colors cursor-pointer ${size === 'sm' ? 'h-9' : 'h-8'} ${className}`}
+    >
+      <ToolSummaryItem tool={tool} size={size} showPoints={size !== 'xs'} />
+    </button>
+  )
+}

--- a/frontend/src/hooks/useDeleteConfirmation.ts
+++ b/frontend/src/hooks/useDeleteConfirmation.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+
+export function useDeleteConfirmation<T>() {
+  const [target, setTarget] = useState<T | null>(null)
+
+  return {
+    deleteTarget: target,
+    requestDelete: setTarget,
+    clearDelete: () => setTarget(null),
+  }
+}

--- a/frontend/src/hooks/useProjectSource.ts
+++ b/frontend/src/hooks/useProjectSource.ts
@@ -1,0 +1,14 @@
+import { useSearchParams } from 'next/navigation'
+import { projectScopedHref } from '@/lib/projectNavigation'
+
+export function useProjectSource(defaultLabel: string, defaultHref = '/') {
+  const searchParams = useSearchParams()
+  const projectId = searchParams.get('from') === 'project' ? searchParams.get('projectId') : null
+
+  return {
+    projectId,
+    rootLabel: projectId ? 'Projects' : defaultLabel,
+    rootHref: projectId ? `/projects/${projectId}` : defaultHref,
+    scopedHref: (path: string) => projectId ? projectScopedHref(projectId, path) : path,
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,10 @@ import type {
   SessionSummary,
   Tool,
   ToolSummary,
+  BinProject,
+  BinProjectSummary,
+  ProjectHealthResponse,
+  ProjectStatus,
   BinData,
   BinSummary,
   PlacedTool,
@@ -224,6 +228,93 @@ export async function saveToolsFromSession(sessionId: string, polygonIds?: strin
     body: polygonIds ? JSON.stringify({ polygon_ids: polygonIds }) : undefined,
   })
   return res.tool_ids
+}
+
+// --- projects ---
+
+export async function listProjects(): Promise<BinProjectSummary[]> {
+  const res = await fetchApi<{ projects: BinProjectSummary[] }>('/api/bin-projects')
+  return res.projects
+}
+
+export async function createProject(opts: {
+  name: string
+  description?: string | null
+  status?: ProjectStatus
+  tool_ids?: string[]
+}): Promise<BinProject> {
+  return fetchApi('/api/bin-projects', {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  })
+}
+
+export async function getProject(projectId: string): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}`)
+}
+
+export async function updateProject(
+  projectId: string,
+  updates: {
+    name?: string
+    description?: string | null
+    status?: ProjectStatus
+    notes?: string | null
+    target_grid_x?: number | null
+    target_grid_y?: number | null
+  }
+): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(updates),
+  })
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  await fetchApi(`/api/bin-projects/${projectId}`, { method: 'DELETE' })
+}
+
+export async function addToolsToProject(projectId: string, toolIds: string[]): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}/tools`, {
+    method: 'POST',
+    body: JSON.stringify({ tool_ids: toolIds }),
+  })
+}
+
+export async function removeToolFromProject(projectId: string, toolId: string): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}/tools/${toolId}`, { method: 'DELETE' })
+}
+
+export async function getProjectHealth(projectId: string): Promise<ProjectHealthResponse> {
+  return fetchApi(`/api/bin-projects/${projectId}/health`)
+}
+
+export async function repairProject(projectId: string): Promise<ProjectHealthResponse> {
+  return fetchApi(`/api/bin-projects/${projectId}/repair`, { method: 'POST' })
+}
+
+export async function addBinsToProject(
+  projectId: string,
+  opts: { bin_ids: string[]; import_tools?: boolean; allow_reassign?: boolean }
+): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}/bins`, {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  })
+}
+
+export async function detachBinFromProject(projectId: string, binId: string): Promise<BinProject> {
+  return fetchApi(`/api/bin-projects/${projectId}/bins/${binId}`, { method: 'DELETE' })
+}
+
+export async function createProjectBin(
+  projectId: string,
+  opts: { name?: string | null; tool_ids?: string[] | null } = {}
+): Promise<BinData> {
+  return fetchApi(`/api/bin-projects/${projectId}/create-bin`, {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  })
 }
 
 // --- bins ---

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -188,7 +188,21 @@ export async function getTool(toolId: string): Promise<Tool> {
 
 export async function updateTool(
   toolId: string,
-  updates: { name?: string; points?: Point[]; finger_holes?: import('@/types').FingerHole[]; interior_rings?: Point[][]; smoothed?: boolean; smooth_level?: number; source_image_transform?: import('@/types').AffineMatrix }
+  updates: {
+    name?: string
+    points?: Point[]
+    finger_holes?: import('@/types').FingerHole[]
+    interior_rings?: Point[][]
+    smoothed?: boolean
+    smooth_level?: number
+    source_image_transform?: import('@/types').AffineMatrix
+    category?: string | null
+    drawer?: string | null
+    tags?: string[]
+    project_ids?: string[]
+    review_status?: string | null
+    needs_cleanup?: boolean
+  }
 ): Promise<void> {
   await fetchApi(`/api/tools/${toolId}`, {
     method: 'PUT',
@@ -223,7 +237,7 @@ export async function getBin(binId: string): Promise<BinData> {
   return fetchApi(`/api/bins/${binId}`)
 }
 
-export async function createBin(opts: { name?: string; tool_ids?: string[] } = {}): Promise<BinData> {
+export async function createBin(opts: { name?: string; project_id?: string | null; tool_ids?: string[] } = {}): Promise<BinData> {
   return fetchApi('/api/bins', {
     method: 'POST',
     body: JSON.stringify(opts),
@@ -234,6 +248,7 @@ export async function updateBin(
   binId: string,
   updates: {
     name?: string
+    project_id?: string | null
     bin_config?: BinConfig
     placed_tools?: PlacedTool[]
     text_labels?: TextLabel[]

--- a/frontend/src/lib/projectNavigation.ts
+++ b/frontend/src/lib/projectNavigation.ts
@@ -1,0 +1,3 @@
+export function projectScopedHref(projectId: string, path: string) {
+  return `${path}?from=project&projectId=${projectId}`
+}

--- a/frontend/src/lib/projectSelectors.ts
+++ b/frontend/src/lib/projectSelectors.ts
@@ -1,0 +1,109 @@
+import type { BinProject, BinProjectSummary, BinSummary, ProjectStatus, ToolSummary } from '@/types'
+
+export const projectStatusLabels: Record<ProjectStatus, string> = {
+  active: 'Active',
+  ready_to_print: 'Ready to print',
+  printed: 'Printed',
+  archived: 'Archived',
+}
+
+export function binLabel(bin: BinSummary) {
+  return bin.name || `Bin ${bin.id.slice(0, 8)}`
+}
+
+export function toolProjectLabel(
+  projectIds: string[],
+  projectNameById: Map<string, string>,
+) {
+  if (projectIds.length === 0) return null
+  if (projectIds.length > 1) return `${projectIds.length} Projects`
+  return projectNameById.get(projectIds[0]) || 'Project'
+}
+
+export function toolProjectTitle(
+  projectIds: string[],
+  projectNameById: Map<string, string>,
+) {
+  if (projectIds.length === 0) return undefined
+  return projectIds.map(projectId => projectNameById.get(projectId) || 'Project').join(', ')
+}
+
+export function projectNameMap(projects: BinProjectSummary[]) {
+  return new Map(projects.map(project => [project.id, project.name]))
+}
+
+export type ProjectToolFilter = 'all' | 'unplaced' | 'placed'
+
+export function getProjectCollections(
+  project: BinProject | null,
+  tools: ToolSummary[],
+  bins: BinSummary[],
+  options: {
+    projectSearch: string
+    addToolSearch: string
+    statusFilter: ProjectToolFilter
+    allowReassignBins: boolean
+  },
+) {
+  const projectToolIds = new Set(project?.tool_ids || [])
+  const placedToolIds = new Set(project?.placed_tool_ids || [])
+  const unplacedToolIds = new Set(project?.unplaced_tool_ids || [])
+  const projectTools = tools.filter(tool => projectToolIds.has(tool.id))
+  const projectBins = project
+    ? bins.filter(bin => bin.project_id === project.id || project.bin_ids.includes(bin.id))
+    : []
+  const projectBinIds = new Set(projectBins.map(bin => bin.id))
+  const toolById = new Map(tools.map(tool => [tool.id, tool]))
+
+  let filteredProjectTools = projectTools
+  if (options.statusFilter === 'unplaced') {
+    filteredProjectTools = filteredProjectTools.filter(tool => unplacedToolIds.has(tool.id))
+  }
+  if (options.statusFilter === 'placed') {
+    filteredProjectTools = filteredProjectTools.filter(tool => placedToolIds.has(tool.id))
+  }
+  if (options.projectSearch.trim()) {
+    const q = options.projectSearch.toLowerCase()
+    filteredProjectTools = filteredProjectTools.filter(tool => tool.name.toLowerCase().includes(q))
+  }
+
+  const toolBins = new Map<string, BinSummary[]>()
+  for (const bin of projectBins) {
+    for (const toolId of bin.tool_ids || []) {
+      const current = toolBins.get(toolId) || []
+      current.push(bin)
+      toolBins.set(toolId, current)
+    }
+  }
+
+  const existingBinOptions = bins.filter(bin => (
+    !projectBinIds.has(bin.id) && (options.allowReassignBins || !bin.project_id)
+  ))
+
+  let availableTools = tools.filter(tool => !projectToolIds.has(tool.id))
+  if (options.addToolSearch.trim()) {
+    const q = options.addToolSearch.toLowerCase()
+    availableTools = availableTools.filter(tool => tool.name.toLowerCase().includes(q))
+  }
+
+  const actionableVisibleToolIds = project
+    ? filteredProjectTools
+      .filter(tool => !placedToolIds.has(tool.id))
+      .map(tool => tool.id)
+    : []
+
+  return {
+    projectToolIds,
+    placedToolIds,
+    unplacedToolIds,
+    projectTools,
+    filteredProjectTools,
+    projectBins,
+    projectBinIds,
+    toolById,
+    toolBins,
+    existingBinOptions,
+    availableTools,
+    actionableVisibleToolIds,
+  }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -166,6 +166,67 @@ export interface ToolSummary {
   needs_cleanup: boolean
 }
 
+// --- projects ---
+
+export type ProjectStatus = 'active' | 'ready_to_print' | 'printed' | 'archived'
+export type ProjectHealthSeverity = 'warning' | 'error'
+export type ProjectHealthCode =
+  | 'missing_tool'
+  | 'missing_bin'
+  | 'bin_missing_project_id'
+  | 'bin_project_mismatch'
+  | 'outside_tool'
+  | 'tool_missing_project_id'
+  | 'tool_extra_project_id'
+
+export interface BinProject {
+  id: string
+  name: string
+  description: string | null
+  status: ProjectStatus
+  tool_ids: string[]
+  bin_ids: string[]
+  placed_tool_ids: string[]
+  unplaced_tool_ids: string[]
+  target_grid_x: number | null
+  target_grid_y: number | null
+  default_bin_config: BinConfig | null
+  notes: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface BinProjectSummary {
+  id: string
+  name: string
+  description: string | null
+  status: ProjectStatus
+  tool_count: number
+  bin_count: number
+  placed_count: number
+  unplaced_count: number
+  target_grid_x: number | null
+  target_grid_y: number | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface ProjectHealthIssue {
+  code: ProjectHealthCode
+  severity: ProjectHealthSeverity
+  message: string
+  tool_id: string | null
+  bin_id: string | null
+  other_project_id: string | null
+  repairable: boolean
+}
+
+export interface ProjectHealthResponse {
+  issues: ProjectHealthIssue[]
+  repairable_count: number
+  manual_count: number
+}
+
 // --- bins ---
 
 export interface PlacedTool {
@@ -200,6 +261,7 @@ export interface BinSummary {
   name: string | null
   project_id: string | null
   created_at: string | null
+  tool_ids: string[]
   tool_count: number
   has_stl: boolean
   grid_x: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -125,6 +125,12 @@ export interface Tool {
   smooth_level: number
   source_session_id: string | null
   image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
   created_at: string | null
 }
 
@@ -152,6 +158,12 @@ export interface ToolSummary {
   thumbnail_url: string | null
   image_transform: AffineMatrix | null
   image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
 }
 
 // --- bins ---
@@ -170,6 +182,7 @@ export interface PlacedTool {
 export interface BinData {
   id: string
   name: string | null
+  project_id: string | null
   bin_config: BinConfig
   placed_tools: PlacedTool[]
   text_labels: TextLabel[]
@@ -185,6 +198,7 @@ export interface BinPreviewTool {
 export interface BinSummary {
   id: string
   name: string | null
+  project_id: string | null
   created_at: string | null
   tool_count: number
   has_stl: boolean


### PR DESCRIPTION
## Intent

`This is a big change to the app so I understand if you don't want to incorporate all or parts of this change. I am happy to make changes to this or keep my fork separate.`

Depends on #44.

This PR adds a project planning workflow for larger drawer/workspace builds. A project groups related tools and bins, tracks which project tools have already been placed in linked bins, and makes it easier to create bins from the remaining tools.

The workflow is intentionally derived from real bin contents: per-tool project status is not manually maintained. A tool is `Placed` when it appears in a bin linked to the project; otherwise it still needs a bin.

## Summary

- Adds bin projects with tool/bin linking.
- Adds project dashboard cards, search, status filters, and collapsible sections.
- Adds a project detail page for managing project tools and linked bins.
- Adds project-scoped bin creation and bin/tool navigation.
- Shows project membership on tool cards and tool detail pages.
- Adds project health/repair endpoints for link mismatches.
- Updates README, API docs, architecture docs, and repo instructions to mention projects.

## Technical changes by file

- `.gitignore`: ignores `.agents/` local Codex/plugin workspace files.
- `CLAUDE.md`: documents that bin projects are part of the app workflow.
- `README.md`: updates the “How it works” flow and feature list with bin projects.
- `docs/api.md`: documents `/api/bin-projects` endpoints.
- `docs/architecture.md`: documents project persistence, project services, project page, and project data model.
- `backend/app/models/schemas.py`: adds `BinProject`, project summary/detail/request/health schemas, plus project links on tools/bins.
- `backend/app/api/routes.py`: adds project CRUD, tool/bin linking, project bin creation, project health/repair, and project-aware bin/tool responses.
- `backend/app/services/project_service.py`: centralizes project summaries, derived placed/unplaced state, link health, and safe repairs.
- `backend/app/services/project_store.py`: adds JSON persistence for `projects.json`.
- `backend/tests/test_bin_projects.py`: covers project defaults, persistence, derived placement, project bin creation, health/repair, and link behavior.
- `frontend/src/app/page.tsx`: adds Projects to the dashboard, project search/status filters, collapsible dashboard sections, and project-aware tool/bin metadata.
- `frontend/src/app/projects/[id]/page.tsx`: adds the project detail workflow for project tools, add tools, linked bins, project bin creation, project status, health repair, and collapsible sections.
- `frontend/src/app/bins/[id]/page.tsx`: supports project-scoped bin context and tool placement updates.
- `frontend/src/app/tools/[id]/page.tsx`: shows project membership on the tool detail page and preserves project navigation context.
- `frontend/src/components/SectionHeader.tsx`: adds reusable search/sort/collapse header controls.
- `frontend/src/components/ToolBrowser.tsx`: filters bin tool picker by project, hides placed project tools by default, and adds tooltip for “Show placed”.
- `frontend/src/components/ToolSummaryItem.tsx`: adds shared compact tool summary rendering.
- `frontend/src/hooks/useDeleteConfirmation.ts`: adds reusable delete confirmation state.
- `frontend/src/hooks/useProjectSource.ts`: tracks project-origin navigation for breadcrumbs.
- `frontend/src/lib/api.ts`: adds project API client methods and project-aware bin/tool request types.
- `frontend/src/lib/projectNavigation.ts`: adds helper for project-scoped links.
- `frontend/src/lib/projectSelectors.ts`: adds project labels, status labels, derived project collections, and filtering helpers.
- `frontend/src/types/index.ts`: adds frontend project, project health, and project-aware bin/tool types.
- `frontend/src/app/globals.css`: standardizes small shared UI colors/classes used by project cards and warnings.

## Verification

- `npm exec -- tsc --noEmit`
- `pytest tests/test_bin_projects.py tests/test_workflow_metadata.py`

## Review note

This branch is stacked on #44. Checking out `feature/bin-projects` gives both #44 and this project workflow together for local testing.

Code and PR drafted with Codex

<img width="1932" height="2112" alt="image" src="https://github.com/user-attachments/assets/f092ce3b-8f53-4f80-a6e9-cc9e76e57742" />
