### PR TITLE
Add default bin settings

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -51,6 +51,7 @@ from app.models.schemas import (
     BinProjectToolsRequest,
     BinProjectCreateBinRequest,
     BinProjectBinsRequest,
+    BinDefaults,
     ProjectHealthResponse,
     PlacedTool,
     BinModel,
@@ -350,7 +351,7 @@ def _build_bin_from_tools(
     project_id: str | None,
     tool_ids: list[str],
     user_tools: ToolStore,
-    default_config: BinConfig | None = None,
+    default_config: BinDefaults | None = None,
 ) -> BinModel:
     placed: list[PlacedTool] = []
     all_points_mm: list[tuple[float, float]] = []
@@ -1391,7 +1392,7 @@ async def create_bin_from_project(
         project_id=project_id,
         tool_ids=tool_ids,
         user_tools=user_tools,
-        default_config=project.default_bin_config,
+        default_config=req.bin_config or project.default_bin_config,
     )
     user_bins.set(bin_id, bin_data)
     add_bin_to_project(project_store, project_id, bin_id)
@@ -1448,6 +1449,7 @@ async def create_bin(request: Request, req: CreateBinRequest, user_id: str = Dep
         project_id=req.project_id,
         tool_ids=req.tool_ids,
         user_tools=user_tools,
+        default_config=req.bin_config,
     )
     user_bins.set(bin_id, bin_data)
     add_bin_to_project(project_store, req.project_id, bin_id)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -371,7 +371,7 @@ def _build_bin_from_tools(
             interior_rings=list(tool.interior_rings),
         ))
 
-    bc = BinConfig.model_validate(default_config.model_dump()) if default_config else BinConfig()
+    bc = BinConfig(**default_config.model_dump(exclude={"text_labels"}), text_labels=[]) if default_config else BinConfig()
     if all_points_mm:
         all_xs = [p[0] for p in all_points_mm]
         all_ys = [p[1] for p in all_points_mm]

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -137,10 +137,13 @@ class BinParams(BaseModel):
         return v
 
 
-class GenerateRequest(BinParams):
+class BinDefaults(BinParams):
+    bed_size: float = 256.0  # mm, 0 = no splitting
+
+
+class GenerateRequest(BinDefaults):
     polygons: list[Polygon] | None = None  # optional: use these instead of session polygons
     text_labels: list[TextLabel] = []
-    bed_size: float = 256.0  # mm, 0 = no splitting
 
 
 class GenerateResponse(BaseModel):
@@ -303,7 +306,7 @@ class BinProject(BaseModel):
     bin_ids: list[str] = []
     target_grid_x: int | None = None
     target_grid_y: int | None = None
-    default_bin_config: BinParams | None = None
+    default_bin_config: BinDefaults | None = None
     notes: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
@@ -338,7 +341,7 @@ class BinProjectCreateRequest(BaseModel):
     status: ProjectStatus = "active"
     target_grid_x: int | None = None
     target_grid_y: int | None = None
-    default_bin_config: BinParams | None = None
+    default_bin_config: BinDefaults | None = None
     notes: str | None = None
     tool_ids: list[str] = []
 
@@ -349,7 +352,7 @@ class BinProjectUpdateRequest(BaseModel):
     status: ProjectStatus | None = None
     target_grid_x: int | None = None
     target_grid_y: int | None = None
-    default_bin_config: BinParams | None = None
+    default_bin_config: BinDefaults | None = None
     notes: str | None = None
 
 
@@ -360,6 +363,7 @@ class BinProjectToolsRequest(BaseModel):
 class BinProjectCreateBinRequest(BaseModel):
     name: str | None = None
     tool_ids: list[str] | None = None
+    bin_config: BinDefaults | None = None
 
 
 class BinProjectBinsRequest(BaseModel):
@@ -397,9 +401,8 @@ class PlacedTool(BaseModel):
     depth_override: float | None = None  # mm; None = use bin_config.cutout_depth
 
 
-class BinConfig(BinParams):
+class BinConfig(BinDefaults):
     text_labels: list[TextLabel] = []
-    bed_size: float = 256.0
 
 
 class BinModel(BaseModel):
@@ -446,3 +449,4 @@ class CreateBinRequest(BaseModel):
     name: str | None = None
     project_id: str | None = None
     tool_ids: list[str] = []  # pre-place these tools
+    bin_config: BinDefaults | None = None

