### PR TITLE
Defer numeric input clamping to blur/Enter

### DIFF
--- a/frontend/e2e/numeric-input.spec.ts
+++ b/frontend/e2e/numeric-input.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, Page } from '@playwright/test'
+
+test.describe('numeric input deferred validation', () => {
+  let page: Page
+  let binId: string
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+
+    // create a bin via API so we have a configurator with numeric inputs
+    const resp = await page.request.post('http://localhost:8000/api/bins', {
+      data: { name: 'Numeric input test bin' },
+    })
+    expect(resp.ok()).toBeTruthy()
+    const body = await resp.json()
+    binId = body.id
+  })
+
+  test.afterAll(async () => {
+    if (binId) {
+      await page.request.delete(`http://localhost:8000/api/bins/${binId}`)
+    }
+    await page.close()
+  })
+
+  test('allows free typing without mid-keystroke clamping', async () => {
+    await page.goto(`/bins/${binId}`)
+    await page.waitForLoadState('networkidle')
+
+    // use the Cutout Clearance input (min=0, max=5, step=0.1) -- always enabled
+    const clearanceInput = page.locator('input[type="number"][min="0"][max="5"][step="0.1"]').first()
+    await expect(clearanceInput).toBeVisible({ timeout: 10_000 })
+
+    // clear and type a value that's within range -- should not be clamped mid-keystroke
+    await clearanceInput.click()
+    await clearanceInput.fill('')
+    await clearanceInput.pressSequentially('3', { delay: 50 })
+
+    // while still focused, the displayed value should be exactly what was typed
+    await expect(clearanceInput).toHaveValue('3')
+  })
+
+  test('clamps value on blur when out of range', async () => {
+    await page.goto(`/bins/${binId}`)
+    await page.waitForLoadState('networkidle')
+
+    // use the cutout clearance input (min=0, max=5, step=0.1)
+    const clearanceInput = page.locator('input[type="number"][min="0"][max="5"][step="0.1"]').first()
+    await expect(clearanceInput).toBeVisible({ timeout: 10_000 })
+
+    // type a value above max
+    await clearanceInput.click()
+    await clearanceInput.fill('')
+    await clearanceInput.pressSequentially('99', { delay: 50 })
+
+    // while focused, value is unclamped
+    await expect(clearanceInput).toHaveValue('99')
+
+    // blur triggers clamping to max (5)
+    await clearanceInput.blur()
+    await expect(clearanceInput).toHaveValue('5')
+  })
+
+  test('clamps value on Enter when out of range', async () => {
+    await page.goto(`/bins/${binId}`)
+    await page.waitForLoadState('networkidle')
+
+    const clearanceInput = page.locator('input[type="number"][min="0"][max="5"][step="0.1"]').first()
+    await expect(clearanceInput).toBeVisible({ timeout: 10_000 })
+
+    await clearanceInput.click()
+    await clearanceInput.fill('')
+    await clearanceInput.pressSequentially('99', { delay: 50 })
+
+    // pressing Enter commits and clamps
+    await clearanceInput.press('Enter')
+    await expect(clearanceInput).toHaveValue('5')
+  })
+
+  test('reverts to previous value on empty blur', async () => {
+    await page.goto(`/bins/${binId}`)
+    await page.waitForLoadState('networkidle')
+
+    // use the Cutout Clearance input (always enabled)
+    const clearanceInput = page.locator('input[type="number"][min="0"][max="5"][step="0.1"]').first()
+    await expect(clearanceInput).toBeVisible({ timeout: 10_000 })
+
+    const originalValue = await clearanceInput.inputValue()
+    expect(originalValue).toBeTruthy()
+
+    // clear the field and blur -- should revert to original
+    await clearanceInput.click()
+    await clearanceInput.fill('')
+    await clearanceInput.blur()
+
+    await expect(clearanceInput).toHaveValue(originalValue)
+  })
+})

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -2,6 +2,7 @@
 
 import { Info } from 'lucide-react'
 import type { BinConfig } from '@/types'
+import { NumericInput } from '@/components/NumericInput'
 
 const GF_HEIGHT_UNIT = 7.0
 const GF_BASE_HEIGHT = 4.75
