### PR TITLE
Add backup and restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 STORAGE_PATH=./storage
 CORS_ORIGINS=["http://localhost:3000","http://localhost:4001"]
 MAX_UPLOAD_MB=20
+MAX_BACKUP_MB=250
 
 # AI API Key (optional - users can provide their own)
 GOOGLE_API_KEY=

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -30,10 +30,13 @@ BACKUP_FILE_NAME_RE = re.compile(r"^tracefinity-auto-backup-\d{8}-\d{6}\.zip$")
 
 
 def _evict_user_store_cache(user_id: str) -> None:
-    from app.api.routes import _project_store_cache, _store_cache
+    import app.api.routes as routes
 
-    _store_cache.pop(user_id, None)
-    _project_store_cache.pop(user_id, None)
+    routes._store_cache.pop(user_id, None)
+    routes._project_store_cache.pop(user_id, None)
+    photo_station_cache = getattr(routes, "_photo_station_store_cache", None)
+    if photo_station_cache is not None:
+        photo_station_cache.pop(user_id, None)
 
 
 @router.get("/users/me/export")

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tempfile
 import shutil
 from pathlib import Path
@@ -15,14 +16,17 @@ from app.models.schemas import RestoreResponse
 from app.services.backup_service import (
     BACKUP_DIR_NAME,
     BackupError,
+    BackupSizeError,
     backup_filename,
     create_backup_package,
     restore_backup_package,
+    validate_backup_file_size,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+BACKUP_FILE_NAME_RE = re.compile(r"^tracefinity-auto-backup-\d{8}-\d{6}\.zip$")
 
 
 def _evict_user_store_cache(user_id: str) -> None:
@@ -33,7 +37,7 @@ def _evict_user_store_cache(user_id: str) -> None:
 
 
 @router.get("/users/me/export")
-async def export_user_data(request: Request, user_id: str = Depends(get_user_id)):
+async def export_user_data(user_id: str = Depends(get_user_id)):
     """download a complete backup package for the authenticated user"""
     user_path = settings.storage_path / user_id
     ensure_user_dirs(user_path)
@@ -61,9 +65,22 @@ async def restore_user_data(request: Request, backup: UploadFile, user_id: str =
     """restore user data from a backup package, replacing existing app data"""
     user_path = settings.storage_path / user_id
     ensure_user_dirs(user_path)
+    max_bytes = settings.max_backup_mb * 1024 * 1024
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            request_size = int(content_length)
+        except ValueError:
+            request_size = 0
+        if request_size > max_bytes:
+            await backup.close()
+            raise HTTPException(status_code=413, detail=f"backup file too large (max {settings.max_backup_mb}MB)")
 
     try:
+        validate_backup_file_size(backup.file, max_bytes)
         result = restore_backup_package(user_path, backup.file)
+    except BackupSizeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
     except BackupError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     finally:
@@ -81,9 +98,9 @@ async def restore_user_data(request: Request, backup: UploadFile, user_id: str =
 
 
 @router.get("/users/me/backups/{file_name}")
-async def download_saved_backup(request: Request, file_name: str, user_id: str = Depends(get_user_id)):
+async def download_saved_backup(file_name: str, user_id: str = Depends(get_user_id)):
     """download an automatic backup saved during restore"""
-    if Path(file_name).name != file_name or not file_name.endswith(".zip"):
+    if not BACKUP_FILE_NAME_RE.fullmatch(file_name):
         raise HTTPException(status_code=400, detail="invalid backup filename")
 
     backup_path = settings.storage_path / user_id / BACKUP_DIR_NAME / file_name
@@ -98,7 +115,7 @@ async def download_saved_backup(request: Request, file_name: str, user_id: str =
 
 
 @router.delete("/users/me")
-async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)):
+async def delete_user_data(user_id: str = Depends(get_user_id)):
     """delete all stored data for the authenticated user"""
     user_path = settings.storage_path / user_id
     if user_path.exists():

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -1,16 +1,100 @@
 import logging
+import tempfile
 import shutil
+from pathlib import Path
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import Response
 
 from app.auth import get_user_id
-from app.config import settings
+from app.config import ensure_user_dirs, settings
+from app.models.schemas import RestoreResponse
+from app.services.backup_service import (
+    BACKUP_DIR_NAME,
+    BackupError,
+    backup_filename,
+    create_backup_package,
+    restore_backup_package,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _evict_user_store_cache(user_id: str) -> None:
+    from app.api.routes import _project_store_cache, _store_cache
+
+    _store_cache.pop(user_id, None)
+    _project_store_cache.pop(user_id, None)
+
+
+@router.get("/users/me/export")
+async def export_user_data(request: Request, user_id: str = Depends(get_user_id)):
+    """download a complete backup package for the authenticated user"""
+    user_path = settings.storage_path / user_id
+    ensure_user_dirs(user_path)
+
+    download_name = backup_filename()
+    with tempfile.NamedTemporaryFile(prefix="tracefinity-export-", suffix=".zip", delete=False) as tmp:
+        output_path = Path(tmp.name)
+
+    try:
+        create_backup_package(user_path, output_path)
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
+
+    return FileResponse(
+        str(output_path),
+        media_type="application/zip",
+        filename=download_name,
+        background=BackgroundTask(lambda: output_path.unlink(missing_ok=True)),
+    )
+
+
+@router.post("/users/me/restore", response_model=RestoreResponse)
+async def restore_user_data(request: Request, backup: UploadFile, user_id: str = Depends(get_user_id)):
+    """restore user data from a backup package, replacing existing app data"""
+    user_path = settings.storage_path / user_id
+    ensure_user_dirs(user_path)
+
+    try:
+        result = restore_backup_package(user_path, backup.file)
+    except BackupError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        await backup.close()
+
+    ensure_user_dirs(user_path)
+    _evict_user_store_cache(user_id)
+
+    return RestoreResponse(
+        status="restored",
+        auto_backup_filename=result.auto_backup_path.name,
+        auto_backup_url=f"/api/users/me/backups/{result.auto_backup_path.name}",
+        restored_files=result.restored_files,
+    )
+
+
+@router.get("/users/me/backups/{file_name}")
+async def download_saved_backup(request: Request, file_name: str, user_id: str = Depends(get_user_id)):
+    """download an automatic backup saved during restore"""
+    if Path(file_name).name != file_name or not file_name.endswith(".zip"):
+        raise HTTPException(status_code=400, detail="invalid backup filename")
+
+    backup_path = settings.storage_path / user_id / BACKUP_DIR_NAME / file_name
+    if not backup_path.exists() or not backup_path.is_file():
+        raise HTTPException(status_code=404, detail="backup not found")
+
+    return FileResponse(
+        str(backup_path),
+        media_type="application/zip",
+        filename=file_name,
+    )
 
 
 @router.delete("/users/me")
@@ -21,8 +105,6 @@ async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)
         shutil.rmtree(user_path)
         logger.info("deleted storage for user %s", user_id)
 
-    # evict from store cache
-    from app.api.routes import _store_cache
-    _store_cache.pop(user_id, None)
+    _evict_user_store_cache(user_id)
 
     return Response(status_code=204)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,7 +50,7 @@ settings = Settings()
 def ensure_user_dirs(user_path: Path):
     """create storage subdirs for a user"""
     user_path.mkdir(parents=True, exist_ok=True)
-    for sub in ("uploads", "processed", "outputs", "tools", "bins", "backups"):
+    for sub in ("uploads", "processed", "outputs", "tools", "bins", "station-photos", "backups"):
         (user_path / sub).mkdir(exist_ok=True)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,7 +49,7 @@ settings = Settings()
 def ensure_user_dirs(user_path: Path):
     """create storage subdirs for a user"""
     user_path.mkdir(parents=True, exist_ok=True)
-    for sub in ("uploads", "processed", "outputs", "tools", "bins"):
+    for sub in ("uploads", "processed", "outputs", "tools", "bins", "backups"):
         (user_path / sub).mkdir(exist_ok=True)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     gemini_image_model: str = "gemini-3.1-flash-image-preview"
     gemini_label_model: str = "gemini-2.0-flash"
     max_upload_mb: int = 20
+    max_backup_mb: int = 250
     log_level: str = "INFO"
     proxy_secret: Optional[str] = None
     cors_origins: list[str] = ["http://localhost:3000", "http://localhost:4001"]

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -280,6 +280,13 @@ class SaveToolsResponse(BaseModel):
     tool_ids: list[str]
 
 
+class RestoreResponse(BaseModel):
+    status: str
+    auto_backup_filename: str
+    auto_backup_url: str
+    restored_files: int
+
+
 # --- bin projects ---
 
 ProjectStatus = Literal["active", "ready_to_print", "printed", "archived"]

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -40,6 +40,10 @@ class BackupError(ValueError):
     """Raised when a backup package cannot be imported safely."""
 
 
+class BackupSizeError(BackupError):
+    """Raised when a backup package exceeds the configured size limit."""
+
+
 @dataclass
 class RestoreResult:
     auto_backup_path: Path
@@ -68,7 +72,7 @@ def _should_export(rel_path: Path) -> bool:
         return False
     if rel_path.parts[0] in EXCLUDED_TOP_LEVEL:
         return False
-    if rel_path.name.endswith(".tmp") and rel_path.name.startswith("."):
+    if rel_path.name.endswith(".tmp") or rel_path.name.startswith("."):
         return False
     return True
 
@@ -130,6 +134,19 @@ def _storage_rel_from_archive_name(name: str) -> Path | None:
     return Path(*rel_parts)
 
 
+def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    return ((info.external_attr >> 16) & 0o170000) == 0o120000
+
+
+def validate_backup_file_size(backup_file: BinaryIO, max_bytes: int) -> None:
+    current = backup_file.tell()
+    backup_file.seek(0, 2)
+    size = backup_file.tell()
+    backup_file.seek(current)
+    if size > max_bytes:
+        raise BackupSizeError(f"backup file too large (max {max_bytes // (1024 * 1024)}MB)")
+
+
 def extract_backup_package(backup_file: BinaryIO, staging_path: Path) -> int:
     """Validate and extract a backup package into staging_path."""
     staging_path.mkdir(parents=True, exist_ok=True)
@@ -142,6 +159,8 @@ def extract_backup_package(backup_file: BinaryIO, staging_path: Path) -> int:
             for info in zf.infolist():
                 if info.is_dir():
                     continue
+                if _is_zip_symlink(info):
+                    raise BackupError("backup contains an unsafe file type")
                 rel_path = _storage_rel_from_archive_name(info.filename)
                 if rel_path is None:
                     continue
@@ -248,31 +267,46 @@ def validate_staged_user_data(staging_path: Path, user_id: str) -> None:
             _validate_store_file(path, model, user_id)
 
 
-def _clear_user_data(user_path: Path) -> None:
-    user_path.mkdir(parents=True, exist_ok=True)
-    for child in user_path.iterdir():
-        if child.name == BACKUP_DIR_NAME:
-            continue
-        if child.is_dir():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
 
 
-def _copy_staged_data(staging_path: Path, user_path: Path) -> None:
-    for child in staging_path.iterdir():
-        dest = user_path / child.name
-        if child.is_dir():
-            shutil.copytree(child, dest, dirs_exist_ok=True)
-        else:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(child, dest)
+def _move_children(src_dir: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for child in list(src_dir.iterdir()):
+        shutil.move(str(child), str(dest_dir / child.name))
+
+
+def _install_staged_data_atomically(staging_path: Path, user_path: Path, old_data_path: Path) -> None:
+    old_data_path.mkdir(parents=True, exist_ok=True)
+    installed_paths: list[Path] = []
+    try:
+        for child in list(user_path.iterdir()):
+            if child.name == BACKUP_DIR_NAME:
+                continue
+            shutil.move(str(child), str(old_data_path / child.name))
+        for child in list(staging_path.iterdir()):
+            dest = user_path / child.name
+            shutil.move(str(child), str(dest))
+            installed_paths.append(dest)
+    except Exception:
+        for path in installed_paths:
+            if path.exists():
+                _remove_path(path)
+        _move_children(old_data_path, user_path)
+        raise
+    else:
+        shutil.rmtree(old_data_path, ignore_errors=True)
 
 
 def restore_backup_package(user_path: Path, backup_file: BinaryIO) -> RestoreResult:
     """Restore a backup package, saving an automatic pre-restore backup first."""
     user_path.mkdir(parents=True, exist_ok=True)
     staging_path = user_path.parent / f".restore-{backup_timestamp()}-{uuid.uuid4().hex}"
+    old_data_path = user_path.parent / f".restore-old-{backup_timestamp()}-{uuid.uuid4().hex}"
     backup_dir = user_path / BACKUP_DIR_NAME
     auto_backup_path = backup_dir / backup_filename("tracefinity-auto-backup")
 
@@ -281,8 +315,8 @@ def restore_backup_package(user_path: Path, backup_file: BinaryIO) -> RestoreRes
         _rewrite_staged_user_paths(staging_path, user_path.name)
         validate_staged_user_data(staging_path, user_path.name)
         create_backup_package(user_path, auto_backup_path)
-        _clear_user_data(user_path)
-        _copy_staged_data(staging_path, user_path)
+        _install_staged_data_atomically(staging_path, user_path, old_data_path)
         return RestoreResult(auto_backup_path=auto_backup_path, restored_files=restored_files)
     finally:
         shutil.rmtree(staging_path, ignore_errors=True)
+        shutil.rmtree(old_data_path, ignore_errors=True)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+from pydantic import ValidationError
+
+from app.models.schemas import BinModel, BinProject, Session, Tool
+
+
+BACKUP_MANIFEST = "tracefinity-backup.json"
+BACKUP_FORMAT_VERSION = 1
+BACKUP_STORAGE_PREFIX = "storage"
+BACKUP_DIR_NAME = "backups"
+EXCLUDED_TOP_LEVEL = {BACKUP_DIR_NAME}
+RESTORED_TOP_LEVEL = {"uploads", "processed", "outputs", "tools", "bins"}
+STORAGE_PATH_FIELDS = {
+    "original_image_path",
+    "corrected_image_path",
+    "mask_image_path",
+    "stl_path",
+    "source_image_path",
+    "thumbnail_path",
+}
+STORE_MODELS = {
+    "sessions.json": Session,
+    "tools.json": Tool,
+    "bins.json": BinModel,
+    "bin-projects.json": BinProject,
+}
+
+
+class BackupError(ValueError):
+    """Raised when a backup package cannot be imported safely."""
+
+
+@dataclass
+class RestoreResult:
+    auto_backup_path: Path
+    restored_files: int
+
+
+def backup_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def backup_filename(prefix: str = "tracefinity-backup") -> str:
+    return f"{prefix}-{backup_timestamp()}.zip"
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "app": "tracefinity",
+        "format_version": BACKUP_FORMAT_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "storage_prefix": BACKUP_STORAGE_PREFIX,
+    }
+
+
+def _should_export(rel_path: Path) -> bool:
+    if not rel_path.parts:
+        return False
+    if rel_path.parts[0] in EXCLUDED_TOP_LEVEL:
+        return False
+    if rel_path.name.endswith(".tmp") and rel_path.name.startswith("."):
+        return False
+    return True
+
+
+def create_backup_package(user_path: Path, output_path: Path) -> Path:
+    """Write a Tracefinity backup ZIP for one user's storage directory."""
+    user_path.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest(), indent=2))
+
+        for path in sorted(user_path.rglob("*")):
+            if not path.is_file():
+                continue
+            rel_path = path.relative_to(user_path)
+            if not _should_export(rel_path):
+                continue
+            archive_name = f"{BACKUP_STORAGE_PREFIX}/{rel_path.as_posix()}"
+            zf.write(path, archive_name)
+
+    return output_path
+
+
+def _validate_manifest(zf: zipfile.ZipFile) -> None:
+    try:
+        raw = zf.read(BACKUP_MANIFEST)
+    except KeyError as exc:
+        raise BackupError("backup is missing tracefinity metadata") from exc
+
+    try:
+        manifest = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackupError("backup metadata is not valid JSON") from exc
+
+    if manifest.get("app") != "tracefinity":
+        raise BackupError("backup was not created by Tracefinity")
+    if manifest.get("format_version") != BACKUP_FORMAT_VERSION:
+        raise BackupError("backup format is not supported by this version of Tracefinity")
+    if manifest.get("storage_prefix") != BACKUP_STORAGE_PREFIX:
+        raise BackupError("backup storage layout is not supported")
+
+
+def _storage_rel_from_archive_name(name: str) -> Path | None:
+    normalized = name.replace("\\", "/")
+    parts = [part for part in normalized.split("/") if part]
+    if not parts or parts[0] == BACKUP_MANIFEST:
+        return None
+    if parts[0] != BACKUP_STORAGE_PREFIX:
+        raise BackupError("backup contains files outside Tracefinity storage")
+    rel_parts = parts[1:]
+    if not rel_parts:
+        return None
+    if rel_parts[0] in EXCLUDED_TOP_LEVEL:
+        return None
+    for part in rel_parts:
+        if part in {".", ".."} or ":" in part:
+            raise BackupError("backup contains an unsafe file path")
+    return Path(*rel_parts)
+
+
+def extract_backup_package(backup_file: BinaryIO, staging_path: Path) -> int:
+    """Validate and extract a backup package into staging_path."""
+    staging_path.mkdir(parents=True, exist_ok=True)
+    staging_root = staging_path.resolve()
+    restored_files = 0
+
+    try:
+        with zipfile.ZipFile(backup_file) as zf:
+            _validate_manifest(zf)
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                rel_path = _storage_rel_from_archive_name(info.filename)
+                if rel_path is None:
+                    continue
+
+                dest = staging_path / rel_path
+                dest_parent = dest.parent
+                dest_parent.mkdir(parents=True, exist_ok=True)
+                resolved_dest = dest.resolve()
+                if staging_root != resolved_dest and staging_root not in resolved_dest.parents:
+                    raise BackupError("backup contains an unsafe file path")
+
+                with zf.open(info) as src, dest.open("wb") as out:
+                    shutil.copyfileobj(src, out)
+                restored_files += 1
+    except zipfile.BadZipFile as exc:
+        raise BackupError("backup file is not a valid ZIP") from exc
+
+    return restored_files
+
+
+def _rewrite_storage_path(value: str, user_id: str) -> str:
+    normalized = value.replace("\\", "/")
+    parts = [part for part in normalized.split("/") if part]
+    if not parts:
+        return value
+    if any(part in {".", ".."} or ":" in part for part in parts):
+        return value
+    if parts[0] in RESTORED_TOP_LEVEL:
+        return f"{user_id}/{'/'.join(parts)}"
+    if len(parts) > 1 and parts[1] in RESTORED_TOP_LEVEL:
+        return f"{user_id}/{'/'.join(parts[1:])}"
+    return value
+
+
+def _rewrite_storage_paths(value: object, user_id: str, key: str | None = None) -> object:
+    if isinstance(value, dict):
+        return {k: _rewrite_storage_paths(v, user_id, k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_storage_paths(item, user_id, key) for item in value]
+    if key in STORAGE_PATH_FIELDS and isinstance(value, str):
+        return _rewrite_storage_path(value, user_id)
+    return value
+
+
+def _rewrite_staged_user_paths(staging_path: Path, user_id: str) -> None:
+    for file_name in STORE_MODELS:
+        path = staging_path / file_name
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            raise BackupError(f"{file_name} is not valid JSON") from exc
+        path.write_text(json.dumps(_rewrite_storage_paths(data, user_id), indent=2))
+
+
+def _validate_storage_path_ref(value: str, user_id: str, file_name: str) -> None:
+    parts = [part for part in value.replace("\\", "/").split("/") if part]
+    if (
+        len(parts) < 2
+        or parts[0] != user_id
+        or parts[1] not in RESTORED_TOP_LEVEL
+        or any(part in {".", ".."} or ":" in part for part in parts)
+    ):
+        raise BackupError(f"{file_name} contains an unsafe storage path")
+
+
+def _validate_storage_path_refs(value: object, user_id: str, file_name: str, key: str | None = None) -> None:
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            _validate_storage_path_refs(child_value, user_id, file_name, child_key)
+    elif isinstance(value, list):
+        for item in value:
+            _validate_storage_path_refs(item, user_id, file_name, key)
+    elif key in STORAGE_PATH_FIELDS and isinstance(value, str):
+        _validate_storage_path_ref(value, user_id, file_name)
+
+
+def _validate_store_file(
+    path: Path,
+    model: type[Session] | type[Tool] | type[BinModel] | type[BinProject],
+    user_id: str,
+) -> None:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise BackupError(f"{path.name} is not valid JSON") from exc
+    if not isinstance(data, dict):
+        raise BackupError(f"{path.name} must contain a JSON object")
+    _validate_storage_path_refs(data, user_id, path.name)
+    try:
+        for record_id, record in data.items():
+            if not isinstance(record_id, str):
+                raise BackupError(f"{path.name} contains a non-string record id")
+            model.model_validate(record)
+    except ValidationError as exc:
+        raise BackupError(f"{path.name} contains invalid records") from exc
+
+
+def validate_staged_user_data(staging_path: Path, user_id: str) -> None:
+    for file_name, model in STORE_MODELS.items():
+        path = staging_path / file_name
+        if path.exists():
+            _validate_store_file(path, model, user_id)
+
+
+def _clear_user_data(user_path: Path) -> None:
+    user_path.mkdir(parents=True, exist_ok=True)
+    for child in user_path.iterdir():
+        if child.name == BACKUP_DIR_NAME:
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def _copy_staged_data(staging_path: Path, user_path: Path) -> None:
+    for child in staging_path.iterdir():
+        dest = user_path / child.name
+        if child.is_dir():
+            shutil.copytree(child, dest, dirs_exist_ok=True)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(child, dest)
+
+
+def restore_backup_package(user_path: Path, backup_file: BinaryIO) -> RestoreResult:
+    """Restore a backup package, saving an automatic pre-restore backup first."""
+    user_path.mkdir(parents=True, exist_ok=True)
+    staging_path = user_path.parent / f".restore-{backup_timestamp()}-{uuid.uuid4().hex}"
+    backup_dir = user_path / BACKUP_DIR_NAME
+    auto_backup_path = backup_dir / backup_filename("tracefinity-auto-backup")
+
+    try:
+        restored_files = extract_backup_package(backup_file, staging_path)
+        _rewrite_staged_user_paths(staging_path, user_path.name)
+        validate_staged_user_data(staging_path, user_path.name)
+        create_backup_package(user_path, auto_backup_path)
+        _clear_user_data(user_path)
+        _copy_staged_data(staging_path, user_path)
+        return RestoreResult(auto_backup_path=auto_backup_path, restored_files=restored_files)
+    finally:
+        shutil.rmtree(staging_path, ignore_errors=True)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -11,6 +11,7 @@ from typing import BinaryIO
 
 from pydantic import ValidationError
 
+from app.models import schemas
 from app.models.schemas import BinModel, BinProject, Session, Tool
 
 
@@ -19,14 +20,16 @@ BACKUP_FORMAT_VERSION = 1
 BACKUP_STORAGE_PREFIX = "storage"
 BACKUP_DIR_NAME = "backups"
 EXCLUDED_TOP_LEVEL = {BACKUP_DIR_NAME}
-RESTORED_TOP_LEVEL = {"uploads", "processed", "outputs", "tools", "bins"}
+RESTORED_TOP_LEVEL = {"uploads", "processed", "outputs", "tools", "bins", "station-photos"}
 STORAGE_PATH_FIELDS = {
     "original_image_path",
     "corrected_image_path",
     "mask_image_path",
+    "station_image_path",
     "stl_path",
     "source_image_path",
     "thumbnail_path",
+    "image_path",
 }
 STORE_MODELS = {
     "sessions.json": Session,
@@ -34,6 +37,9 @@ STORE_MODELS = {
     "bins.json": BinModel,
     "bin-projects.json": BinProject,
 }
+if hasattr(schemas, "PhotoStation"):
+    STORE_MODELS["photo-stations.json"] = schemas.PhotoStation
+PATH_REWRITE_STORE_FILES = set(STORE_MODELS) | {"photo-stations.json"}
 
 
 class BackupError(ValueError):
@@ -206,7 +212,7 @@ def _rewrite_storage_paths(value: object, user_id: str, key: str | None = None) 
 
 
 def _rewrite_staged_user_paths(staging_path: Path, user_id: str) -> None:
-    for file_name in STORE_MODELS:
+    for file_name in PATH_REWRITE_STORE_FILES:
         path = staging_path / file_name
         if not path.exists():
             continue

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -209,6 +209,39 @@ def test_restore_rewrites_storage_paths_for_target_user(tmp_path):
     assert bin_data["stl_path"] == "default/outputs/bin-1.stl"
 
 
+def test_restore_rewrites_photo_station_paths_for_target_user(tmp_path):
+    source_path = tmp_path / "source"
+    (source_path / "station-photos").mkdir(parents=True)
+    (source_path / "station-photos" / "station-1.jpg").write_bytes(b"station preview")
+    (source_path / "photo-stations.json").write_text(json.dumps({
+        "station-1": {
+            "id": "station-1",
+            "name": "Bench station",
+            "image_width": 1000,
+            "image_height": 800,
+            "image_path": "source/station-photos/station-1.jpg",
+            "paper_size": "a4",
+            "corners": [
+                {"x": 0, "y": 0},
+                {"x": 100, "y": 0},
+                {"x": 100, "y": 100},
+                {"x": 0, "y": 100},
+            ],
+        }
+    }))
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    with package_path.open("rb") as f:
+        restore_backup_package(target_path, f)
+
+    station = json.loads((target_path / "photo-stations.json").read_text())["station-1"]
+    assert station["image_path"] == "default/station-photos/station-1.jpg"
+    assert (target_path / "station-photos" / "station-1.jpg").read_bytes() == b"station preview"
+
+
 def test_restore_rejects_invalid_store_before_changing_data(tmp_path):
     target_path = tmp_path / "default"
     target_path.mkdir()

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -1,0 +1,234 @@
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import ensure_user_dirs, settings
+from app.main import app
+import app.api.routes as routes
+import app.api.user_routes as user_routes
+from app.services.backup_service import (
+    BACKUP_FORMAT_VERSION,
+    BACKUP_MANIFEST,
+    BACKUP_STORAGE_PREFIX,
+    BackupError,
+    create_backup_package,
+    restore_backup_package,
+)
+
+
+def _manifest():
+    return {
+        "app": "tracefinity",
+        "format_version": BACKUP_FORMAT_VERSION,
+        "storage_prefix": BACKUP_STORAGE_PREFIX,
+    }
+
+
+def _tool_record(tool_id: str, name: str, **extra):
+    return {
+        "id": tool_id,
+        "name": name,
+        "points": [{"x": 0, "y": 0}, {"x": 10, "y": 0}, {"x": 10, "y": 10}],
+        **extra,
+    }
+
+
+def _api_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    monkeypatch.setattr(user_routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def test_backup_package_includes_storage_data_and_skips_saved_backups(tmp_path):
+    user_path = tmp_path / "default"
+    (user_path / "outputs").mkdir(parents=True)
+    (user_path / "tools").mkdir()
+    (user_path / "backups").mkdir()
+    (user_path / "tools.json").write_text(json.dumps({"tool-1": _tool_record("tool-1", "pliers")}))
+    (user_path / "outputs" / "bin.stl").write_bytes(b"solid bin")
+    (user_path / "backups" / "older.zip").write_bytes(b"previous backup")
+
+    backup_path = tmp_path / "tracefinity-backup.zip"
+    create_backup_package(user_path, backup_path)
+
+    with zipfile.ZipFile(backup_path) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read(BACKUP_MANIFEST))
+
+    assert manifest["app"] == "tracefinity"
+    assert "storage/tools.json" in names
+    assert "storage/outputs/bin.stl" in names
+    assert "storage/backups/older.zip" not in names
+
+
+def test_restore_replaces_data_and_saves_pre_restore_backup(tmp_path):
+    source_path = tmp_path / "source"
+    (source_path / "outputs").mkdir(parents=True)
+    (source_path / "tools.json").write_text(json.dumps({"tool-new": _tool_record("tool-new", "new")}))
+    (source_path / "outputs" / "new.stl").write_bytes(b"new stl")
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    (target_path / "outputs").mkdir(parents=True)
+    (target_path / "backups").mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+    (target_path / "backups" / "keep.zip").write_bytes(b"kept")
+
+    with package_path.open("rb") as f:
+        result = restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-new": _tool_record("tool-new", "new")}
+    assert (target_path / "outputs" / "new.stl").read_bytes() == b"new stl"
+    assert not (target_path / "outputs" / "old.stl").exists()
+    assert (target_path / "backups" / "keep.zip").exists()
+    assert result.auto_backup_path.exists()
+
+    with zipfile.ZipFile(result.auto_backup_path) as zf:
+        old_tools = json.loads(zf.read("storage/tools.json"))
+        names = set(zf.namelist())
+
+    assert old_tools == {"tool-old": _tool_record("tool-old", "old")}
+    assert "storage/outputs/old.stl" in names
+
+
+def test_restore_rewrites_storage_paths_for_target_user(tmp_path):
+    source_path = tmp_path / "source"
+    (source_path / "processed").mkdir(parents=True)
+    (source_path / "outputs").mkdir()
+    (source_path / "tools").mkdir()
+    (source_path / "sessions.json").write_text(json.dumps({
+        "session-1": {
+            "id": "session-1",
+            "corrected_image_path": "source/processed/session-1.png",
+            "stl_path": "source/outputs/session-1.stl",
+        }
+    }))
+    (source_path / "tools.json").write_text(json.dumps({
+        "tool-1": _tool_record(
+            "tool-1",
+            "pliers",
+            source_image_path="source/processed/session-1.png",
+            thumbnail_path="source/tools/tool-1.svg",
+        )
+    }))
+    (source_path / "bins.json").write_text(json.dumps({
+        "bin-1": {"id": "bin-1", "stl_path": "source/outputs/bin-1.stl"}
+    }))
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    with package_path.open("rb") as f:
+        restore_backup_package(target_path, f)
+
+    session = json.loads((target_path / "sessions.json").read_text())["session-1"]
+    tool = json.loads((target_path / "tools.json").read_text())["tool-1"]
+    bin_data = json.loads((target_path / "bins.json").read_text())["bin-1"]
+    assert session["corrected_image_path"] == "default/processed/session-1.png"
+    assert session["stl_path"] == "default/outputs/session-1.stl"
+    assert tool["source_image_path"] == "default/processed/session-1.png"
+    assert tool["thumbnail_path"] == "default/tools/tool-1.svg"
+    assert bin_data["stl_path"] == "default/outputs/bin-1.stl"
+
+
+def test_restore_rejects_invalid_store_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+
+    package_path = tmp_path / "invalid-store.zip"
+    with zipfile.ZipFile(package_path, "w") as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest()))
+        zf.writestr("storage/tools.json", json.dumps({"tool-bad": {"id": "tool-bad"}}))
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert not (target_path / "backups").exists()
+
+
+def test_restore_rejects_unsafe_json_path_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+
+    package_path = tmp_path / "unsafe-json-path.zip"
+    with zipfile.ZipFile(package_path, "w") as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest()))
+        zf.writestr(
+            "storage/tools.json",
+            json.dumps({
+                "tool-bad": _tool_record("tool-bad", "bad", source_image_path="../processed/evil.png")
+            }),
+        )
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert not (target_path / "backups").exists()
+
+
+def test_restore_rejects_unsafe_paths_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+
+    package_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(package_path, "w") as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest()))
+        zf.writestr("storage/../evil.txt", "bad")
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert not (target_path / "backups").exists()
+
+
+def test_user_restore_endpoint_replaces_data_and_reports_auto_backup(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    target_path = tmp_path / "default"
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+
+    export_response = client.get("/api/users/me/export")
+    assert export_response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(export_response.content)) as zf:
+        assert "storage/tools.json" in zf.namelist()
+
+    source_path = tmp_path / "source"
+    (source_path / "outputs").mkdir(parents=True)
+    (source_path / "tools.json").write_text(json.dumps({"tool-new": _tool_record("tool-new", "new")}))
+    (source_path / "outputs" / "new.stl").write_bytes(b"new stl")
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    with package_path.open("rb") as f:
+        restore_response = client.post(
+            "/api/users/me/restore",
+            files={"backup": ("tracefinity-backup.zip", f, "application/zip")},
+        )
+
+    assert restore_response.status_code == 200
+    body = restore_response.json()
+    assert body["status"] == "restored"
+    assert body["auto_backup_filename"].startswith("tracefinity-auto-backup-")
+    assert body["auto_backup_url"].endswith(body["auto_backup_filename"])
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-new": _tool_record("tool-new", "new")}
+    assert not (target_path / "outputs" / "old.stl").exists()
+    assert (target_path / "backups" / body["auto_backup_filename"]).exists()

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -1,6 +1,7 @@
 import io
 import json
 import zipfile
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,6 +10,7 @@ from app.config import ensure_user_dirs, settings
 from app.main import app
 import app.api.routes as routes
 import app.api.user_routes as user_routes
