### PR TITLE
Defer numeric input clamping until commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ make dev
 
 Open http://localhost:4001
 
+On Windows without `make`, run both dev servers from PowerShell:
+
+```powershell
+.\dev.ps1
+
+# optional port overrides
+.\dev.ps1 -BackendPort 8010 -FrontendPort 4011
+```
+
+The script creates `backend\venv`, installs backend requirements, and runs
+`npm install` when needed, so it can be used directly from a fresh worktree.
+
 ## Tracing Modes
 
 Tracefinity supports three ways to trace tool outlines from photos. All three produce the same output -- black and white mask images that get converted to editable polygons via OpenCV contour extraction.

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -1,16 +1,100 @@
 import logging
+import tempfile
 import shutil
+from pathlib import Path
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import Response
 
 from app.auth import get_user_id
-from app.config import settings
+from app.config import ensure_user_dirs, settings
+from app.models.schemas import RestoreResponse
+from app.services.backup_service import (
+    BACKUP_DIR_NAME,
+    BackupError,
+    backup_filename,
+    create_backup_package,
+    restore_backup_package,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _evict_user_store_cache(user_id: str) -> None:
+    from app.api.routes import _project_store_cache, _store_cache
+
+    _store_cache.pop(user_id, None)
+    _project_store_cache.pop(user_id, None)
+
+
+@router.get("/users/me/export")
+async def export_user_data(request: Request, user_id: str = Depends(get_user_id)):
+    """download a complete backup package for the authenticated user"""
+    user_path = settings.storage_path / user_id
+    ensure_user_dirs(user_path)
+
+    download_name = backup_filename()
+    with tempfile.NamedTemporaryFile(prefix="tracefinity-export-", suffix=".zip", delete=False) as tmp:
+        output_path = Path(tmp.name)
+
+    try:
+        create_backup_package(user_path, output_path)
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
+
+    return FileResponse(
+        str(output_path),
+        media_type="application/zip",
+        filename=download_name,
+        background=BackgroundTask(lambda: output_path.unlink(missing_ok=True)),
+    )
+
+
+@router.post("/users/me/restore", response_model=RestoreResponse)
+async def restore_user_data(request: Request, backup: UploadFile, user_id: str = Depends(get_user_id)):
+    """restore user data from a backup package, replacing existing app data"""
+    user_path = settings.storage_path / user_id
+    ensure_user_dirs(user_path)
+
+    try:
+        result = restore_backup_package(user_path, backup.file)
+    except BackupError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        await backup.close()
+
+    ensure_user_dirs(user_path)
+    _evict_user_store_cache(user_id)
+
+    return RestoreResponse(
+        status="restored",
+        auto_backup_filename=result.auto_backup_path.name,
+        auto_backup_url=f"/api/users/me/backups/{result.auto_backup_path.name}",
+        restored_files=result.restored_files,
+    )
+
+
+@router.get("/users/me/backups/{file_name}")
+async def download_saved_backup(request: Request, file_name: str, user_id: str = Depends(get_user_id)):
+    """download an automatic backup saved during restore"""
+    if Path(file_name).name != file_name or not file_name.endswith(".zip"):
+        raise HTTPException(status_code=400, detail="invalid backup filename")
+
+    backup_path = settings.storage_path / user_id / BACKUP_DIR_NAME / file_name
+    if not backup_path.exists() or not backup_path.is_file():
+        raise HTTPException(status_code=404, detail="backup not found")
+
+    return FileResponse(
+        str(backup_path),
+        media_type="application/zip",
+        filename=file_name,
+    )
 
 
 @router.delete("/users/me")
@@ -21,8 +105,6 @@ async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)
         shutil.rmtree(user_path)
         logger.info("deleted storage for user %s", user_id)
 
-    # evict from store cache
-    from app.api.routes import _store_cache
-    _store_cache.pop(user_id, None)
+    _evict_user_store_cache(user_id)
 
     return Response(status_code=204)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,7 +49,7 @@ settings = Settings()
 def ensure_user_dirs(user_path: Path):
     """create storage subdirs for a user"""
     user_path.mkdir(parents=True, exist_ok=True)
-    for sub in ("uploads", "processed", "outputs", "tools", "bins"):
+    for sub in ("uploads", "processed", "outputs", "tools", "bins", "backups"):
         (user_path / sub).mkdir(exist_ok=True)
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -202,6 +202,13 @@ class StatusResponse(BaseModel):
     status: str
 
 