@@ -108,17 +109,13 @@ function SliderRow({
           style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
         />
         <div className="flex items-center gap-1">
-          <input
-            type="number"
+          <NumericInput
             min={min}
             max={max}
             step={step}
             value={value}
             disabled={disabled}
-            onChange={(e) => {
-              const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value)
-              if (!isNaN(v)) onChange(Math.min(max, Math.max(min, v)))
-            }}
+            onChange={onChange}
             className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
           />
           {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}

--- a/frontend/src/components/BinEditorToolbar.tsx
+++ b/frontend/src/components/BinEditorToolbar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { MousePointer2, Trash2, Magnet, Type, Pencil, Maximize2 } from 'lucide-react'
 import type { FingerHole, PlacedTool, TextLabel } from '@/types'
 import { SNAP_GRID } from '@/lib/constants'
+import { NumericInput } from '@/components/NumericInput'
 
 interface DepthInputProps {
   value: number | null | undefined
@@ -231,20 +232,18 @@ export function BinEditorToolbar({
           />
           <div className="flex items-center gap-0.5 text-[10px] text-text-muted" title="Text size">
             <span>Size</span>
-            <input
-              type="number"
+            <NumericInput
               value={selectedLabel.font_size}
-              onChange={e => onUpdateLabel({ font_size: Math.max(1, Math.min(50, parseFloat(e.target.value) || 1)) })}
+              onChange={v => onUpdateLabel({ font_size: v })}
               className="w-10 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
               min={1} max={50} step={0.5}
             />
           </div>
           <div className="flex items-center gap-0.5 text-[10px] text-text-muted" title="Depth into surface">
             <span>Depth</span>
-            <input
-              type="number"
+            <NumericInput
               value={selectedLabel.depth}
-              onChange={e => onUpdateLabel({ depth: Math.max(0.1, Math.min(5, parseFloat(e.target.value) || 0.5)) })}
+              onChange={v => onUpdateLabel({ depth: v })}
               className="w-10 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
               min={0.1} max={5} step={0.1}
             />

--- a/frontend/src/components/NumericInput.test.ts
+++ b/frontend/src/components/NumericInput.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+// test the clamping logic that NumericInput uses on commit
+function clampNumeric(raw: string, min: number, max: number, step: number, fallback: number): number {
+  const trimmed = raw.trim()
+  if (trimmed === '') return fallback
+  const parsed = step < 1 ? parseFloat(trimmed) : parseInt(trimmed, 10)
+  if (Number.isNaN(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+describe('NumericInput clamping', () => {
+  it('clamps value above max to max', () => {
+    expect(clampNumeric('999', 1, 50, 1, 5)).toBe(50)
+  })
+
+  it('clamps value below min to min', () => {
+    expect(clampNumeric('0', 1, 50, 1, 5)).toBe(1)
+  })
+
+  it('passes through value within range', () => {
+    expect(clampNumeric('7', 1, 50, 1, 5)).toBe(7)
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(clampNumeric('', 1, 50, 1, 5)).toBe(5)
+  })
+
+  it('returns fallback for non-numeric text', () => {
+    expect(clampNumeric('abc', 1, 50, 1, 5)).toBe(5)
+  })
+
+  it('parses float when step < 1', () => {
+    expect(clampNumeric('3.5', 0, 10, 0.5, 1)).toBe(3.5)
+  })
+
+  it('parses int when step >= 1', () => {
+    expect(clampNumeric('3.9', 0, 10, 1, 1)).toBe(3)
+  })
+
+  it('handles whitespace-padded input', () => {
+    expect(clampNumeric('  7  ', 1, 50, 1, 5)).toBe(7)
+  })
+
+  it('clamps negative values to min', () => {
+    expect(clampNumeric('-5', 0, 100, 1, 10)).toBe(0)
+  })
+})

--- a/frontend/src/components/NumericInput.test.ts
+++ b/frontend/src/components/NumericInput.test.ts
@@ -1,13 +1,5 @@
 import { describe, expect, it } from 'vitest'
-
-// test the clamping logic that NumericInput uses on commit
-function clampNumeric(raw: string, min: number, max: number, step: number, fallback: number): number {
-  const trimmed = raw.trim()
-  if (trimmed === '') return fallback
-  const parsed = step < 1 ? parseFloat(trimmed) : parseInt(trimmed, 10)
-  if (Number.isNaN(parsed)) return fallback
-  return Math.max(min, Math.min(max, parsed))
-}
+import { clampNumericValue as clampNumeric } from './NumericInput'
 
 describe('NumericInput clamping', () => {
   it('clamps value above max to max', () => {

--- a/frontend/src/components/NumericInput.tsx
+++ b/frontend/src/components/NumericInput.tsx
@@ -12,8 +12,16 @@ interface Props {
   disabled?: boolean
 }
 
+export function clampNumericValue(raw: string, min: number, max: number, step: number, fallback: number): number {
+  const trimmed = raw.trim()
+  if (trimmed === '') return fallback
+  const parsed = step < 1 ? parseFloat(trimmed) : parseInt(trimmed, 10)
+  if (Number.isNaN(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
 // defers min/max clamping to blur or Enter -- lets users type freely
-export function NumericInput({ value, min, max, step, onChange, className, disabled }: Props) {
+export function NumericInput({ value, min, max, step = 1, onChange, className, disabled }: Props) {
   const [text, setText] = useState(String(value))
   const committedRef = useRef(value)
 
@@ -29,21 +37,12 @@ export function NumericInput({ value, min, max, step, onChange, className, disab
   }, [value])
 
   const commit = useCallback((raw: string) => {
-    const trimmed = raw.trim()
-    if (trimmed === '') {
-      // empty: revert to current committed value
-      setText(String(committedRef.current))
-      return
+    const result = clampNumericValue(raw, min, max, step, committedRef.current)
+    setText(String(result))
+    if (raw.trim() !== '') {
+      committedRef.current = result
+      onChange(result)
     }
-    const parsed = step != null && step < 1 ? parseFloat(trimmed) : parseInt(trimmed, 10)
-    if (Number.isNaN(parsed)) {
-      setText(String(committedRef.current))
-      return
-    }
-    const clamped = Math.max(min, Math.min(max, parsed))
-    setText(String(clamped))
-    committedRef.current = clamped
-    onChange(clamped)
   }, [min, max, step, onChange])
 
   return (

--- a/frontend/src/components/NumericInput.tsx
+++ b/frontend/src/components/NumericInput.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+interface Props {
+  value: number
+  min: number
+  max: number
+  step?: number
+  onChange: (v: number) => void
+  className?: string
+  disabled?: boolean
+}
+
+// defers min/max clamping to blur or Enter -- lets users type freely
+export function NumericInput({ value, min, max, step, onChange, className, disabled }: Props) {
+  const [text, setText] = useState(String(value))
+  const committedRef = useRef(value)
+
+  useEffect(() => {
+    // sync display when value changes externally (e.g. slider drag)
+    const incoming = String(value)
+    if (incoming !== text && value !== committedRef.current) {
+      setText(incoming)
+      committedRef.current = value
+    }
+    // intentionally excluding `text` -- we only want to react to external value changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  const commit = useCallback((raw: string) => {
+    const trimmed = raw.trim()
+    if (trimmed === '') {
+      // empty: revert to current committed value
+      setText(String(committedRef.current))
+      return
+    }
+    const parsed = step != null && step < 1 ? parseFloat(trimmed) : parseInt(trimmed, 10)
+    if (Number.isNaN(parsed)) {
+      setText(String(committedRef.current))
+      return
+    }
+    const clamped = Math.max(min, Math.min(max, parsed))
+    setText(String(clamped))
+    committedRef.current = clamped
+    onChange(clamped)
+  }, [min, max, step, onChange])
+
+  return (
+    <input
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={text}
+      disabled={disabled}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={(e) => commit(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          commit(e.currentTarget.value)
+          e.currentTarget.blur()
+        }
+        if (e.key === 'Escape') {
+          setText(String(committedRef.current))
+          e.currentTarget.blur()
+        }
+      }}
+      className={className}
+    />
+  )
+}

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { Settings } from 'lucide-react'
 import { getSettings, saveSettings } from '@/lib/settings'
 import { IconButton } from '@/components/IconButton'
+import { NumericInput } from '@/components/NumericInput'
 
 export function SettingsPopover() {
   const [open, setOpen] = useState(false)
@@ -58,16 +59,12 @@ export function SettingsPopover() {
                 style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
               />
               <div className="flex items-center gap-1">
-                <input
-                  type="number"
+                <NumericInput
                   min={150}
                   max={400}
                   step={1}
                   value={bedSize}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value)
-                    if (!isNaN(v)) handleBedSizeChange(Math.min(400, Math.max(150, v)))
-                  }}
+                  onChange={handleBedSizeChange}
                   className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
                 />
                 <span className="text-[10px] text-text-muted w-5">mm</span>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    exclude: ['e2e/**', 'node_modules/**'],
+  },
+})


### PR DESCRIPTION
## Summary

Fixes numeric input validation firing on every keystroke, making fields unusable. Extracts a shared `NumericInput` component that allows free typing and only clamps to min/max on blur or Enter.

Closes #55

## Changes

- New `NumericInput` component with deferred clamping logic
- Replaced inline clamping in `BinConfigurator`, `BinEditorToolbar`, `SettingsPopover`
- Exported `clampNumericValue` as a pure function for testability

## Test plan

- 9 unit tests (`NumericInput.test.ts`) covering clamping, parsing, edge cases
- 4 Playwright e2e tests (`numeric-input.spec.ts`) covering free typing, blur clamp, Enter clamp, empty revert
- `tsc --noEmit` clean
- All 14 tests pass