+import app.services.backup_service as backup_service
 from app.services.backup_service import (
     BACKUP_FORMAT_VERSION,
     BACKUP_MANIFEST,
@@ -16,6 +18,7 @@ from app.services.backup_service import (
     BackupError,
     create_backup_package,
     restore_backup_package,
+    validate_backup_file_size,
 )
 
 
@@ -50,10 +53,13 @@ def test_backup_package_includes_storage_data_and_skips_saved_backups(tmp_path):
     user_path = tmp_path / "default"
     (user_path / "outputs").mkdir(parents=True)
     (user_path / "tools").mkdir()
+    (user_path / "uploads").mkdir()
     (user_path / "backups").mkdir()
     (user_path / "tools.json").write_text(json.dumps({"tool-1": _tool_record("tool-1", "pliers")}))
     (user_path / "outputs" / "bin.stl").write_bytes(b"solid bin")
     (user_path / "backups" / "older.zip").write_bytes(b"previous backup")
+    (user_path / "uploads" / "upload.tmp").write_bytes(b"partial upload")
+    (user_path / ".lockfile").write_bytes(b"lock")
 
     backup_path = tmp_path / "tracefinity-backup.zip"
     create_backup_package(user_path, backup_path)
@@ -66,6 +72,8 @@ def test_backup_package_includes_storage_data_and_skips_saved_backups(tmp_path):
     assert "storage/tools.json" in names
     assert "storage/outputs/bin.stl" in names
     assert "storage/backups/older.zip" not in names
+    assert "storage/uploads/upload.tmp" not in names
+    assert "storage/.lockfile" not in names
 
 
 def test_restore_replaces_data_and_saves_pre_restore_backup(tmp_path):
@@ -98,6 +106,66 @@ def test_restore_replaces_data_and_saves_pre_restore_backup(tmp_path):
 
     assert old_tools == {"tool-old": _tool_record("tool-old", "old")}
     assert "storage/outputs/old.stl" in names
+
+
+def test_restore_empty_backup_clears_current_data_but_keeps_backups(tmp_path):
+    source_path = tmp_path / "source"
+    source_path.mkdir()
+    package_path = tmp_path / "empty.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    (target_path / "outputs").mkdir(parents=True)
+    (target_path / "backups").mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+    (target_path / "backups" / "keep.zip").write_bytes(b"kept")
+
+    with package_path.open("rb") as f:
+        result = restore_backup_package(target_path, f)
+
+    assert result.restored_files == 0
+    assert not (target_path / "tools.json").exists()
+    assert not (target_path / "outputs").exists()
+    assert (target_path / "backups" / "keep.zip").exists()
+    assert result.auto_backup_path.exists()
+
+
+def test_restore_rolls_back_when_install_fails(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    (source_path / "outputs").mkdir(parents=True)
+    (source_path / "tools.json").write_text(json.dumps({"tool-new": _tool_record("tool-new", "new")}))
+    (source_path / "outputs" / "new.stl").write_bytes(b"new stl")
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    (target_path / "outputs").mkdir(parents=True)
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+
+    original_move = backup_service.shutil.move
+
+    def fail_install_outputs(src, dst):
+        src_path = Path(src)
+        if (
+            src_path.name == "outputs"
+            and src_path.parent.name.startswith(".restore-")
+            and not src_path.parent.name.startswith(".restore-old-")
+        ):
+            raise OSError("simulated install failure")
+        return original_move(src, dst)
+
+    monkeypatch.setattr(backup_service.shutil, "move", fail_install_outputs)
+
+    with package_path.open("rb") as f:
+        with pytest.raises(OSError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert (target_path / "outputs" / "old.stl").read_bytes() == b"old stl"
+    assert not (target_path / "outputs" / "new.stl").exists()
+    assert any((target_path / "backups").glob("tracefinity-auto-backup-*.zip"))
 
 
 def test_restore_rewrites_storage_paths_for_target_user(tmp_path):
@@ -157,6 +225,47 @@ def test_restore_rejects_invalid_store_before_changing_data(tmp_path):
 
     assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
     assert not (target_path / "backups").exists()
+
+
+def test_restore_rejects_corrupt_zip_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    package_path = tmp_path / "corrupt.zip"
+    package_path.write_bytes(b"not a zip")
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert not (target_path / "backups").exists()
+
+
+def test_restore_rejects_zip_symlink_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": _tool_record("tool-old", "old")}))
+    package_path = tmp_path / "symlink.zip"
+    symlink_info = zipfile.ZipInfo("storage/tools/link")
+    symlink_info.external_attr = 0o120777 << 16
+    with zipfile.ZipFile(package_path, "w") as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest()))
+        zf.writestr(symlink_info, "tools.json")
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": _tool_record("tool-old", "old")}
+    assert not (target_path / "backups").exists()
+
+
+def test_restore_rejects_oversized_backup_file():
+    backup_file = io.BytesIO(b"abcdef")
+
+    with pytest.raises(BackupError):
+        validate_backup_file_size(backup_file, 5)
 
 
 def test_restore_rejects_unsafe_json_path_before_changing_data(tmp_path):
@@ -232,3 +341,36 @@ def test_user_restore_endpoint_replaces_data_and_reports_auto_backup(tmp_path, m
     assert json.loads((target_path / "tools.json").read_text()) == {"tool-new": _tool_record("tool-new", "new")}
     assert not (target_path / "outputs" / "old.stl").exists()
     assert (target_path / "backups" / body["auto_backup_filename"]).exists()
+
+
+def test_user_restore_endpoint_rejects_oversized_upload(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    monkeypatch.setattr(settings, "max_backup_mb", 0)
+
+    response = client.post(
+        "/api/users/me/restore",
+        files={"backup": ("tracefinity-backup.zip", io.BytesIO(b"too large"), "application/zip")},
+    )
+
+    assert response.status_code == 413
+
+
+def test_user_backup_download_endpoint_returns_saved_backup(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    backup_dir = tmp_path / "default" / "backups"
+    backup_dir.mkdir(exist_ok=True)
+    backup_name = "tracefinity-auto-backup-20260606-120000.zip"
+    (backup_dir / backup_name).write_bytes(b"backup bytes")
+
+    response = client.get(f"/api/users/me/backups/{backup_name}")
+
+    assert response.status_code == 200
+    assert response.content == b"backup bytes"
+
+
+def test_user_backup_download_endpoint_rejects_bad_filename(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+
+    response = client.get("/api/users/me/backups/foo%5Cbar.zip")
+
+    assert response.status_code == 400

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,7 @@
 - `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
 
 ## User data
-- `GET /api/users/me/export` - download a ZIP backup of the current user's Tracefinity storage data
+- `GET /api/users/me/export` - download a ZIP backup of the current user's Tracefinity storage data, including photo station records and preview images
 - `POST /api/users/me/restore` - upload a Tracefinity ZIP backup and replace current user data; saves an automatic pre-restore backup first; limited by `MAX_BACKUP_MB`
 - `GET /api/users/me/backups/{file_name}` - download an automatic backup saved during restore
 - `DELETE /api/users/me` - delete all current user data

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@
 
 ## User data
 - `GET /api/users/me/export` - download a ZIP backup of the current user's Tracefinity storage data
-- `POST /api/users/me/restore` - upload a Tracefinity ZIP backup and replace current user data; saves an automatic pre-restore backup first
+- `POST /api/users/me/restore` - upload a Tracefinity ZIP backup and replace current user data; saves an automatic pre-restore backup first; limited by `MAX_BACKUP_MB`
 - `GET /api/users/me/backups/{file_name}` - download an automatic backup saved during restore
 - `DELETE /api/users/me` - delete all current user data
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,12 @@
 - `GET /api/bin-projects/{id}/health` - report project/tool/bin link mismatches
 - `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
 
+## User data
+- `GET /api/users/me/export` - download a ZIP backup of the current user's Tracefinity storage data
+- `POST /api/users/me/restore` - upload a Tracefinity ZIP backup and replace current user data; saves an automatic pre-restore backup first
+- `GET /api/users/me/backups/{file_name}` - download an automatic backup saved during restore
+- `DELETE /api/users/me` - delete all current user data
+
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL
 - `GET /api/files/{session_id}/bin.3mf` - session 3MF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@
 - Session persistence (JSON files)
 - Tool library, bin, and bin project persistence (JSON files)
 - STL/3MF generation with manifold3d
+- Backup/restore packages persisted user data as ZIP archives
 
 ## Frontend (Next.js 16/React/TypeScript)
 - Dashboard with project, tool library, and bin management
@@ -40,7 +41,8 @@ tracefinity/
 │   │       ├── tool_store.py              # tool library persistence
 │   │       ├── bin_store.py               # bin persistence
 │   │       ├── project_store.py           # bin project persistence
-│   │       └── project_service.py         # project summaries, health, repair
+│   │       ├── project_service.py         # project summaries, health, repair
+│   │       └── backup_service.py          # user data ZIP export/restore
 │   └── requirements.txt
 ├── frontend/
 │   ├── src/
@@ -86,10 +88,13 @@ tracefinity/
 - **Bin**: bin config + placed tools + text labels. Used for STL generation (`bins.json`).
 - **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`).
 - **Session**: ephemeral, used only for upload/trace workflow. Output is tools saved to library via `save-tools`.
+- **Backup**: a ZIP package containing Tracefinity storage metadata plus user JSON records and assets under `storage/`. Saved restore safety backups live in `backups/` and are not nested into future exports.
 
 PlacedTools sync with their library source on bin load (`GET /bins/{id}`) via `bin_service.sync_placed_tools()`. Edits to a tool's points, finger holes, or name propagate to all bins that use it. The position offset is preserved.
 
 Projects do not own tools or bins. Tools keep `project_ids`, bins keep `project_id`, and project health/repair endpoints keep those links consistent when records are renamed, deleted, or manually edited.
+
+Current bin project records are persisted by `project_store.py` as `bin-projects.json`.
 
 ## Backend route helpers
 

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -41,7 +41,7 @@ export function SettingsPopover() {
     if (!file) return
 
     const confirmed = window.confirm(
-      'Restore this backup? Existing data will be overridden. Tracefinity will first save an automatic backup with the app before replacing current data.'
+      'Restore this backup? Existing data will be overwritten. Tracefinity will first save an automatic backup with the app before replacing current data.'
     )
     if (!confirmed) return
 

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -1,14 +1,19 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Settings } from 'lucide-react'
+import { Download, Loader2, Settings, Upload } from 'lucide-react'
 import { getSettings, saveSettings } from '@/lib/settings'
+import { getBackupExportUrl, restoreBackup } from '@/lib/api'
 import { IconButton } from '@/components/IconButton'
 
 export function SettingsPopover() {
   const [open, setOpen] = useState(false)
   const [bedSize, setBedSize] = useState(256)
+  const [restoring, setRestoring] = useState(false)
+  const [backupMessage, setBackupMessage] = useState<string | null>(null)
+  const [backupError, setBackupError] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     setBedSize(getSettings().bedSize)
@@ -30,6 +35,32 @@ export function SettingsPopover() {
     saveSettings({ bedSize: v })
   }
 
+  async function handleRestoreFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+
+    const confirmed = window.confirm(
+      'Restore this backup? Existing data will be overridden. Tracefinity will first save an automatic backup with the app before replacing current data.'
+    )
+    if (!confirmed) return
+
+    setRestoring(true)
+    setBackupMessage(null)
+    setBackupError(null)
+    try {
+      const result = await restoreBackup(file)
+      const message = `Restore complete. Automatic backup saved with the app as ${result.auto_backup_filename}.`
+      setBackupMessage(message)
+      window.alert(`${message} The app will reload now.`)
+      window.location.assign('/')
+    } catch (err) {
+      setBackupError(err instanceof Error ? err.message : 'restore failed')
+    } finally {
+      setRestoring(false)
+    }
+  }
+
   const pct = ((bedSize - 150) / (400 - 150)) * 100
 
   return (
@@ -42,7 +73,7 @@ export function SettingsPopover() {
         <div className="absolute right-0 top-full mt-1.5 w-64 glass rounded-[10px] shadow-xl z-50 p-4">
           <h3 className="text-xs font-medium text-text-muted uppercase tracking-wide mb-3">Settings</h3>
 
-          <div className="space-y-1.5">
+          <div className="space-y-1.5 pb-4 border-b border-border">
             <div className="flex items-center justify-between">
               <span className="text-xs text-text-primary tracking-[0.3px]">Default Bed Size</span>
             </div>
@@ -76,6 +107,44 @@ export function SettingsPopover() {
             <p className="text-[11px] text-text-muted leading-tight mt-1">
               Bins wider than this are automatically split into printable pieces.
             </p>
+          </div>
+
+          <div className="space-y-2 pt-4">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-primary tracking-[0.3px]">Backup</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <a
+                href={getBackupExportUrl()}
+                download
+                className="glass-sm rounded-[7px] px-2.5 py-2 text-[11px] text-text-secondary flex items-center justify-center gap-1.5 hover:bg-glass-hover transition-colors"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export
+              </a>
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                disabled={restoring}
+                className="glass-sm rounded-[7px] px-2.5 py-2 text-[11px] text-text-secondary flex items-center justify-center gap-1.5 hover:bg-glass-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                {restoring ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+                Restore
+              </button>
+            </div>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".zip,application/zip"
+              className="hidden"
+              onChange={handleRestoreFile}
+            />
+            {backupMessage && (
+              <p className="text-[11px] text-green-400 leading-tight">{backupMessage}</p>
+            )}
+            {backupError && (
+              <p className="text-[11px] text-red-400 leading-tight">{backupError}</p>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,23 @@ export function getImageUrl(path: string): string {
   return `${API_URL}${path}`
 }
 
+export interface RestoreBackupResponse {
+  status: string
+  auto_backup_filename: string
+  auto_backup_url: string
+  restored_files: number
+}
+
+export function getBackupExportUrl(): string {
+  return `${API_URL}/api/users/me/export`
+}
+
+export async function restoreBackup(file: File): Promise<RestoreBackupResponse> {
+  const formData = new FormData()
+  formData.append('backup', file)
+  return fetchForm('/api/users/me/restore', formData)
+}
+
 export function getStlUrl(sessionId: string): string {
   return `${API_URL}/api/files/${sessionId}/bin.stl`
 }


### PR DESCRIPTION
## Summary
- add ZIP export and restore endpoints for user storage data
- add settings popover controls for exporting and restoring backups
- validate restore packages before replacing current data, rewrite restored storage paths for the target user, and preserve pre-restore auto-backups
- document backup/restore API and architecture behavior

## Validation
- backend\\venv\\Scripts\\python.exe -m py_compile backend\\app\\services\\backup_service.py backend\\tests\\test_backup_service.py
- npx tsc --noEmit
- git diff --check

Code and PR drafted with Codex
