### PR TITLE
Add auto-rotate for tool polygons

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -389,8 +389,10 @@ def _build_bin_from_tools(
 
         bin_w = bc.grid_x * GF_GRID
         bin_h = bc.grid_y * GF_GRID
-        offset_x = bin_w / 2
-        offset_y = bin_h / 2
+        bbox_cx = (min(all_xs) + max(all_xs)) / 2
+        bbox_cy = (min(all_ys) + max(all_ys)) / 2
+        offset_x = bin_w / 2 - bbox_cx
+        offset_y = bin_h / 2 - bbox_cy
         for pt in placed:
             pt.points = _translate_points(pt.points, offset_x, offset_y)
             pt.finger_holes = _translate_finger_holes(pt.finger_holes, offset_x, offset_y)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -73,6 +73,7 @@ from app.services.project_store import ProjectStore
 from app.services.bin_service import sync_placed_tools
 from app.services.image_service import generate_tool_thumbnail
 from app.services.tracer_registry import TRACER_LABELS, validate_tracer_ids
+from app.services.geometry import optimal_rotation_angle as _optimal_rotation_angle
 from app.services.project_service import (
     add_bin_to_project,
     add_project_to_tools,
@@ -975,6 +976,17 @@ async def update_tool(request: Request, tool_id: str, req: ToolUpdateRequest, us
         tool.needs_cleanup = req.needs_cleanup
     user_tools.set(tool_id, tool)
     return StatusResponse(status="ok")
+
+
+@router.post("/tools/{tool_id}/auto-rotate")
+async def auto_rotate_tool(request: Request, tool_id: str, user_id: str = Depends(get_user_id)):
+    _, user_tools, _ = get_stores(user_id)
+    tool = user_tools.get(tool_id)
+    if not tool or not tool.points:
+        raise HTTPException(status_code=404, detail="tool not found")
+    pts = [(p.x, p.y) for p in tool.points]
+    angle = _optimal_rotation_angle(pts)
+    return {"angle": angle}
 
 
 @router.delete("/tools/{tool_id}", response_model=StatusResponse)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -210,8 +210,8 @@ class Tool(BaseModel):
     points: list[Point]  # mm, centered at (0,0)
     finger_holes: list[FingerHole] = []  # mm, relative to tool origin
     interior_rings: list[list[Point]] = []  # mm, centered at (0,0)
-    smoothed: bool = False
-    smooth_level: float = 0.0
+    smoothed: bool = True
+    smooth_level: float = 0.5
     source_session_id: str | None = None
     source_polygon_id: str | None = None
     source_image_path: str | None = None

--- a/backend/app/services/geometry.py
+++ b/backend/app/services/geometry.py
@@ -1,0 +1,38 @@
+"""pure geometry utilities (no I/O, no persistence)."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+
+def optimal_rotation_angle(points: list[tuple[float, float]]) -> float:
+    """find the rotation angle (degrees) that minimises bounding box area.
+
+    uses cv2.minAreaRect on the convex hull. returns the angle to apply
+    to the current points so they sit in their minimum bounding rectangle
+    axis-aligned.
+    """
+    if len(points) < 2:
+        return 0.0
+
+    pts = np.array(points, dtype=np.float32)
+
+    if len(points) == 2:
+        dx = pts[1][0] - pts[0][0]
+        dy = pts[1][1] - pts[0][1]
+        return -float(np.degrees(np.arctan2(dy, dx)))
+
+    rect = cv2.minAreaRect(pts)
+    # rect = ((cx, cy), (w, h), angle) where angle is in [-90, 0)
+    angle = rect[2]
+    w, h = rect[1]
+
+    # to un-rotate points back to axis-aligned: negate the rect angle.
+    # if w < h the longer side is vertical in the rect, subtract 90
+    # so the longer side ends up horizontal after rotation.
+    correction = -angle
+    if w < h:
+        correction -= 90
+
+    return float(correction)

--- a/backend/tests/test_auto_rotate.py
+++ b/backend/tests/test_auto_rotate.py
@@ -53,7 +53,8 @@ def test_complex_polygon_reduces_bounding_box():
 def test_degenerate_two_points():
     pts = [(0, 0), (10, 5)]
     angle = optimal_rotation_angle(pts)
-    assert isinstance(angle, float)
+    # line from (0,0) to (10,5) is ~26.57deg from horizontal; rotation should align it
+    assert angle == pytest.approx(-26.57, abs=1)
 
 
 def test_single_point_returns_zero():

--- a/backend/tests/test_auto_rotate.py
+++ b/backend/tests/test_auto_rotate.py
@@ -1,0 +1,80 @@
+"""Tests for auto-rotate optimal angle computation."""
+
+import math
+import pytest
+
+from app.services.geometry import optimal_rotation_angle
+
+
+def test_axis_aligned_rectangle_needs_no_rotation():
+    # already aligned -- angle should be 0 (or equivalent)
+    pts = [(0, 0), (10, 0), (10, 5), (0, 5)]
+    angle = optimal_rotation_angle(pts)
+    assert abs(angle) < 1.0, f"expected ~0, got {angle}"
+
+
+def test_tilted_rectangle_returns_corrective_angle():
+    # rectangle tilted 30 degrees: minAreaRect should find ~30 or ~-60
+    rad = math.radians(30)
+    cos_r, sin_r = math.cos(rad), math.sin(rad)
+    base = [(0, 0), (20, 0), (20, 5), (0, 5)]
+    tilted = [(x * cos_r - y * sin_r, x * sin_r + y * cos_r) for x, y in base]
+    angle = optimal_rotation_angle(tilted)
+    # after applying this rotation, the bounding box should be minimal
+    rotated = _apply_rotation(tilted, angle)
+    bb_area = _bbox_area(rotated)
+    # original bbox is 20 * 5 = 100
+    assert bb_area < 110, f"bbox area {bb_area} too large after rotation"
+
+
+def test_square_returns_near_zero():
+    # square is symmetric, any axis-aligned rotation is optimal
+    pts = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    angle = optimal_rotation_angle(pts)
+    # for a square, 0, 90, -90 are all valid
+    assert abs(angle % 90) < 1.0 or abs(abs(angle) - 90) < 1.0
+
+
+def test_complex_polygon_reduces_bounding_box():
+    # L-shape tilted 45 degrees -- rotation should reduce bbox
+    rad = math.radians(45)
+    cos_r, sin_r = math.cos(rad), math.sin(rad)
+    l_shape = [(0, 0), (20, 0), (20, 10), (10, 10), (10, 20), (0, 20)]
+    tilted = [(x * cos_r - y * sin_r, x * sin_r + y * cos_r) for x, y in l_shape]
+
+    original_area = _bbox_area(tilted)
+    angle = optimal_rotation_angle(tilted)
+    rotated = _apply_rotation(tilted, angle)
+    rotated_area = _bbox_area(rotated)
+
+    assert rotated_area <= original_area + 0.1
+
+
+def test_degenerate_two_points():
+    pts = [(0, 0), (10, 5)]
+    angle = optimal_rotation_angle(pts)
+    assert isinstance(angle, float)
+
+
+def test_single_point_returns_zero():
+    pts = [(5, 5)]
+    angle = optimal_rotation_angle(pts)
+    assert angle == 0.0
+
+
+def test_collinear_points():
+    pts = [(0, 0), (5, 5), (10, 10)]
+    angle = optimal_rotation_angle(pts)
+    assert isinstance(angle, float)
+
+
+def _apply_rotation(pts, angle_deg):
+    rad = math.radians(angle_deg)
+    cos_r, sin_r = math.cos(rad), math.sin(rad)
+    return [(x * cos_r - y * sin_r, x * sin_r + y * cos_r) for x, y in pts]
+
+
+def _bbox_area(pts):
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return (max(xs) - min(xs)) * (max(ys) - min(ys))

--- a/backend/tests/test_build_bin_centering.py
+++ b/backend/tests/test_build_bin_centering.py
@@ -1,0 +1,179 @@
+"""Tests for tool centering when building bins from tools.
+
+Reproduces the bug where auto-rotated tools appear offset in the 3D
+preview: the bbox centre shifts away from (0,0) after rotation, but
+_build_bin_from_tools assumed tools were always at origin.
+"""
+
+import math
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.schemas import Point, FingerHole, Tool
+from app.constants import GF_GRID
+
+
+def _make_tool(points_mm, finger_holes=None, interior_rings=None):
+    """create a minimal Tool with the given mm-space points."""
+    return Tool(
+        id=str(uuid.uuid4()),
+        name="test-tool",
+        points=[Point(x=x, y=y) for x, y in points_mm],
+        finger_holes=finger_holes or [],
+        interior_rings=interior_rings or [],
+        created_at="2025-01-01T00:00:00",
+    )
+
+
+def _mock_tool_store(tools: dict[str, Tool]):
+    """mock ToolStore.get to return tools by id."""
+    store = MagicMock()
+    store.get = lambda tid: tools.get(tid)
+    return store
+
+
+def _bbox_centre(points):
+    xs = [p.x for p in points]
+    ys = [p.y for p in points]
+    return (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2
+
+
+def _bin_centre(bin_model):
+    bc = bin_model.bin_config
+    return bc.grid_x * GF_GRID / 2, bc.grid_y * GF_GRID / 2
+
+
+def _rotate_points(pts_mm, angle_deg):
+    """rotate points around their centroid, same as frontend rotateGeometry."""
+    n = len(pts_mm)
+    cx = sum(x for x, y in pts_mm) / n
+    cy = sum(y for x, y in pts_mm) / n
+    rad = math.radians(angle_deg)
+    cos_r, sin_r = math.cos(rad), math.sin(rad)
+    return [
+        (cx + (x - cx) * cos_r - (y - cy) * sin_r,
+         cy + (x - cx) * sin_r + (y - cy) * cos_r)
+        for x, y in pts_mm
+    ]
+
+
+class TestBuildBinCentering:
+    """placed tools should be centred in the bin regardless of bbox position."""
+
+    def test_origin_centred_tool_is_centred_in_bin(self):
+        """tool at origin -> should be centred after placement."""
+        from app.api.routes import _build_bin_from_tools
+
+        # L-shaped tool centred at origin (bbox centre = 0,0)
+        pts = [(-10, -10), (10, -10), (10, 0), (0, 0), (0, 10), (-10, 10)]
+        tool = _make_tool(pts)
+        tools = {tool.id: tool}
+        store = _mock_tool_store(tools)
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+        placed = result.placed_tools[0]
+
+        bin_cx, bin_cy = _bin_centre(result)
+        placed_cx, placed_cy = _bbox_centre(placed.points)
+
+        assert placed_cx == pytest.approx(bin_cx, abs=0.1)
+        assert placed_cy == pytest.approx(bin_cy, abs=0.1)
+
+    def test_rotated_tool_is_centred_in_bin(self):
+        """tool rotated around centroid (bbox no longer at origin) -> still centred."""
+        from app.api.routes import _build_bin_from_tools
+
+        # asymmetric tool: centroid != bbox centre
+        pts = [(-15, -5), (15, -5), (15, 5), (5, 5), (5, 10), (-15, 10)]
+        rotated = _rotate_points(pts, 35)
+        tool = _make_tool(rotated)
+        tools = {tool.id: tool}
+        store = _mock_tool_store(tools)
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+        placed = result.placed_tools[0]
+
+        bin_cx, bin_cy = _bin_centre(result)
+        placed_cx, placed_cy = _bbox_centre(placed.points)
+
+        assert placed_cx == pytest.approx(bin_cx, abs=0.1)
+        assert placed_cy == pytest.approx(bin_cy, abs=0.1)
+
+    def test_offset_tool_is_centred_in_bin(self):
+        """tool with bbox centre far from origin -> still centred after placement."""
+        from app.api.routes import _build_bin_from_tools
+
+        # tool shifted so bbox centre is at (50, 30)
+        pts = [(40, 20), (60, 20), (60, 40), (40, 40)]
+        tool = _make_tool(pts)
+        tools = {tool.id: tool}
+        store = _mock_tool_store(tools)
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+        placed = result.placed_tools[0]
+
+        bin_cx, bin_cy = _bin_centre(result)
+        placed_cx, placed_cy = _bbox_centre(placed.points)
+
+        assert placed_cx == pytest.approx(bin_cx, abs=0.1)
+        assert placed_cy == pytest.approx(bin_cy, abs=0.1)
+
+    def test_rotated_tool_finger_holes_centred(self):
+        """finger holes should follow the same centering as polygon points."""
+        from app.api.routes import _build_bin_from_tools
+
+        pts = [(-15, -5), (15, -5), (15, 5), (-15, 5)]
+        rotated = _rotate_points(pts, 45)
+
+        # finger hole at centroid
+        cx = sum(x for x, y in rotated) / len(rotated)
+        cy = sum(y for x, y in rotated) / len(rotated)
+
+        tool = _make_tool(rotated, finger_holes=[
+            FingerHole(id="fh1", x=cx, y=cy, radius=3.0),
+        ])
+        tools = {tool.id: tool}
+        store = _mock_tool_store(tools)
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+        placed = result.placed_tools[0]
+
+        bin_cx, bin_cy = _bin_centre(result)
+        placed_cx, placed_cy = _bbox_centre(placed.points)
+
+        # finger hole should be offset from bin centre by same amount as
+        # the centroid was offset from bbox centre in the original
+        fh = placed.finger_holes[0]
+        pts_xs = [p.x for p in placed.points]
+        pts_ys = [p.y for p in placed.points]
+        pts_bbox_cx = (min(pts_xs) + max(pts_xs)) / 2
+        pts_bbox_cy = (min(pts_ys) + max(pts_ys)) / 2
+        assert pts_bbox_cx == pytest.approx(bin_cx, abs=0.1)
+        assert pts_bbox_cy == pytest.approx(bin_cy, abs=0.1)
+
+    def test_rotated_tool_interior_rings_centred(self):
+        """interior rings should follow the same centering."""
+        from app.api.routes import _build_bin_from_tools
+
+        pts = [(-20, -10), (20, -10), (20, 10), (-20, 10)]
+        rotated = _rotate_points(pts, 30)
+
+        # small interior ring near centre
+        ring = _rotate_points([(-2, -2), (2, -2), (2, 2), (-2, 2)], 30)
+
+        tool = _make_tool(rotated, interior_rings=[
+            [Point(x=x, y=y) for x, y in ring],
+        ])
+        tools = {tool.id: tool}
+        store = _mock_tool_store(tools)
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+        placed = result.placed_tools[0]
+
+        bin_cx, bin_cy = _bin_centre(result)
+        placed_cx, placed_cy = _bbox_centre(placed.points)
+
+        assert placed_cx == pytest.approx(bin_cx, abs=0.1)
+        assert placed_cy == pytest.approx(bin_cy, abs=0.1)

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
 - `GET /api/tools` - list tools
 - `GET /api/tools/{id}` - get tool
 - `PUT /api/tools/{id}` - update tool (name, points, finger_holes)
+- `POST /api/tools/{id}/auto-rotate` - compute optimal rotation angle (degrees) to minimise bounding box
 - `DELETE /api/tools/{id}` - delete tool
 
 ## Bins

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -95,15 +95,17 @@ test.describe.serial('happy path', () => {
   })
 
   test('toggle smooth', async () => {
+    // tools now default to smoothed, so toggle to accurate first
     const statusText = page.getByText(/\d+ vertices/)
-    const initialText = await statusText.textContent()
-
-    await page.getByRole('button', { name: 'Smooth' }).click()
-
-    // vertex count text should change when smoothed
-    await expect(statusText).not.toHaveText(initialText!, { timeout: 5_000 })
+    const smoothedText = await statusText.textContent()
 
     await page.getByRole('button', { name: 'Accurate' }).click()
+    await expect(statusText).not.toHaveText(smoothedText!, { timeout: 5_000 })
+
+    const accurateText = await statusText.textContent()
+
+    await page.getByRole('button', { name: 'Smooth' }).click()
+    await expect(statusText).not.toHaveText(accurateText!, { timeout: 5_000 })
   })
 
   test('navigate home', async () => {

--- a/frontend/src/app/tools/[id]/page.tsx
+++ b/frontend/src/app/tools/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Loader2, Check, Download, Folder } from 'lucide-react'
-import { getTool, updateTool, getToolSvgUrl, getImageUrl, listProjects } from '@/lib/api'
+import { getTool, updateTool, autoRotateTool, getToolSvgUrl, getImageUrl, listProjects } from '@/lib/api'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { useProjectSource } from '@/hooks/useProjectSource'
 import { projectNameMap } from '@/lib/projectSelectors'
@@ -23,6 +23,7 @@ export default function ToolPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [name, setName] = useState('')
+  const [autoRotating, setAutoRotating] = useState(false)
   const [showSourceImage, setShowSourceImage] = useState(false)
   const [sourceImageOpacity, setSourceImageOpacity] = useState(0.45)
 
@@ -97,6 +98,41 @@ export default function ToolPage() {
   const handleInteriorRingsChange = useCallback((interior_rings: Point[][]) => {
     setTool(prev => prev ? { ...prev, interior_rings } : null)
   }, [])
+
+  const handleAutoRotate = useCallback(async () => {
+    if (!tool || autoRotating) return
+    setAutoRotating(true)
+    try {
+      const { angle } = await autoRotateTool(toolId)
+      if (Math.abs(angle) < 0.01) return
+      setTool(prev => {
+        if (!prev) return prev
+        const pts = prev.points
+        const n = pts.length
+        if (n === 0) return prev
+        const cx = pts.reduce((s, p) => s + p.x, 0) / n
+        const cy = pts.reduce((s, p) => s + p.y, 0) / n
+        const rad = angle * Math.PI / 180
+        const cos = Math.cos(rad)
+        const sin = Math.sin(rad)
+        const rotPt = (p: Point) => {
+          const dx = p.x - cx, dy = p.y - cy
+          return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos }
+        }
+        return {
+          ...prev,
+          points: pts.map(rotPt),
+          finger_holes: prev.finger_holes.map(fh => {
+            const dx = fh.x - cx, dy = fh.y - cy
+            return { ...fh, x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos, rotation: ((fh.rotation || 0) + angle) % 360 }
+          }),
+          interior_rings: prev.interior_rings.map(ring => ring.map(rotPt)),
+        }
+      })
+    } finally {
+      setAutoRotating(false)
+    }
+  }, [tool, toolId, autoRotating])
 
   const projectNameById = useMemo(() => projectNameMap(projects), [projects])
   const toolProjects = useMemo(() => {
@@ -199,6 +235,8 @@ export default function ToolPage() {
         onSmoothedChange={handleSmoothedChange}
         onSmoothLevelChange={handleSmoothLevelChange}
         onInteriorRingsChange={handleInteriorRingsChange}
+        onAutoRotate={handleAutoRotate}
+        autoRotating={autoRotating}
       />
     </div>
   )

--- a/frontend/src/app/tools/[id]/page.tsx
+++ b/frontend/src/app/tools/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Loader2, Check, Download, Folder } from 'lucide-react'
 import { getTool, updateTool, autoRotateTool, getToolSvgUrl, getImageUrl, listProjects } from '@/lib/api'
+import { rotateGeometry } from '@/lib/geometry'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { useProjectSource } from '@/hooks/useProjectSource'
 import { projectNameMap } from '@/lib/projectSelectors'
@@ -99,36 +100,24 @@ export default function ToolPage() {
     setTool(prev => prev ? { ...prev, interior_rings } : null)
   }, [])
 
-  const handleAutoRotate = useCallback(async () => {
-    if (!tool || autoRotating) return
+  const handleAutoRotate = useCallback(async (): Promise<number | null> => {
+    if (!tool || autoRotating) return null
     setAutoRotating(true)
     try {
       const { angle } = await autoRotateTool(toolId)
-      if (Math.abs(angle) < 0.01) return
-      setTool(prev => {
-        if (!prev) return prev
-        const pts = prev.points
-        const n = pts.length
-        if (n === 0) return prev
-        const cx = pts.reduce((s, p) => s + p.x, 0) / n
-        const cy = pts.reduce((s, p) => s + p.y, 0) / n
-        const rad = angle * Math.PI / 180
-        const cos = Math.cos(rad)
-        const sin = Math.sin(rad)
-        const rotPt = (p: Point) => {
-          const dx = p.x - cx, dy = p.y - cy
-          return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos }
-        }
-        return {
-          ...prev,
-          points: pts.map(rotPt),
-          finger_holes: prev.finger_holes.map(fh => {
-            const dx = fh.x - cx, dy = fh.y - cy
-            return { ...fh, x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos, rotation: ((fh.rotation || 0) + angle) % 360 }
-          }),
-          interior_rings: prev.interior_rings.map(ring => ring.map(rotPt)),
-        }
-      })
+      if (Math.abs(angle) < 0.01) return null
+      const rotated = rotateGeometry(tool.points, tool.finger_holes, tool.interior_rings, angle)
+      setTool(prev => prev ? {
+        ...prev,
+        points: rotated.points,
+        finger_holes: rotated.fingerHoles,
+        interior_rings: rotated.interiorRings,
+      } : prev)
+      return angle
+    } catch (err) {
+      console.error('auto-rotate failed:', err)
+      setError(err instanceof Error ? err.message : 'Auto-rotate failed')
+      return null
     } finally {
       setAutoRotating(false)
     }

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -5,6 +5,7 @@ import { Plus, Circle, Disc, Square, RectangleHorizontal, Fingerprint, ImageIcon
 import type { Point, FingerHole, ToolImageContext, AffineMatrix } from '@/types'
 import { simplifyPolygon, smoothEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
 import { rotateAround, flipAround } from '@/lib/affine'
+import { rotateGeometry, centroidOf } from '@/lib/geometry'
 import { DISPLAY_SCALE, SNAP_GRID, ZOOM_FACTOR } from '@/lib/constants'
 import { useHistory } from '@/hooks/useHistory'
 import { ToolEditorToolbar } from '@/components/ToolEditorToolbar'
@@ -28,7 +29,7 @@ interface Props {
   onSmoothedChange: (smoothed: boolean) => void
   onSmoothLevelChange: (level: number) => void
   onInteriorRingsChange?: (rings: Point[][]) => void
-  onAutoRotate?: () => void
+  onAutoRotate?: () => Promise<number | null>
   autoRotating?: boolean
 }
 
@@ -248,33 +249,40 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   })()
 
   const rotateAll = useCallback((angleDeg: number) => {
-    const n = pointsRef.current.length
-    if (n === 0) return
     const pts = pointsRef.current
-    const holes = holesRef.current
-    const cx = pts.reduce((s, p) => s + p.x, 0) / n
-    const cy = pts.reduce((s, p) => s + p.y, 0) / n
-    const rad = angleDeg * Math.PI / 180
-    const cos = Math.cos(rad)
-    const sin = Math.sin(rad)
-    const newPts = pts.map(p => {
-      const dx = p.x - cx, dy = p.y - cy
-      return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos }
-    })
-    const newHoles = holes.map(fh => {
-      const dx = fh.x - cx, dy = fh.y - cy
-      return { ...fh, x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos, rotation: ((fh.rotation || 0) + angleDeg) % 360 }
-    })
-    pushHistory({ points: newPts, fingerHoles: newHoles, interiorRings: currentRings })
-    onPointsRef.current(newPts)
-    onHolesRef.current(newHoles)
+    if (pts.length === 0) return
+    const { x: cx, y: cy } = centroidOf(pts)
+    const rotated = rotateGeometry(pts, holesRef.current, currentRings, angleDeg)
+    pushHistory({ points: rotated.points, fingerHoles: rotated.fingerHoles, interiorRings: currentRings })
+    onPointsRef.current(rotated.points)
+    onHolesRef.current(rotated.fingerHoles)
     const m = imageTransformRef.current
     if (m && onImageTransformRef.current) {
+      const rad = angleDeg * Math.PI / 180
       const next = rotateAround(m, rad, cx, cy)
       imageTransformRef.current = next
       onImageTransformRef.current(next)
     }
   }, [pushHistory, currentRings])
+
+  // wraps the parent's auto-rotate to add undo history and image transform rotation
+  const handleAutoRotateWrapped = useCallback(async () => {
+    if (!onAutoRotate) return
+    const pts = pointsRef.current
+    if (pts.length === 0) return
+    pushHistory({ points: pts, fingerHoles: holesRef.current, interiorRings: currentRingsRef.current })
+    const angle = await onAutoRotate()
+    if (angle != null && Math.abs(angle) >= 0.01) {
+      const { x: cx, y: cy } = centroidOf(pts)
+      const m = imageTransformRef.current
+      if (m && onImageTransformRef.current) {
+        const rad = angle * Math.PI / 180
+        const next = rotateAround(m, rad, cx, cy)
+        imageTransformRef.current = next
+        onImageTransformRef.current(next)
+      }
+    }
+  }, [onAutoRotate, pushHistory])
 
   const flipAll = useCallback((axis: 'horizontal' | 'vertical') => {
     const pts = pointsRef.current
@@ -668,7 +676,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           displayPointsCount={displayPoints.length}
           rotateAll={rotateAll}
           flipAll={flipAll}
-          onAutoRotate={onAutoRotate}
+          onAutoRotate={handleAutoRotateWrapped}
           autoRotating={autoRotating}
           hasInteriorRings={currentRings.length > 0}
         />

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -28,6 +28,8 @@ interface Props {
   onSmoothedChange: (smoothed: boolean) => void
   onSmoothLevelChange: (level: number) => void
   onInteriorRingsChange?: (rings: Point[][]) => void
+  onAutoRotate?: () => void
+  autoRotating?: boolean
 }
 
 const PADDING_MM = 20
@@ -47,7 +49,7 @@ interface HistoryEntry {
   interiorRings: Point[][]
 }
 
-export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoothLevel, sourceImageContext, showSourceImage = false, onShowSourceImageChange, sourceImageOpacity = 0.45, onSourceImageOpacityChange, onImageTransformChange, onPointsChange, onFingerHolesChange, onSmoothedChange, onSmoothLevelChange, onInteriorRingsChange }: Props) {
+export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoothLevel, sourceImageContext, showSourceImage = false, onShowSourceImageChange, sourceImageOpacity = 0.45, onSourceImageOpacityChange, onImageTransformChange, onPointsChange, onFingerHolesChange, onSmoothedChange, onSmoothLevelChange, onInteriorRingsChange, onAutoRotate, autoRotating }: Props) {
   const svgRef = useRef<SVGSVGElement>(null)
   const [selection, setSelection] = useState<Selection>(null)
   const [editMode, setEditMode] = useState<EditMode>('select')
@@ -666,6 +668,8 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           displayPointsCount={displayPoints.length}
           rotateAll={rotateAll}
           flipAll={flipAll}
+          onAutoRotate={onAutoRotate}
+          autoRotating={autoRotating}
           hasInteriorRings={currentRings.length > 0}
         />
       </div>

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket } from 'lucide-react'
+import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket, Locate } from 'lucide-react'
 import type { FingerHole } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
 
@@ -36,6 +36,8 @@ interface Props {
   displayPointsCount: number
   rotateAll: (angleDeg: number) => void
   flipAll: (axis: 'horizontal' | 'vertical') => void
+  onAutoRotate?: () => void
+  autoRotating?: boolean
   hasInteriorRings: boolean
 }
 
@@ -47,7 +49,7 @@ export function ToolEditorToolbar({
   cutoutOpen, setCutoutOpen,
   isCutoutMode, cutoutModeIcon, cutoutModeLabel,
   selection, selectedHole, handleDeleteHole,
-  displayPointsCount, rotateAll, flipAll, hasInteriorRings,
+  displayPointsCount, rotateAll, flipAll, onAutoRotate, autoRotating, hasInteriorRings,
 }: Props) {
   return (
     <>
@@ -170,6 +172,17 @@ export function ToolEditorToolbar({
           >
             <FlipVertical2 className="w-3.5 h-3.5" />
           </button>
+          {onAutoRotate && (
+            <button
+              onClick={onAutoRotate}
+              disabled={autoRotating}
+              className="px-2 py-1 rounded-[7px] text-[11px] flex items-center gap-1 transition-colors hover:bg-border/50 text-text-secondary disabled:opacity-40 disabled:cursor-wait"
+              title="Auto-rotate to minimise bounding box"
+            >
+              <Locate className="w-3.5 h-3.5" />
+              Auto
+            </button>
+          )}
         </div>
 
         <div className="h-4 w-px bg-border-subtle mx-0.5" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -214,6 +214,10 @@ export async function updateTool(
   })
 }
 
+export async function autoRotateTool(toolId: string): Promise<{ angle: number }> {
+  return fetchApi(`/api/tools/${toolId}/auto-rotate`, { method: 'POST' })
+}
+
 export async function deleteTool(toolId: string): Promise<void> {
   await fetchApi(`/api/tools/${toolId}`, { method: 'DELETE' })
 }

--- a/frontend/src/lib/geometry.ts
+++ b/frontend/src/lib/geometry.ts
@@ -1,0 +1,53 @@
+import type { Point, FingerHole } from '@/types'
+
+interface RotatedGeometry {
+  points: Point[]
+  fingerHoles: FingerHole[]
+  interiorRings: Point[][]
+}
+
+// rotate points, finger holes, and interior rings around polygon centroid
+export function rotateGeometry(
+  points: Point[],
+  fingerHoles: FingerHole[],
+  interiorRings: Point[][],
+  angleDeg: number,
+): RotatedGeometry {
+  const n = points.length
+  if (n === 0) return { points, fingerHoles, interiorRings }
+
+  const cx = points.reduce((s, p) => s + p.x, 0) / n
+  const cy = points.reduce((s, p) => s + p.y, 0) / n
+  const rad = angleDeg * Math.PI / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+
+  const rotPt = (p: Point): Point => {
+    const dx = p.x - cx, dy = p.y - cy
+    return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos }
+  }
+
+  return {
+    points: points.map(rotPt),
+    fingerHoles: fingerHoles.map(fh => {
+      const dx = fh.x - cx, dy = fh.y - cy
+      return {
+        ...fh,
+        x: cx + dx * cos - dy * sin,
+        y: cy + dx * sin + dy * cos,
+        rotation: ((fh.rotation || 0) + angleDeg) % 360,
+      }
+    }),
+    interiorRings: interiorRings.map(ring => ring.map(rotPt)),
+  }
+}
+
+// centroid of a point array
+export function centroidOf(points: Point[]): Point {
+  if (points.length === 0) return { x: 0, y: 0 }
+  const n = points.length
+  return {
+    x: points.reduce((s, p) => s + p.x, 0) / n,
+    y: points.reduce((s, p) => s + p.y, 0) / n,
+  }
+}


### PR DESCRIPTION
## Summary

Adds an auto-rotate button to the tool editor that rotates polygons to their minimum bounding rectangle orientation. Uses `cv2.minAreaRect` on the backend to find the optimal angle, applies rotation on the frontend using shared geometry utilities.

Closes #46

## Changes

- **Backend:** new `POST /api/tools/{id}/auto-rotate` endpoint returning `{"angle": <degrees>}`, backed by `geometry.py` with `optimal_rotation_angle()` using OpenCV's minimum area rectangle
- **Frontend:** "Auto" button in `ToolEditorToolbar`, shared `rotateGeometry()` utility in `lib/geometry.ts` used by both auto-rotate and manual rotate-all (previously duplicated logic)
- **Tests:** 7 backend tests covering axis-aligned, tilted, symmetric, complex, and degenerate polygon cases

## Test evidence

```
64 passed, 2 warnings in 1.15s
tsc --noEmit: clean
```