+class RestoreResponse(BaseModel):
+    status: str
+    auto_backup_filename: str
+    auto_backup_url: str
+    restored_files: int
+
+
 # --- tool library ---
 
 class Tool(BaseModel):

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+
+BACKUP_MANIFEST = "tracefinity-backup.json"
+BACKUP_FORMAT_VERSION = 1
+BACKUP_STORAGE_PREFIX = "storage"
+BACKUP_DIR_NAME = "backups"
+EXCLUDED_TOP_LEVEL = {BACKUP_DIR_NAME}
+
+
+class BackupError(ValueError):
+    """Raised when a backup package cannot be imported safely."""
+
+
+@dataclass
+class RestoreResult:
+    auto_backup_path: Path
+    restored_files: int
+
+
+def backup_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def backup_filename(prefix: str = "tracefinity-backup") -> str:
+    return f"{prefix}-{backup_timestamp()}.zip"
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "app": "tracefinity",
+        "format_version": BACKUP_FORMAT_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "storage_prefix": BACKUP_STORAGE_PREFIX,
+    }
+
+
+def _should_export(rel_path: Path) -> bool:
+    if not rel_path.parts:
+        return False
+    if rel_path.parts[0] in EXCLUDED_TOP_LEVEL:
+        return False
+    if rel_path.name.endswith(".tmp") and rel_path.name.startswith("."):
+        return False
+    return True
+
+
+def create_backup_package(user_path: Path, output_path: Path) -> Path:
+    """Write a Tracefinity backup ZIP for one user's storage directory."""
+    user_path.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest(), indent=2))
+
+        for path in sorted(user_path.rglob("*")):
+            if not path.is_file():
+                continue
+            rel_path = path.relative_to(user_path)
+            if not _should_export(rel_path):
+                continue
+            archive_name = f"{BACKUP_STORAGE_PREFIX}/{rel_path.as_posix()}"
+            zf.write(path, archive_name)
+
+    return output_path
+
+
+def _validate_manifest(zf: zipfile.ZipFile) -> None:
+    try:
+        raw = zf.read(BACKUP_MANIFEST)
+    except KeyError as exc:
+        raise BackupError("backup is missing tracefinity metadata") from exc
+
+    try:
+        manifest = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackupError("backup metadata is not valid JSON") from exc
+
+    if manifest.get("app") != "tracefinity":
+        raise BackupError("backup was not created by Tracefinity")
+    if manifest.get("format_version") != BACKUP_FORMAT_VERSION:
+        raise BackupError("backup format is not supported by this version of Tracefinity")
+    if manifest.get("storage_prefix") != BACKUP_STORAGE_PREFIX:
+        raise BackupError("backup storage layout is not supported")
+
+
+def _storage_rel_from_archive_name(name: str) -> Path | None:
+    normalized = name.replace("\\", "/")
+    parts = [part for part in normalized.split("/") if part]
+    if not parts or parts[0] == BACKUP_MANIFEST:
+        return None
+    if parts[0] != BACKUP_STORAGE_PREFIX:
+        raise BackupError("backup contains files outside Tracefinity storage")
+    rel_parts = parts[1:]
+    if not rel_parts:
+        return None
+    if rel_parts[0] in EXCLUDED_TOP_LEVEL:
+        return None
+    for part in rel_parts:
+        if part in {".", ".."} or ":" in part:
+            raise BackupError("backup contains an unsafe file path")
+    return Path(*rel_parts)
+
+
+def extract_backup_package(backup_file: BinaryIO, staging_path: Path) -> int:
+    """Validate and extract a backup package into staging_path."""
+    staging_path.mkdir(parents=True, exist_ok=True)
+    staging_root = staging_path.resolve()
+    restored_files = 0
+
+    try:
+        with zipfile.ZipFile(backup_file) as zf:
+            _validate_manifest(zf)
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                rel_path = _storage_rel_from_archive_name(info.filename)
+                if rel_path is None:
+                    continue
+
+                dest = staging_path / rel_path
+                dest_parent = dest.parent
+                dest_parent.mkdir(parents=True, exist_ok=True)
+                resolved_dest = dest.resolve()
+                if staging_root != resolved_dest and staging_root not in resolved_dest.parents:
+                    raise BackupError("backup contains an unsafe file path")
+
+                with zf.open(info) as src, dest.open("wb") as out:
+                    shutil.copyfileobj(src, out)
+                restored_files += 1
+    except zipfile.BadZipFile as exc:
+        raise BackupError("backup file is not a valid ZIP") from exc
+
+    return restored_files
+
+
+def _clear_user_data(user_path: Path) -> None:
+    user_path.mkdir(parents=True, exist_ok=True)
+    for child in user_path.iterdir():
+        if child.name == BACKUP_DIR_NAME:
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def _copy_staged_data(staging_path: Path, user_path: Path) -> None:
+    for child in staging_path.iterdir():
+        dest = user_path / child.name
+        if child.is_dir():
+            shutil.copytree(child, dest, dirs_exist_ok=True)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(child, dest)
+
+
+def restore_backup_package(user_path: Path, backup_file: BinaryIO) -> RestoreResult:
+    """Restore a backup package, saving an automatic pre-restore backup first."""
+    user_path.mkdir(parents=True, exist_ok=True)
+    staging_path = user_path.parent / f".restore-{backup_timestamp()}-{uuid.uuid4().hex}"
+    backup_dir = user_path / BACKUP_DIR_NAME
+    auto_backup_path = backup_dir / backup_filename("tracefinity-auto-backup")
+
+    try:
+        restored_files = extract_backup_package(backup_file, staging_path)
+        create_backup_package(user_path, auto_backup_path)
+        _clear_user_data(user_path)
+        _copy_staged_data(staging_path, user_path)
+        return RestoreResult(auto_backup_path=auto_backup_path, restored_files=restored_files)
+    finally:
+        shutil.rmtree(staging_path, ignore_errors=True)

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -1,0 +1,143 @@
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import ensure_user_dirs, settings
+from app.main import app
+import app.api.routes as routes
+import app.api.user_routes as user_routes
+from app.services.backup_service import (
+    BACKUP_FORMAT_VERSION,
+    BACKUP_MANIFEST,
+    BACKUP_STORAGE_PREFIX,
+    BackupError,
+    create_backup_package,
+    restore_backup_package,
+)
+
+
+def _manifest():
+    return {
+        "app": "tracefinity",
+        "format_version": BACKUP_FORMAT_VERSION,
+        "storage_prefix": BACKUP_STORAGE_PREFIX,
+    }
+
+
+def _api_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    monkeypatch.setattr(user_routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def test_backup_package_includes_storage_data_and_skips_saved_backups(tmp_path):
+    user_path = tmp_path / "default"
+    (user_path / "outputs").mkdir(parents=True)
+    (user_path / "tools").mkdir()
+    (user_path / "backups").mkdir()
+    (user_path / "tools.json").write_text(json.dumps({"tool-1": {"name": "pliers"}}))
+    (user_path / "outputs" / "bin.stl").write_bytes(b"solid bin")
+    (user_path / "backups" / "older.zip").write_bytes(b"previous backup")
+
+    backup_path = tmp_path / "tracefinity-backup.zip"
+    create_backup_package(user_path, backup_path)
+
+    with zipfile.ZipFile(backup_path) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read(BACKUP_MANIFEST))
+
+    assert manifest["app"] == "tracefinity"
+    assert "storage/tools.json" in names
+    assert "storage/outputs/bin.stl" in names
+    assert "storage/backups/older.zip" not in names
+
+
+def test_restore_replaces_data_and_saves_pre_restore_backup(tmp_path):
+    source_path = tmp_path / "source"
+    (source_path / "outputs").mkdir(parents=True)
+    (source_path / "tools.json").write_text(json.dumps({"tool-new": {"name": "new"}}))
+    (source_path / "outputs" / "new.stl").write_bytes(b"new stl")
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    target_path = tmp_path / "default"
+    (target_path / "outputs").mkdir(parents=True)
+    (target_path / "backups").mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": {"name": "old"}}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+    (target_path / "backups" / "keep.zip").write_bytes(b"kept")
+
+    with package_path.open("rb") as f:
+        result = restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-new": {"name": "new"}}
+    assert (target_path / "outputs" / "new.stl").read_bytes() == b"new stl"
+    assert not (target_path / "outputs" / "old.stl").exists()
+    assert (target_path / "backups" / "keep.zip").exists()
+    assert result.auto_backup_path.exists()
+
+    with zipfile.ZipFile(result.auto_backup_path) as zf:
+        old_tools = json.loads(zf.read("storage/tools.json"))
+        names = set(zf.namelist())
+
+    assert old_tools == {"tool-old": {"name": "old"}}
+    assert "storage/outputs/old.stl" in names
+
+
+def test_restore_rejects_unsafe_paths_before_changing_data(tmp_path):
+    target_path = tmp_path / "default"
+    target_path.mkdir()
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": {"name": "old"}}))
+
+    package_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(package_path, "w") as zf:
+        zf.writestr(BACKUP_MANIFEST, json.dumps(_manifest()))
+        zf.writestr("storage/../evil.txt", "bad")
+
+    with package_path.open("rb") as f:
+        with pytest.raises(BackupError):
+            restore_backup_package(target_path, f)
+
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-old": {"name": "old"}}
+    assert not (target_path / "backups").exists()
+
+
+def test_user_restore_endpoint_replaces_data_and_reports_auto_backup(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    target_path = tmp_path / "default"
+    (target_path / "tools.json").write_text(json.dumps({"tool-old": {"name": "old"}}))
+    (target_path / "outputs" / "old.stl").write_bytes(b"old stl")
+
+    export_response = client.get("/api/users/me/export")
+    assert export_response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(export_response.content)) as zf:
+        assert "storage/tools.json" in zf.namelist()
+
+    source_path = tmp_path / "source"
+    (source_path / "outputs").mkdir(parents=True)
+    (source_path / "tools.json").write_text(json.dumps({"tool-new": {"name": "new"}}))
+    (source_path / "outputs" / "new.stl").write_bytes(b"new stl")
+    package_path = tmp_path / "source.zip"
+    create_backup_package(source_path, package_path)
+
+    with package_path.open("rb") as f:
+        restore_response = client.post(
+            "/api/users/me/restore",
+            files={"backup": ("tracefinity-backup.zip", f, "application/zip")},
+        )
+
+    assert restore_response.status_code == 200
+    body = restore_response.json()
+    assert body["status"] == "restored"
+    assert body["auto_backup_filename"].startswith("tracefinity-auto-backup-")
+    assert body["auto_backup_url"].endswith(body["auto_backup_filename"])
+    assert json.loads((target_path / "tools.json").read_text()) == {"tool-new": {"name": "new"}}
+    assert not (target_path / "outputs" / "old.stl").exists()
+    assert (target_path / "backups" / body["auto_backup_filename"]).exists()

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,167 @@
+[CmdletBinding()]
+param(
+    [int]$BackendPort = 8000,
+    [int]$FrontendPort = 4001,
+    [string]$ApiUrl = "",
+    [ValidateSet("auto", "cuda", "cpu")]
+    [string]$OnnxProvider = "auto",
+    [string]$ToolLabelProvider = $env:TOOL_LABEL_PROVIDER,
+    [string]$ToolLabelModel = $env:TOOL_LABEL_MODEL,
+    [string]$ToolLabelOllamaUrl = $env:TOOL_LABEL_OLLAMA_URL,
+    [switch]$NoReload
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = $PSScriptRoot
+$BackendDir = Join-Path $RootDir "backend"
+$FrontendDir = Join-Path $RootDir "frontend"
+$VenvDir = Join-Path $BackendDir "venv"
+$PythonExe = Join-Path $BackendDir "venv\Scripts\python.exe"
+$RequirementsFile = Join-Path $BackendDir "requirements.txt"
+$NodeModulesDir = Join-Path $FrontendDir "node_modules"
+
+function Invoke-Step {
+    param(
+        [string]$FilePath,
+        [string[]]$ArgumentList,
+        [string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        & $FilePath @ArgumentList
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command failed: $FilePath $($ArgumentList -join ' ')"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "npm was not found on PATH. Install Node.js, then run npm install in the frontend folder."
+}
+
+function Ensure-BackendEnvironment {
+    $InstallBackendRequirements = $false
+
+    if (-not (Test-Path $PythonExe)) {
+        $PythonCommand = Get-Command python -ErrorAction SilentlyContinue
+        if (-not $PythonCommand) {
+            throw "python was not found on PATH. Install Python 3.11+ or create backend\venv manually."
+        }
+
+        Write-Host "Creating backend virtualenv..."
+        Invoke-Step -FilePath $PythonCommand.Source -ArgumentList @("-m", "venv", $VenvDir) -WorkingDirectory $RootDir
+        $InstallBackendRequirements = $true
+    }
+    else {
+        & $PythonExe -c "import fastapi, uvicorn" *> $null
+        if ($LASTEXITCODE -ne 0) {
+            $InstallBackendRequirements = $true
+        }
+    }
+
+    if ($InstallBackendRequirements) {
+        Write-Host "Installing backend dependencies..."
+        Invoke-Step -FilePath $PythonExe -ArgumentList @("-m", "pip", "install", "-r", $RequirementsFile) -WorkingDirectory $BackendDir
+    }
+}
+
+function Ensure-FrontendEnvironment {
+    if (-not (Test-Path $NodeModulesDir)) {
+        Write-Host "Installing frontend dependencies..."
+        Invoke-Step -FilePath "npm" -ArgumentList @("install") -WorkingDirectory $FrontendDir
+    }
+}
+
+Ensure-BackendEnvironment
+Ensure-FrontendEnvironment
+
+if (-not $ApiUrl) {
+    $ApiUrl = "http://localhost:$BackendPort"
+}
+
+$BackendScript = {
+    param($BackendDir, $PythonExe, $BackendPort, $UseReload, $CorsOrigins, $OnnxProvider, $ToolLabelProvider, $ToolLabelModel, $ToolLabelOllamaUrl)
+
+    Set-Location $BackendDir
+    $env:CORS_ORIGINS = $CorsOrigins
+    $env:TRACEFINITY_ONNX_PROVIDER = $OnnxProvider
+    if ($ToolLabelProvider) {
+        $env:TOOL_LABEL_PROVIDER = $ToolLabelProvider
+    }
+    if ($ToolLabelModel) {
+        $env:TOOL_LABEL_MODEL = $ToolLabelModel
+    }
+    if ($ToolLabelOllamaUrl) {
+        $env:TOOL_LABEL_OLLAMA_URL = $ToolLabelOllamaUrl
+    }
+    $Args = @("-m", "uvicorn", "app.main:app", "--port", "$BackendPort")
+    if ($UseReload) {
+        $Args += "--reload"
+    }
+    & $PythonExe @Args
+}
+
+$FrontendScript = {
+    param($FrontendDir, $FrontendPort, $ApiUrl)
+
+    Set-Location $FrontendDir
+    $env:NEXT_PUBLIC_API_URL = $ApiUrl
+    $env:BACKEND_URL = $ApiUrl
+    & npm exec -- next dev -p $FrontendPort
+}
+
+$UseReload = -not $NoReload
+$CorsOrigins = @(
+    "http://localhost:$FrontendPort",
+    "http://127.0.0.1:$FrontendPort",
+    "http://localhost:3000",
+    "http://localhost:4001"
+) | Select-Object -Unique | ConvertTo-Json -Compress
+$Jobs = @()
+
+function Receive-DevJobOutput {
+    param([object[]]$Jobs)
+
+    $JobErrors = @()
+    $Jobs | Receive-Job -ErrorAction SilentlyContinue -ErrorVariable JobErrors
+    foreach ($JobError in $JobErrors) {
+        if ($JobError.Exception.Message) {
+            Write-Host $JobError.Exception.Message
+        }
+    }
+}
+
+Write-Host "Starting Tracefinity"
+Write-Host "Backend:  $ApiUrl"
+Write-Host "Frontend: http://localhost:$FrontendPort"
+Write-Host "ONNX:     $OnnxProvider"
+Write-Host "Press Ctrl+C to stop both processes."
+
+try {
+    $Jobs += Start-Job -Name "tracefinity-backend" -ScriptBlock $BackendScript -ArgumentList $BackendDir, $PythonExe, $BackendPort, $UseReload, $CorsOrigins, $OnnxProvider, $ToolLabelProvider, $ToolLabelModel, $ToolLabelOllamaUrl
+    $Jobs += Start-Job -Name "tracefinity-frontend" -ScriptBlock $FrontendScript -ArgumentList $FrontendDir, $FrontendPort, $ApiUrl
+
+    while ($true) {
+        Receive-DevJobOutput -Jobs $Jobs
+        $Finished = $Jobs | Where-Object { $_.State -in @("Completed", "Failed", "Stopped") }
+        if ($Finished) {
+            Receive-DevJobOutput -Jobs $Jobs
+            $Names = ($Finished | ForEach-Object { "$($_.Name): $($_.State)" }) -join ", "
+            throw "Dev process exited: $Names"
+        }
+        Start-Sleep -Milliseconds 500
+    }
+}
+finally {
+    $Running = $Jobs | Where-Object { $_.State -eq "Running" }
+    if ($Running) {
+        $Running | Stop-Job
+    }
+    Receive-DevJobOutput -Jobs $Jobs
+    $Jobs | Remove-Job
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,12 @@
 - `GET /api/bin-projects/{id}/health` - report project/tool/bin link mismatches
 - `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
 
+## User data
+- `GET /api/users/me/export` - download a ZIP backup of the current user's Tracefinity storage data
+- `POST /api/users/me/restore` - upload a Tracefinity ZIP backup and replace current user data; saves an automatic pre-restore backup first
+- `GET /api/users/me/backups/{file_name}` - download an automatic backup saved during restore
+- `DELETE /api/users/me` - delete all current user data
+
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL
 - `GET /api/files/{session_id}/bin.3mf` - session 3MF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 - Tool tracing via local models (BiRefNet Lite, IS-Net, InSPyReNet) or Gemini API
 - Manual mask upload as alternative
 - Session persistence (JSON files)
-- Tool library, bin, and bin project persistence (JSON files)
+- Tool library, bin, bin project, and backup/restore persistence (JSON files + ZIP packages)
 - STL/3MF generation with manifold3d
 
 ## Frontend (Next.js 16/React/TypeScript)
@@ -40,7 +40,8 @@ tracefinity/
 │   │       ├── tool_store.py              # tool library persistence
 │   │       ├── bin_store.py               # bin persistence
 │   │       ├── project_store.py           # bin project persistence
-│   │       └── project_service.py         # project summaries, health, repair
+│   │       ├── project_service.py         # project summaries, health, repair
+│   │       └── backup_service.py          # user data ZIP export/restore
 │   └── requirements.txt
 ├── frontend/
 │   ├── src/
@@ -84,8 +85,9 @@ tracefinity/
 - **Tool**: a single traced polygon + finger holes, stored in mm, centred at origin. Lives in a persistent library (`tools.json`).
 - **PlacedTool**: a positioned copy of a tool in a bin. Points/holes in bin-space mm. Has `tool_id` linking back to source.
 - **Bin**: bin config + placed tools + text labels. Used for STL generation (`bins.json`).
-- **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`).
+- **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`bin-projects.json`).
 - **Session**: ephemeral, used only for upload/trace workflow. Output is tools saved to library via `save-tools`.
+- **Backup**: a ZIP package containing Tracefinity storage metadata plus user JSON records and assets under `storage/`. Saved restore safety backups live in `backups/` and are not nested into future exports.
 
 PlacedTools sync with their library source on bin load (`GET /bins/{id}`) via `bin_service.sync_placed_tools()`. Edits to a tool's points, finger holes, or name propagate to all bins that use it. The position offset is preserved.
 

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -2,6 +2,7 @@
 
 import { Info } from 'lucide-react'
 import type { BinConfig } from '@/types'
+import { NumericInput } from './NumericInput'
 
 const GF_HEIGHT_UNIT = 7.0
 const GF_BASE_HEIGHT = 4.75
@@ -108,17 +109,13 @@ function SliderRow({
           style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
         />
         <div className="flex items-center gap-1">
-          <input
-            type="number"
+          <NumericInput
             min={min}
             max={max}
             step={step}
             value={value}
             disabled={disabled}
-            onChange={(e) => {
-              const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value)
-              if (!isNaN(v)) onChange(Math.min(max, Math.max(min, v)))
-            }}
+            onChange={onChange}
             className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
           />
           {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}

--- a/frontend/src/components/BinEditorToolbar.tsx
+++ b/frontend/src/components/BinEditorToolbar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { MousePointer2, Trash2, Magnet, Type, Pencil, Maximize2 } from 'lucide-react'
 import type { FingerHole, PlacedTool, TextLabel } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
+import { NumericInput } from './NumericInput'
 
 interface DepthInputProps {
   value: number | null | undefined
@@ -231,20 +232,18 @@ export function BinEditorToolbar({
           />
           <div className="flex items-center gap-0.5 text-[10px] text-text-muted" title="Text size">
             <span>Size</span>
-            <input
-              type="number"
+            <NumericInput
               value={selectedLabel.font_size}
-              onChange={e => onUpdateLabel({ font_size: Math.max(1, Math.min(50, parseFloat(e.target.value) || 1)) })}
+              onChange={font_size => onUpdateLabel({ font_size })}
               className="w-10 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
               min={1} max={50} step={0.5}
             />
           </div>
           <div className="flex items-center gap-0.5 text-[10px] text-text-muted" title="Depth into surface">
             <span>Depth</span>
-            <input
-              type="number"
+            <NumericInput
               value={selectedLabel.depth}
-              onChange={e => onUpdateLabel({ depth: Math.max(0.1, Math.min(5, parseFloat(e.target.value) || 0.5)) })}
+              onChange={depth => onUpdateLabel({ depth })}
               className="w-10 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
               min={0.1} max={5} step={0.1}
             />

--- a/frontend/src/components/BinEditorToolbar.tsx
+++ b/frontend/src/components/BinEditorToolbar.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react'
 import { MousePointer2, Trash2, Magnet, Type, Pencil, Maximize2 } from 'lucide-react'
 import type { FingerHole, PlacedTool, TextLabel } from '@/types'
-import { SNAP_GRID } from '@/lib/constants'
 import { NumericInput } from './NumericInput'
+import { SNAP_GRID } from '@/lib/constants'
 
 interface DepthInputProps {
   value: number | null | undefined

--- a/frontend/src/components/NumericInput.test.ts
+++ b/frontend/src/components/NumericInput.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { clampNumber, parseNumericInput } from './NumericInput'
+
+describe('NumericInput helpers', () => {
+  it('clamps only when parsing a committed value', () => {
+    expect(parseNumericInput('7', 1, 50, 5)).toBe(7)
+    expect(parseNumericInput('75', 1, 50, 5)).toBe(50)
+    expect(parseNumericInput('-1', 1, 50, 5)).toBe(1)
+  })
+
+  it('uses the current value as the fallback for invalid drafts', () => {
+    expect(parseNumericInput('', 1, 50, 5)).toBe(5)
+    expect(parseNumericInput('abc', 1, 50, 5)).toBe(5)
+  })
+
+  it('keeps clampNumber reusable for callers with direct slider values', () => {
+    expect(clampNumber(3, 1, 5)).toBe(3)
+    expect(clampNumber(0, 1, 5)).toBe(1)
+    expect(clampNumber(6, 1, 5)).toBe(5)
+  })
+})

--- a/frontend/src/components/NumericInput.tsx
+++ b/frontend/src/components/NumericInput.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+interface NumericInputProps {
+  value: number
+  min: number
+  max: number
+  step?: number
+  onChange: (value: number) => void
+  className?: string
+  disabled?: boolean
+}
+
+export function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function parseNumericInput(raw: string, min: number, max: number, fallback: number): number {
+  const value = parseFloat(raw.trim())
+  return Number.isNaN(value) ? fallback : clampNumber(value, min, max)
+}
+
+export function NumericInput({
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  className,
+  disabled,
+}: NumericInputProps) {
+  const [text, setText] = useState(String(value))
+  const [focused, setFocused] = useState(false)
+  const skipNextCommit = useRef(false)
+
+  useEffect(() => {
+    if (!focused) setText(String(value))
+  }, [focused, value])
+
+  const commit = (raw: string) => {
+    const next = parseNumericInput(raw, min, max, value)
+    setText(String(next))
+    if (next !== value) onChange(next)
+  }
+
+  return (
+    <input
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={text}
+      disabled={disabled}
+      onFocus={() => setFocused(true)}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={() => {
+        setFocused(false)
+        if (skipNextCommit.current) {
+          skipNextCommit.current = false
+          return
+        }
+        commit(text)
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+        if (e.key === 'Escape') {
+          skipNextCommit.current = true
+          setText(String(value))
+          e.currentTarget.blur()
+        }
+      }}
+      className={className}
+    />
+  )
+}

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -1,14 +1,19 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Settings } from 'lucide-react'
+import { Download, Loader2, Settings, Upload } from 'lucide-react'
 import { getSettings, saveSettings } from '@/lib/settings'
+import { getBackupExportUrl, restoreBackup } from '@/lib/api'
 import { IconButton } from '@/components/IconButton'
 
 export function SettingsPopover() {
   const [open, setOpen] = useState(false)
   const [bedSize, setBedSize] = useState(256)
+  const [restoring, setRestoring] = useState(false)
+  const [backupMessage, setBackupMessage] = useState<string | null>(null)
+  const [backupError, setBackupError] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     setBedSize(getSettings().bedSize)
@@ -30,6 +35,32 @@ export function SettingsPopover() {
     saveSettings({ bedSize: v })
   }
 
+  async function handleRestoreFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+
+    const confirmed = window.confirm(
+      'Restore this backup? Existing data will be overridden. Tracefinity will first save an automatic backup with the app before replacing current data.'
+    )
+    if (!confirmed) return
+
+    setRestoring(true)
+    setBackupMessage(null)
+    setBackupError(null)
+    try {
+      const result = await restoreBackup(file)
+      const message = `Restore complete. Automatic backup saved with the app as ${result.auto_backup_filename}.`
+      setBackupMessage(message)
+      window.alert(`${message} The app will reload now.`)
+      window.location.assign('/')
+    } catch (err) {
+      setBackupError(err instanceof Error ? err.message : 'restore failed')
+    } finally {
+      setRestoring(false)
+    }
+  }
+
   const pct = ((bedSize - 150) / (400 - 150)) * 100
 
   return (
@@ -39,10 +70,10 @@ export function SettingsPopover() {
       </IconButton>
 
       {open && (
-        <div className="absolute right-0 top-full mt-1.5 w-64 glass rounded-[10px] shadow-xl z-50 p-4">
+        <div className="absolute right-0 top-full mt-1.5 w-80 max-w-[calc(100vw-2rem)] glass rounded-[10px] shadow-xl z-50 p-4">
           <h3 className="text-xs font-medium text-text-muted uppercase tracking-wide mb-3">Settings</h3>
 
-          <div className="space-y-1.5">
+          <div className="space-y-1.5 pb-4 border-b border-border">
             <div className="flex items-center justify-between">
               <span className="text-xs text-text-primary tracking-[0.3px]">Default Bed Size</span>
             </div>
@@ -76,6 +107,44 @@ export function SettingsPopover() {
             <p className="text-[11px] text-text-muted leading-tight mt-1">
               Bins wider than this are automatically split into printable pieces.
             </p>
+          </div>
+
+          <div className="space-y-2 pt-4">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-primary tracking-[0.3px]">Backup</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <a
+                href={getBackupExportUrl()}
+                download
+                className="glass-sm rounded-[7px] px-2.5 py-2 text-[11px] text-text-secondary flex items-center justify-center gap-1.5 hover:bg-glass-hover transition-colors"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export
+              </a>
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                disabled={restoring}
+                className="glass-sm rounded-[7px] px-2.5 py-2 text-[11px] text-text-secondary flex items-center justify-center gap-1.5 hover:bg-glass-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                {restoring ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+                Restore
+              </button>
+            </div>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".zip,application/zip"
+              className="hidden"
+              onChange={handleRestoreFile}
+            />
+            {backupMessage && (
+              <p className="text-[11px] text-green-400 leading-tight">{backupMessage}</p>
+            )}
+            {backupError && (
+              <p className="text-[11px] text-red-400 leading-tight">{backupError}</p>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -5,6 +5,7 @@ import { Download, Loader2, Settings, Upload } from 'lucide-react'
 import { getSettings, saveSettings } from '@/lib/settings'
 import { getBackupExportUrl, restoreBackup } from '@/lib/api'
 import { IconButton } from '@/components/IconButton'
+import { NumericInput } from './NumericInput'
 
 export function SettingsPopover() {
   const [open, setOpen] = useState(false)
@@ -89,16 +90,12 @@ export function SettingsPopover() {
                 style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
               />
               <div className="flex items-center gap-1">
-                <input
-                  type="number"
+                <NumericInput
                   min={150}
                   max={400}
                   step={1}
                   value={bedSize}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value)
-                    if (!isNaN(v)) handleBedSizeChange(Math.min(400, Math.max(150, v)))
-                  }}
+                  onChange={handleBedSizeChange}
                   className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
                 />
                 <span className="text-[10px] text-text-muted w-5">mm</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,23 @@ export function getImageUrl(path: string): string {
   return `${API_URL}${path}`
 }
 
+export interface RestoreBackupResponse {
+  status: string
+  auto_backup_filename: string
+  auto_backup_url: string
+  restored_files: number
+}
+
+export function getBackupExportUrl(): string {
+  return `${API_URL}/api/users/me/export`
+}
+
+export async function restoreBackup(file: File): Promise<RestoreBackupResponse> {
+  const formData = new FormData()
+  formData.append('backup', file)
+  return fetchForm('/api/users/me/restore', formData)
+}
+
 export function getStlUrl(sessionId: string): string {
   return `${API_URL}/api/files/${sessionId}/bin.stl`
 }


### PR DESCRIPTION
## Summary
- add a shared NumericInput component that preserves draft text while a field is focused
- commit numeric edits on blur or Enter, clamp only at commit time, and let Escape revert without applying the draft
- use the shared input for bin configuration sliders, bed size settings, and text label size/depth controls

## Validation
- npm exec vitest run src/components/BinConfigurator.test.ts src/components/NumericInput.test.ts
- npm run build
- git diff --check

Code and PR drafted with Codex