--- a/backend/tests/test_bin_projects.py
+++ b/backend/tests/test_bin_projects.py
@@ -199,6 +199,34 @@ def test_project_placed_status_updates_when_bin_contents_change(tmp_path, monkey
     assert detail["unplaced_tool_ids"] == ["tool-1"]
 
 
+def test_project_update_round_trips_default_bin_config(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    project = client.post("/api/bin-projects", json={"name": "Top drawer"}).json()
+
+    update_resp = client.patch(f"/api/bin-projects/{project['id']}", json={
+        "default_bin_config": {
+            "magnet_diameter": 6.2,
+            "magnet_depth": 2.8,
+            "magnet_corners_only": True,
+            "bed_size": 220,
+        },
+    })
+
+    assert update_resp.status_code == 200
+    updated_config = update_resp.json()["default_bin_config"]
+    assert updated_config["magnet_diameter"] == 6.2
+    assert updated_config["magnet_depth"] == 2.8
+    assert updated_config["magnet_corners_only"] is True
+    assert updated_config["bed_size"] == 220
+    detail_config = client.get(f"/api/bin-projects/{project['id']}").json()["default_bin_config"]
+    assert detail_config == updated_config
+
+    clear_resp = client.patch(f"/api/bin-projects/{project['id']}", json={"default_bin_config": None})
+
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["default_bin_config"] is None
+
+
 def test_create_bin_accepts_default_bin_config(tmp_path, monkeypatch):
     client = _api_client(tmp_path, monkeypatch)
 

--- a/backend/tests/test_bin_projects.py
+++ b/backend/tests/test_bin_projects.py
@@ -66,21 +66,28 @@ def test_project_requests_support_clearable_fields():
     create_req = BinProjectCreateRequest(
         name="Top drawer",
         tool_ids=["tool-1"],
-        default_bin_config=BinConfig(grid_x=4, grid_y=3),
+        default_bin_config=BinConfig(grid_x=4, grid_y=3, magnet_diameter=6.2, bed_size=220),
     )
     update_req = BinProjectUpdateRequest(description=None, notes=None, target_grid_x=None)
     tools_req = BinProjectToolsRequest(tool_ids=["tool-1", "tool-2"])
     bins_req = BinProjectBinsRequest(bin_ids=["bin-1"], import_tools=True)
-    bin_req = BinProjectCreateBinRequest(name="Top drawer bin", tool_ids=["tool-1"])
+    bin_req = BinProjectCreateBinRequest(
+        name="Top drawer bin",
+        tool_ids=["tool-1"],
+        bin_config=BinConfig(magnet_diameter=6.4, bed_size=210),
+    )
 
     assert create_req.tool_ids == ["tool-1"]
     assert create_req.default_bin_config.grid_x == 4
+    assert create_req.default_bin_config.magnet_diameter == 6.2
+    assert create_req.default_bin_config.bed_size == 220
     assert "description" in update_req.model_fields_set
     assert "notes" in update_req.model_fields_set
     assert "target_grid_x" in update_req.model_fields_set
     assert tools_req.tool_ids == ["tool-1", "tool-2"]
     assert bins_req.import_tools is True
     assert bin_req.tool_ids == ["tool-1"]
+    assert bin_req.bin_config.magnet_diameter == 6.4
 
 
 def test_project_store_round_trips(tmp_path):
@@ -190,6 +197,58 @@ def test_project_placed_status_updates_when_bin_contents_change(tmp_path, monkey
 
     assert detail["placed_tool_ids"] == []
     assert detail["unplaced_tool_ids"] == ["tool-1"]
+
+
+def test_create_bin_accepts_default_bin_config(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+
+    resp = client.post("/api/bins", json={
+        "name": "Magnet test",
+        "bin_config": {
+            "magnet_diameter": 6.2,
+            "magnet_depth": 2.8,
+            "magnet_corners_only": True,
+            "bed_size": 220,
+        },
+    })
+
+    assert resp.status_code == 200
+    bin_config = resp.json()["bin_config"]
+    assert bin_config["magnet_diameter"] == 6.2
+    assert bin_config["magnet_depth"] == 2.8
+    assert bin_config["magnet_corners_only"] is True
+    assert bin_config["bed_size"] == 220
+
+
+def test_project_create_bin_uses_request_config_before_project_default(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    _seed_tool("tool-1")
+
+    project = client.post("/api/bin-projects", json={
+        "name": "Top drawer",
+        "tool_ids": ["tool-1"],
+        "default_bin_config": {"magnet_diameter": 6.2, "bed_size": 220},
+    }).json()
+
+    project_default_resp = client.post(
+        f"/api/bin-projects/{project['id']}/create-bin",
+        json={"tool_ids": ["tool-1"]},
+    )
+    override_resp = client.post(
+        f"/api/bin-projects/{project['id']}/create-bin",
+        json={
+            "name": "Override bin",
+            "tool_ids": ["tool-1"],
+            "bin_config": {"magnet_diameter": 6.4, "bed_size": 210},
+        },
+    )
+
+    assert project_default_resp.status_code == 200
+    assert project_default_resp.json()["bin_config"]["magnet_diameter"] == 6.2
+    assert project_default_resp.json()["bin_config"]["bed_size"] == 220
+    assert override_resp.status_code == 200
+    assert override_resp.json()["bin_config"]["magnet_diameter"] == 6.4
+    assert override_resp.json()["bin_config"]["bed_size"] == 210
 
 
 def test_project_health_reports_and_repairs_safe_link_mismatches(tmp_path):

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@
 ## Bins
 - `GET /api/bins` - list bins
 - `GET /api/bins/{id}` - get bin (syncs placed tools with library versions)
-- `POST /api/bins` - create bin (optionally with tool_ids for auto-sizing)
+- `POST /api/bins` - create bin (optionally with tool_ids for auto-sizing and bin_config defaults)
 - `PUT /api/bins/{id}` - update bin
 - `DELETE /api/bins/{id}` - delete bin + output files
 - `POST /api/bins/{id}/generate` - generate STL/3MF from bin
@@ -37,7 +37,7 @@
 - `DELETE /api/bin-projects/{id}/tools/{tool_id}` - remove a tool from a project
 - `POST /api/bin-projects/{id}/bins` - link existing bins to a project
 - `DELETE /api/bin-projects/{id}/bins/{bin_id}` - detach a bin from a project
-- `POST /api/bin-projects/{id}/create-bin` - create a new bin from selected project tools
+- `POST /api/bin-projects/{id}/create-bin` - create a new bin from selected project tools, using project or request bin defaults
 - `GET /api/bin-projects/{id}/health` - report project/tool/bin link mismatches
 - `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ tracefinity/
 - **Tool**: a single traced polygon + finger holes, stored in mm, centred at origin. Lives in a persistent library (`tools.json`).
 - **PlacedTool**: a positioned copy of a tool in a bin. Points/holes in bin-space mm. Has `tool_id` linking back to source.
 - **Bin**: bin config + placed tools + text labels. Used for STL generation (`bins.json`).
-- **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`).
+- **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`). Projects can carry default bin settings used when creating project bins.
 - **Session**: ephemeral, used only for upload/trace workflow. Output is tools saved to library via `save-tools`.
 
 PlacedTools sync with their library source on bin load (`GET /bins/{id}`) via `bin_service.sync_placed_tools()`. Edits to a tool's points, finger holes, or name propagate to all bins that use it. The position offset is preserved.

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -7,7 +7,7 @@ import { BinConfigurator, calcMaxCutoutDepth } from '@/components/BinConfigurato
 import { BinPreview3D } from '@/components/BinPreview3D'
 import { ToolBrowser } from '@/components/ToolBrowser'
 import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
-import { getSettings } from '@/lib/settings'
+import { getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from '@/lib/binDefaults'
 import type { BinConfig, BinData, PlacedTool, TextLabel } from '@/types'
 import { Download, Loader2, Package, ChevronDown, Check } from 'lucide-react'
 import { Breadcrumb } from '@/components/Breadcrumb'
@@ -24,27 +24,6 @@ function InfoBanner({ children }: { children: React.ReactNode }) {
   )
 }
 
-function defaultConfig(): BinConfig {
-  return {
-    grid_x: 2,
-    grid_y: 2,
-    height_units: 4,
-    magnets: true,
-    magnet_diameter: 6.0,
-    magnet_depth: 2.4,
-    magnet_corners_only: false,
-    stacking_lip: true,
-    wall_thickness: 1.6,
-    cutout_depth: 20,
-    cutout_clearance: 1.0,
-    cutout_chamfer: 0,
-    insert_enabled: false,
-    insert_height: 1.0,
-    text_labels: [],
-    bed_size: getSettings().bedSize,
-  }
-}
-
 export default function BinPage() {
   const router = useRouter()
   const params = useParams()
@@ -54,7 +33,7 @@ export default function BinPage() {
   const [binData, setBinData] = useState<BinData | null>(null)
   const [placedTools, setPlacedTools] = useState<PlacedTool[]>([])
   const [textLabels, setTextLabels] = useState<TextLabel[]>([])
-  const [config, setConfig] = useState<BinConfig>(defaultConfig)
+  const [config, setConfig] = useState<BinConfig>(() => getDefaultBinConfig())
   const [name, setName] = useState('')
   const [stlUrl, setStlUrl] = useState<string | null>(null)
   const [stlUrls, setStlUrls] = useState<string[]>([])
@@ -79,6 +58,7 @@ export default function BinPage() {
   const [autoSize, setAutoSize] = useState(true)
   const [isDragging, setIsDragging] = useState(false)
   const [exportOpen, setExportOpen] = useState(false)
+  const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null)
   const exportRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -332,6 +312,16 @@ export default function BinPage() {
     window.open(getBinInsertUrl(binId), '_blank')
   }
 
+  function handleSaveDefaults() {
+    saveDefaultBinConfig(config)
+    setDefaultsStatus('Defaults saved')
+  }
+
+  function handleResetDefaults() {
+    setConfig(resetDefaultBinConfig())
+    setDefaultsStatus('Defaults reset')
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
@@ -371,6 +361,28 @@ export default function BinPage() {
               {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
             </div>
             <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
+            <div className="mt-3 border-t border-border pt-3 space-y-1.5">
+              <div className="flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={handleSaveDefaults}
+                  className="btn-secondary flex-1 px-2 py-1.5 text-[11px]"
+                >
+                  Save as default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleResetDefaults}
+                  className="btn-secondary px-2 py-1.5 text-[11px]"
+                  title="Reset this bin and saved defaults"
+                >
+                  Reset
+                </button>
+              </div>
+              {defaultsStatus && (
+                <p className="text-[10px] text-text-muted">{defaultsStatus}</p>
+              )}
+            </div>
           </div>
 
           <div className="glass rounded-[10px] px-3 py-3">

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -59,6 +59,7 @@ export default function BinPage() {
   const [isDragging, setIsDragging] = useState(false)
   const [exportOpen, setExportOpen] = useState(false)
   const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null)
+  const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const exportRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -178,7 +179,10 @@ export default function BinPage() {
   )
 
   useEffect(() => {
-    return () => { abortRef.current?.abort() }
+    return () => {
+      abortRef.current?.abort()
+      if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
+    }
   }, [])
 
   useEffect(() => {
@@ -312,14 +316,23 @@ export default function BinPage() {
     window.open(getBinInsertUrl(binId), '_blank')
   }
 
+  function showDefaultsStatus(message: string) {
+    if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
+    setDefaultsStatus(message)
+    defaultsStatusTimeoutRef.current = setTimeout(() => {
+      setDefaultsStatus(null)
+      defaultsStatusTimeoutRef.current = null
+    }, 2500)
+  }
+
   function handleSaveDefaults() {
     saveDefaultBinConfig(config)
-    setDefaultsStatus('Defaults saved')
+    showDefaultsStatus('Defaults saved')
   }
 
   function handleResetDefaults() {
     setConfig(resetDefaultBinConfig())
-    setDefaultsStatus('Defaults reset')
+    showDefaultsStatus('Defaults reset')
   }
 
   if (loading) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,6 +12,7 @@ import { Trash2, Package, Plus, Loader2, Grid3X3, Folder } from 'lucide-react'
 import { Alert } from '@/components/Alert'
 import { PhotoIllustration, CornersIllustration, TraceIllustration, OrganiseIllustration } from '@/components/OnboardingIllustrations'
 import { GRID_UNIT } from '@/lib/constants'
+import { getDefaultBinDefaults } from '@/lib/binDefaults'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
 import { projectNameMap, projectStatusLabels, toolProjectLabel, toolProjectTitle } from '@/lib/projectSelectors'
 
@@ -367,7 +368,7 @@ export default function HomePage() {
     if (sourceToolId) setCreatingBin(sourceToolId)
     setNameModal(null)
     try {
-      const bin = await createBin({ name, tool_ids: toolIds })
+      const bin = await createBin({ name, tool_ids: toolIds, bin_config: getDefaultBinDefaults() })
       router.push(`/bins/${bin.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'failed to create bin')

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -37,10 +37,11 @@ import {
 import { AlertTriangle, ArrowLeft, CheckSquare, ChevronDown, ChevronRight, Loader2, Package, Plus, Search, Square, Trash2, Unlink } from 'lucide-react'
 
 const PROJECT_SECTION_COLLAPSE_KEY = 'tracefinity.project.collapsedSections'
-type ProjectSectionId = 'projectTools' | 'linkedBins'
+type ProjectSectionId = 'binDefaults' | 'projectTools' | 'linkedBins'
 type ProjectSectionCollapseState = Record<ProjectSectionId, boolean>
 
 const defaultProjectSectionCollapse: ProjectSectionCollapseState = {
+  binDefaults: true,
   projectTools: false,
   linkedBins: false,
 }
@@ -296,7 +297,7 @@ export default function ProjectPage() {
       const bin = await createProjectBin(project.id, {
         name: `${project.name} bin ${projectBins.length + 1}`,
         tool_ids: Array.from(selectedBinToolIds),
-        bin_config: project.default_bin_config || getDefaultBinDefaults(),
+        ...(project.default_bin_config ? {} : { bin_config: getDefaultBinDefaults() }),
       })
       router.push(projectScopedHref(project.id, `/bins/${bin.id}`))
     } catch (err) {
@@ -429,40 +430,47 @@ export default function ProjectPage() {
 
       {error && <Alert variant="error">{error}</Alert>}
 
-      <section className="glass rounded-[8px] px-3 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">Bin defaults</h2>
-            <p className="mt-1 text-[11px] text-text-secondary">
-              {project.default_bin_config ? 'Project-specific defaults' : 'Using global defaults'}
-            </p>
+      <section>
+        <SectionHeader
+          title="Bin defaults"
+          collapsed={collapsedSections.binDefaults}
+          onToggleCollapsed={() => setSectionCollapsed('binDefaults', !collapsedSections.binDefaults)}
+        >
+          <span className="text-[11px] text-text-muted">
+            {project.default_bin_config ? 'Project-specific defaults' : 'Using global defaults'}
+          </span>
+          {!collapsedSections.binDefaults && (
+            <>
+              {projectDefaultsStatus && (
+                <span className="text-[10px] text-text-muted">{projectDefaultsStatus}</span>
+              )}
+              <button
+                type="button"
+                onClick={handleClearProjectDefaults}
+                disabled={savingProjectDefaults}
+                className="btn-secondary px-2 py-1 text-[11px]"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveProjectDefaults}
+                disabled={savingProjectDefaults}
+                className="btn-primary px-2.5 py-1 text-[11px] inline-flex items-center gap-1"
+              >
+                {savingProjectDefaults && <Loader2 className="w-3 h-3 animate-spin" />}
+                Save defaults
+              </button>
+            </>
+          )}
+        </SectionHeader>
+        {!collapsedSections.binDefaults && (
+          <div className="glass rounded-[8px] px-3 py-3">
+            <div className="max-w-sm">
+              <BinConfigurator config={projectDefaultConfig} onChange={setProjectDefaultConfig} />
+            </div>
           </div>
-          <div className="flex items-center gap-1.5">
-            {projectDefaultsStatus && (
-              <span className="text-[10px] text-text-muted">{projectDefaultsStatus}</span>
-            )}
-            <button
-              type="button"
-              onClick={handleClearProjectDefaults}
-              disabled={savingProjectDefaults}
-              className="btn-secondary px-2 py-1 text-[11px]"
-            >
-              Clear
-            </button>
-            <button
-              type="button"
-              onClick={handleSaveProjectDefaults}
-              disabled={savingProjectDefaults}
-              className="btn-primary px-2.5 py-1 text-[11px] inline-flex items-center gap-1"
-            >
-              {savingProjectDefaults && <Loader2 className="w-3 h-3 animate-spin" />}
-              Save defaults
-            </button>
-          </div>
-        </div>
-        <div className="mt-3 max-w-sm">
-          <BinConfigurator config={projectDefaultConfig} onChange={setProjectDefaultConfig} />
-        </div>
+        )}
       </section>
 
       {healthIssues.length > 0 && (

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -17,12 +17,14 @@ import {
   repairProject,
   updateProject,
 } from '@/lib/api'
-import type { BinProject, BinProjectSummary, BinSummary, ProjectHealthIssue, ProjectStatus, ToolSummary } from '@/types'
+import type { BinConfig, BinProject, BinProjectSummary, BinSummary, ProjectHealthIssue, ProjectStatus, ToolSummary } from '@/types'
 import { Alert } from '@/components/Alert'
+import { BinConfigurator } from '@/components/BinConfigurator'
 import { ConfirmModal } from '@/components/ConfirmModal'
 import { SectionHeader } from '@/components/SectionHeader'
 import { ToolSummaryButton, ToolSummaryItem } from '@/components/ToolSummaryItem'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
+import { binDefaultsFromConfig, buildBinConfig, getDefaultBinConfig, getDefaultBinDefaults } from '@/lib/binDefaults'
 import { projectScopedHref } from '@/lib/projectNavigation'
 import {
   binLabel,
@@ -76,6 +78,9 @@ export default function ProjectPage() {
   const [allowReassignBins, setAllowReassignBins] = useState(false)
   const [collapsedSections, setCollapsedSections] = useState<ProjectSectionCollapseState>(loadProjectSectionCollapseState)
   const [healthIssues, setHealthIssues] = useState<ProjectHealthIssue[]>([])
+  const [projectDefaultConfig, setProjectDefaultConfig] = useState<BinConfig>(() => getDefaultBinConfig())
+  const [savingProjectDefaults, setSavingProjectDefaults] = useState(false)
+  const [projectDefaultsStatus, setProjectDefaultsStatus] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [creatingBin, setCreatingBin] = useState(false)
@@ -99,6 +104,8 @@ export default function ProjectPage() {
       ])
       const savedAddToolsOpen = window.localStorage.getItem('tracefinity.project.addToolsOpen')
       setProject(p)
+      setProjectDefaultConfig(buildBinConfig(p.default_bin_config || getDefaultBinDefaults()))
+      setProjectDefaultsStatus(null)
       setProjects(allProjects)
       setTools(t)
       setBins(b)
@@ -206,6 +213,39 @@ export default function ProjectPage() {
     }
   }
 
+  async function handleSaveProjectDefaults() {
+    if (!project) return
+    setSavingProjectDefaults(true)
+    setError(null)
+    try {
+      const updated = await updateProject(project.id, {
+        default_bin_config: binDefaultsFromConfig(projectDefaultConfig),
+      })
+      setProject(updated)
+      setProjectDefaultsStatus('Project defaults saved')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to save project defaults')
+    } finally {
+      setSavingProjectDefaults(false)
+    }
+  }
+
+  async function handleClearProjectDefaults() {
+    if (!project) return
+    setSavingProjectDefaults(true)
+    setError(null)
+    try {
+      const updated = await updateProject(project.id, { default_bin_config: null })
+      setProject(updated)
+      setProjectDefaultConfig(getDefaultBinConfig())
+      setProjectDefaultsStatus('Using global defaults')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to clear project defaults')
+    } finally {
+      setSavingProjectDefaults(false)
+    }
+  }
+
   async function handleRepairHealth() {
     if (!project) return
     setSaving(true)
@@ -256,6 +296,7 @@ export default function ProjectPage() {
       const bin = await createProjectBin(project.id, {
         name: `${project.name} bin ${projectBins.length + 1}`,
         tool_ids: Array.from(selectedBinToolIds),
+        bin_config: project.default_bin_config || getDefaultBinDefaults(),
       })
       router.push(projectScopedHref(project.id, `/bins/${bin.id}`))
     } catch (err) {
@@ -387,6 +428,42 @@ export default function ProjectPage() {
       </div>
 
       {error && <Alert variant="error">{error}</Alert>}
+
+      <section className="glass rounded-[8px] px-3 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">Bin defaults</h2>
+            <p className="mt-1 text-[11px] text-text-secondary">
+              {project.default_bin_config ? 'Project-specific defaults' : 'Using global defaults'}
+            </p>
+          </div>
+          <div className="flex items-center gap-1.5">
+            {projectDefaultsStatus && (
+              <span className="text-[10px] text-text-muted">{projectDefaultsStatus}</span>
+            )}
+            <button
+              type="button"
+              onClick={handleClearProjectDefaults}
+              disabled={savingProjectDefaults}
+              className="btn-secondary px-2 py-1 text-[11px]"
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={handleSaveProjectDefaults}
+              disabled={savingProjectDefaults}
+              className="btn-primary px-2.5 py-1 text-[11px] inline-flex items-center gap-1"
+            >
+              {savingProjectDefaults && <Loader2 className="w-3 h-3 animate-spin" />}
+              Save defaults
+            </button>
+          </div>
+        </div>
+        <div className="mt-3 max-w-sm">
+          <BinConfigurator config={projectDefaultConfig} onChange={setProjectDefaultConfig} />
+        </div>
+      </section>
 
       {healthIssues.length > 0 && (
         <section className="glass rounded-[8px] px-3 py-2">

--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -23,7 +23,7 @@ export function SectionHeader({ title, count, search, onSearchChange, sortKey, o
   }, [searchOpen])
 
   return (
-    <div className="flex items-center justify-between mb-3 gap-2">
+    <div className="flex h-[32px] items-center justify-between mb-3 gap-2">
       {onToggleCollapsed ? (
         <button
           onClick={onToggleCollapsed}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   GenerateResponse,
   Point,
   Polygon,
+  BinDefaults,
   BinConfig,
   Session,
   SessionSummary,
@@ -245,6 +246,7 @@ export async function createProject(opts: {
   name: string
   description?: string | null
   status?: ProjectStatus
+  default_bin_config?: BinDefaults | null
   tool_ids?: string[]
 }): Promise<BinProject> {
   return fetchApi('/api/bin-projects', {
@@ -266,6 +268,7 @@ export async function updateProject(
     notes?: string | null
     target_grid_x?: number | null
     target_grid_y?: number | null
+    default_bin_config?: BinDefaults | null
   }
 ): Promise<BinProject> {
   return fetchApi(`/api/bin-projects/${projectId}`, {
@@ -313,7 +316,7 @@ export async function detachBinFromProject(projectId: string, binId: string): Pr
 
 export async function createProjectBin(
   projectId: string,
-  opts: { name?: string | null; tool_ids?: string[] | null } = {}
+  opts: { name?: string | null; tool_ids?: string[] | null; bin_config?: BinDefaults | null } = {}
 ): Promise<BinData> {
   return fetchApi(`/api/bin-projects/${projectId}/create-bin`, {
     method: 'POST',
@@ -332,7 +335,7 @@ export async function getBin(binId: string): Promise<BinData> {
   return fetchApi(`/api/bins/${binId}`)
 }
 
-export async function createBin(opts: { name?: string; project_id?: string | null; tool_ids?: string[] } = {}): Promise<BinData> {
+export async function createBin(opts: { name?: string; project_id?: string | null; tool_ids?: string[]; bin_config?: BinDefaults | null } = {}): Promise<BinData> {
   return fetchApi('/api/bins', {
     method: 'POST',
     body: JSON.stringify(opts),

--- a/frontend/src/lib/binDefaults.test.ts
+++ b/frontend/src/lib/binDefaults.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  binDefaultsFromConfig,
   buildBinConfig,
   getDefaultBinConfig,
   getDefaultBinDefaults,
@@ -62,6 +63,17 @@ describe('bin defaults', () => {
     expect(defaults.magnet_diameter).toBe(6.2)
     expect(defaults.magnet_depth).toBe(2.8)
     expect(defaults.magnet_corners_only).toBe(true)
+    expect('text_labels' in defaults).toBe(false)
+  })
+
+  it('strips text labels when deriving defaults from a full config', () => {
+    const defaults = binDefaultsFromConfig({
+      ...buildBinConfig({ magnet_diameter: 6.2 }),
+      text_labels: [{ id: 'label-1', text: '12mm', x: 1, y: 2, font_size: 4, rotation: 0, emboss: true, depth: 0.6 }],
+    })
+
+    expect(defaults.magnet_diameter).toBe(6.2)
+    expect('text_labels' in defaults).toBe(false)
   })
 
   it('keeps the legacy bedSize setting authoritative', () => {
@@ -85,5 +97,25 @@ describe('bin defaults', () => {
     expect(reset.magnet_diameter).toBe(6)
     expect(stored.bedSize).toBe(256)
     expect(stored.binDefaults).toBeUndefined()
+  })
+
+  it('does not throw when localStorage writes are unavailable', () => {
+    const storage = {
+      get length() {
+        return 0
+      },
+      clear: () => {},
+      getItem: () => null,
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {
+        throw new Error('localStorage blocked')
+      },
+    } as Storage
+    vi.stubGlobal('window', { localStorage: storage })
+    vi.stubGlobal('localStorage', storage)
+
+    expect(() => saveDefaultBinConfig(buildBinConfig({ magnet_diameter: 6.2 }))).not.toThrow()
+    expect(() => resetDefaultBinConfig()).not.toThrow()
   })
 })

--- a/frontend/src/lib/binDefaults.test.ts
+++ b/frontend/src/lib/binDefaults.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildBinConfig,
+  getDefaultBinConfig,
+  getDefaultBinDefaults,
+  resetDefaultBinConfig,
+  saveDefaultBinConfig,
+} from './binDefaults'
+
+const SETTINGS_KEY = 'tracefinity-settings'
+
+function installLocalStorage() {
+  const data = new Map<string, string>()
+  const storage = {
+    get length() {
+      return data.size
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    removeItem: (key: string) => data.delete(key),
+    setItem: (key: string, value: string) => data.set(key, value),
+  } as Storage
+
+  vi.stubGlobal('window', { localStorage: storage })
+  vi.stubGlobal('localStorage', storage)
+  return storage
+}
+
+describe('bin defaults', () => {
+  let storage: Storage
+
+  beforeEach(() => {
+    storage = installLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses legacy bedSize when no full bin defaults are saved', () => {
+    storage.setItem(SETTINGS_KEY, JSON.stringify({ bedSize: 220 }))
+
+    const defaults = getDefaultBinConfig()
+
+    expect(defaults.bed_size).toBe(220)
+    expect(defaults.magnet_diameter).toBe(6)
+  })
+
+  it('saves and restores magnet defaults', () => {
+    saveDefaultBinConfig(buildBinConfig({
+      magnet_diameter: 6.2,
+      magnet_depth: 2.8,
+      magnet_corners_only: true,
+      bed_size: 230,
+    }))
+
+    const stored = JSON.parse(storage.getItem(SETTINGS_KEY) || '{}')
+    const defaults = getDefaultBinDefaults()
+
+    expect(stored.bedSize).toBe(230)
+    expect(defaults.magnet_diameter).toBe(6.2)
+    expect(defaults.magnet_depth).toBe(2.8)
+    expect(defaults.magnet_corners_only).toBe(true)
+  })
+
+  it('keeps the legacy bedSize setting authoritative', () => {
+    storage.setItem(SETTINGS_KEY, JSON.stringify({
+      bedSize: 245,
+      binDefaults: { magnet_diameter: 6.2, bed_size: 220 },
+    }))
+
+    const defaults = getDefaultBinDefaults()
+
+    expect(defaults.bed_size).toBe(245)
+    expect(defaults.magnet_diameter).toBe(6.2)
+  })
+
+  it('clears saved defaults without leaving a stale binDefaults key', () => {
+    saveDefaultBinConfig(buildBinConfig({ magnet_diameter: 6.2 }))
+
+    const reset = resetDefaultBinConfig()
+    const stored = JSON.parse(storage.getItem(SETTINGS_KEY) || '{}')
+
+    expect(reset.magnet_diameter).toBe(6)
+    expect(stored.bedSize).toBe(256)
+    expect(stored.binDefaults).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -29,24 +29,8 @@ export function buildBinConfig(overrides: Partial<BinDefaults> | null = null): B
 }
 
 export function binDefaultsFromConfig(config: Partial<BinConfig>): BinDefaults {
-  const merged = buildBinConfig(config)
-  return {
-    grid_x: merged.grid_x,
-    grid_y: merged.grid_y,
-    height_units: merged.height_units,
-    magnets: merged.magnets,
-    magnet_diameter: merged.magnet_diameter,
-    magnet_depth: merged.magnet_depth,
-    magnet_corners_only: merged.magnet_corners_only,
-    stacking_lip: merged.stacking_lip,
-    wall_thickness: merged.wall_thickness,
-    cutout_depth: merged.cutout_depth,
-    cutout_clearance: merged.cutout_clearance,
-    cutout_chamfer: merged.cutout_chamfer,
-    insert_enabled: merged.insert_enabled,
-    insert_height: merged.insert_height,
-    bed_size: merged.bed_size,
-  }
+  const { text_labels: _textLabels, ...defaults } = buildBinConfig(config)
+  return defaults
 }
 
 export function getDefaultBinConfig(): BinConfig {

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -1,0 +1,73 @@
+import type { BinConfig, BinDefaults } from '@/types'
+import { getSettings, saveSettings } from './settings'
+
+export const FACTORY_BIN_CONFIG: BinConfig = {
+  grid_x: 2,
+  grid_y: 2,
+  height_units: 4,
+  magnets: true,
+  magnet_diameter: 6.0,
+  magnet_depth: 2.4,
+  magnet_corners_only: false,
+  stacking_lip: true,
+  wall_thickness: 1.6,
+  cutout_depth: 20,
+  cutout_clearance: 1.0,
+  cutout_chamfer: 0,
+  insert_enabled: false,
+  insert_height: 1.0,
+  bed_size: 256,
+  text_labels: [],
+}
+
+export function buildBinConfig(overrides: Partial<BinDefaults> | null = null): BinConfig {
+  return {
+    ...FACTORY_BIN_CONFIG,
+    ...(overrides || {}),
+    text_labels: [],
+  }
+}
+
+export function binDefaultsFromConfig(config: Partial<BinConfig>): BinDefaults {
+  const merged = buildBinConfig(config)
+  return {
+    grid_x: merged.grid_x,
+    grid_y: merged.grid_y,
+    height_units: merged.height_units,
+    magnets: merged.magnets,
+    magnet_diameter: merged.magnet_diameter,
+    magnet_depth: merged.magnet_depth,
+    magnet_corners_only: merged.magnet_corners_only,
+    stacking_lip: merged.stacking_lip,
+    wall_thickness: merged.wall_thickness,
+    cutout_depth: merged.cutout_depth,
+    cutout_clearance: merged.cutout_clearance,
+    cutout_chamfer: merged.cutout_chamfer,
+    insert_enabled: merged.insert_enabled,
+    insert_height: merged.insert_height,
+    bed_size: merged.bed_size,
+  }
+}
+
+export function getDefaultBinConfig(): BinConfig {
+  const settings = getSettings()
+  return buildBinConfig({
+    ...(settings.binDefaults || {}),
+    bed_size: settings.bedSize,
+  })
+}
+
+export function getDefaultBinDefaults(): BinDefaults {
+  return binDefaultsFromConfig(getDefaultBinConfig())
+}
+
+export function saveDefaultBinConfig(config: BinConfig): BinDefaults {
+  const defaults = binDefaultsFromConfig(config)
+  saveSettings({ bedSize: defaults.bed_size, binDefaults: defaults })
+  return defaults
+}
+
+export function resetDefaultBinConfig(): BinConfig {
+  saveSettings({ bedSize: FACTORY_BIN_CONFIG.bed_size, binDefaults: undefined })
+  return buildBinConfig()
+}

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -20,10 +20,15 @@ export function getSettings(): UserSettings {
 }
 
 export function saveSettings(partial: Partial<UserSettings>): void {
-  const current = getSettings()
-  const next: Record<string, unknown> = { ...current, ...partial }
-  for (const key of Object.keys(next)) {
-    if (next[key] === undefined) delete next[key]
+  if (typeof window === 'undefined') return
+  try {
+    const current = getSettings()
+    const next: Record<string, unknown> = { ...current, ...partial }
+    for (const key of Object.keys(next)) {
+      if (next[key] === undefined) delete next[key]
+    }
+    window.localStorage.setItem(KEY, JSON.stringify(next))
+  } catch {
+    // localStorage can be unavailable in private browsing or restricted contexts.
   }
-  localStorage.setItem(KEY, JSON.stringify(next))
 }

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -1,5 +1,8 @@
+import type { BinDefaults } from '@/types'
+
 export interface UserSettings {
   bedSize: number
+  binDefaults?: Partial<BinDefaults>
 }
 
 const DEFAULTS: UserSettings = { bedSize: 256 }
@@ -18,5 +21,9 @@ export function getSettings(): UserSettings {
 
 export function saveSettings(partial: Partial<UserSettings>): void {
   const current = getSettings()
-  localStorage.setItem(KEY, JSON.stringify({ ...current, ...partial }))
+  const next: Record<string, unknown> = { ...current, ...partial }
+  for (const key of Object.keys(next)) {
+    if (next[key] === undefined) delete next[key]
+  }
+  localStorage.setItem(KEY, JSON.stringify(next))
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -94,7 +94,7 @@ export interface GenerateResponse {
   warning?: string | null
 }
 
-export interface BinConfig {
+export interface BinDefaults {
   grid_x: number
   grid_y: number
   height_units: number
@@ -109,8 +109,11 @@ export interface BinConfig {
   cutout_chamfer: number
   insert_enabled: boolean
   insert_height: number
-  text_labels: TextLabel[]
   bed_size: number
+}
+
+export interface BinConfig extends BinDefaults {
+  text_labels: TextLabel[]
 }
 
 // --- tool library ---
@@ -190,7 +193,7 @@ export interface BinProject {
   unplaced_tool_ids: string[]
   target_grid_x: number | null
   target_grid_y: number | null
-  default_bin_config: BinConfig | null
+  default_bin_config: BinDefaults | null
   notes: string | null
   created_at: string | null
   updated_at: string | null


### PR DESCRIPTION
Fixes #49

## Summary
- Add shared bin defaults for standalone and project bin creation.
- Persist global bin defaults in frontend settings, including magnet diameter/depth and corners-only placement.
- Add project-level bin defaults and pass them through when creating project bins.
- Document the API and architecture updates for bin defaults.

## Testing
- `python -m pytest -q` from `backend` - 71 passed.
- `npm exec vitest run src` from `frontend` - 9 passed.
- `npm exec tsc -- --noEmit` from `frontend`.
- `npm run build` from `frontend`.
- I've done basic tests with a few tools and bins.

## Codex disclosure
This draft PR was prepared with assistance from OpenAI Codex.