### PR TITLE
Fix silent data loss from bare except in store _load() methods

### DIFF
--- a/backend/app/services/bin_store.py
+++ b/backend/app/services/bin_store.py
@@ -25,7 +25,7 @@ class BinStore:
                 data = json.loads(self.file_path.read_text())
                 for bid, bdata in data.items():
                     self._bins[bid] = BinModel.model_validate(bdata)
-            except PermissionError:
+            except OSError:
                 logger.error(f"Failed to load {self.file_path}: permission denied")
                 raise
             except Exception as e:

--- a/backend/app/services/bin_store.py
+++ b/backend/app/services/bin_store.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import BinModel
+
+logger = logging.getLogger(__name__)
 
 
 class BinStore:
@@ -22,7 +25,11 @@ class BinStore:
                 data = json.loads(self.file_path.read_text())
                 for bid, bdata in data.items():
                     self._bins[bid] = BinModel.model_validate(bdata)
-            except Exception:
+            except PermissionError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                logger.error(f"Failed to load {self.file_path}: {e}")
                 self._bins = {}
 
     def _save(self):

--- a/backend/app/services/drawer_store.py
+++ b/backend/app/services/drawer_store.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import DrawerModel
+
+logger = logging.getLogger(__name__)
 
 
 class DrawerStore:
@@ -22,7 +25,11 @@ class DrawerStore:
                 data = json.loads(self.file_path.read_text())
                 for did, ddata in data.items():
                     self._drawers[did] = DrawerModel.model_validate(ddata)
-            except Exception:
+            except PermissionError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                logger.error(f"Failed to load {self.file_path}: {e}")
                 self._drawers = {}
 
     def _save(self):

--- a/backend/app/services/drawer_store.py
+++ b/backend/app/services/drawer_store.py
@@ -25,7 +25,7 @@ class DrawerStore:
                 data = json.loads(self.file_path.read_text())
                 for did, ddata in data.items():
                     self._drawers[did] = DrawerModel.model_validate(ddata)
-            except PermissionError:
+            except OSError:
                 logger.error(f"Failed to load {self.file_path}: permission denied")
                 raise
             except Exception as e:

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -25,7 +25,7 @@ class ProjectStore:
                 data = json.loads(self.file_path.read_text())
                 for pid, pdata in data.items():
                     self._projects[pid] = BinProject.model_validate(pdata)
-            except PermissionError:
+            except OSError:
                 logger.error(f"Failed to load {self.file_path}: permission denied")
                 raise
             except Exception as e:

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import BinProject
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectStore:
@@ -22,7 +25,11 @@ class ProjectStore:
                 data = json.loads(self.file_path.read_text())
                 for pid, pdata in data.items():
                     self._projects[pid] = BinProject.model_validate(pdata)
-            except Exception:
+            except PermissionError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                logger.error(f"Failed to load {self.file_path}: {e}")
                 self._projects = {}
 
     def _save(self):

--- a/backend/app/services/session_store.py
+++ b/backend/app/services/session_store.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import Session
+
+logger = logging.getLogger(__name__)
 
 
 class SessionStore:
@@ -22,7 +25,11 @@ class SessionStore:
                 data = json.loads(self.file_path.read_text())
                 for sid, sdata in data.items():
                     self._sessions[sid] = Session.model_validate(sdata)
-            except Exception:
+            except PermissionError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                logger.error(f"Failed to load {self.file_path}: {e}")
                 self._sessions = {}
 
     def _save(self):

--- a/backend/app/services/session_store.py
+++ b/backend/app/services/session_store.py
@@ -25,7 +25,7 @@ class SessionStore:
                 data = json.loads(self.file_path.read_text())
                 for sid, sdata in data.items():
                     self._sessions[sid] = Session.model_validate(sdata)
-            except PermissionError:
+            except OSError:
                 logger.error(f"Failed to load {self.file_path}: permission denied")
                 raise
             except Exception as e:

--- a/backend/app/services/tool_store.py
+++ b/backend/app/services/tool_store.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import Tool
+
+logger = logging.getLogger(__name__)
 
 
 class ToolStore:
@@ -22,7 +25,11 @@ class ToolStore:
                 data = json.loads(self.file_path.read_text())
                 for tid, tdata in data.items():
                     self._tools[tid] = Tool.model_validate(tdata)
-            except Exception:
+            except PermissionError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                logger.error(f"Failed to load {self.file_path}: {e}")
                 self._tools = {}
 
     def _save(self):

--- a/backend/app/services/tool_store.py
+++ b/backend/app/services/tool_store.py
@@ -25,7 +25,7 @@ class ToolStore:
                 data = json.loads(self.file_path.read_text())
                 for tid, tdata in data.items():
                     self._tools[tid] = Tool.model_validate(tdata)
-            except PermissionError:
+            except OSError:
                 logger.error(f"Failed to load {self.file_path}: permission denied")
                 raise
             except Exception as e:

--- a/backend/tests/test_store_load_errors.py
+++ b/backend/tests/test_store_load_errors.py
@@ -1,0 +1,130 @@
+"""tests for store _load() error handling.
+
+validates that stores don't silently cache empty data when the underlying
+file exists but can't be read (e.g. PermissionError from UID mismatch).
+"""
+
+import json
+import os
+import stat
+
+import pytest
+
+from app.services.tool_store import ToolStore
+from app.services.bin_store import BinStore
+from app.services.session_store import SessionStore
+from app.services.project_store import ProjectStore
+
+
+# -- helpers --
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_unreadable(path):
+    os.chmod(path, 0o000)
+
+
+def _restore_readable(path):
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+# -- PermissionError: store must not cache empty dict --
+
+@pytest.fixture(params=[
+    ("tools.json", ToolStore),
+    ("bins.json", BinStore),
+    ("sessions.json", SessionStore),
+    ("bin-projects.json", ProjectStore),
+])
+def store_spec(request, tmp_path):
+    filename, store_cls = request.param
+    return filename, store_cls, tmp_path
+
+
+class TestPermissionError:
+    def test_unreadable_file_raises_not_caches_empty(self, store_spec):
+        filename, store_cls, tmp_path = store_spec
+        file_path = tmp_path / filename
+        _write_json(file_path, {"item-1": _seed_data(store_cls)})
+        _make_unreadable(file_path)
+
+        try:
+            with pytest.raises(PermissionError):
+                store_cls(tmp_path)
+        finally:
+            _restore_readable(file_path)
+
+    def test_unreadable_file_logs_error(self, store_spec, caplog):
+        filename, store_cls, tmp_path = store_spec
+        file_path = tmp_path / filename
+        _write_json(file_path, {"item-1": _seed_data(store_cls)})
+        _make_unreadable(file_path)
+
+        try:
+            with pytest.raises(PermissionError):
+                import logging
+                with caplog.at_level(logging.ERROR):
+                    store_cls(tmp_path)
+
+            assert any("Failed to load" in r.message for r in caplog.records)
+        finally:
+            _restore_readable(file_path)
+
+
+# -- corrupt JSON: log and use empty dict (data is gone anyway) --
+
+class TestCorruptJson:
+    def test_corrupt_json_loads_empty(self, store_spec):
+        filename, store_cls, tmp_path = store_spec
+        file_path = tmp_path / filename
+        file_path.write_text("{invalid json!!!")
+
+        store = store_cls(tmp_path)
+        assert store.all() == {}
+
+    def test_corrupt_json_logs_error(self, store_spec, caplog):
+        filename, store_cls, tmp_path = store_spec
+        file_path = tmp_path / filename
+        file_path.write_text("{invalid json!!!")
+
+        import logging
+        with caplog.at_level(logging.ERROR):
+            store_cls(tmp_path)
+
+        assert any("Failed to load" in r.message for r in caplog.records)
+
+
+# -- normal operation still works --
+
+class TestNormalLoad:
+    def test_missing_file_loads_empty(self, store_spec):
+        _, store_cls, tmp_path = store_spec
+        store = store_cls(tmp_path)
+        assert store.all() == {}
+
+    def test_valid_file_loads_data(self, store_spec):
+        filename, store_cls, tmp_path = store_spec
+        file_path = tmp_path / filename
+        _write_json(file_path, {"item-1": _seed_data(store_cls)})
+
+        store = store_cls(tmp_path)
+        assert len(store.all()) == 1
+
+
+# -- seed data per store type --
+
+def _seed_data(store_cls):
+    """minimal valid record for each store type."""
+    from app.models.schemas import Tool, BinModel, Session, BinProject
+
+    if store_cls is ToolStore:
+        return Tool(id="item-1", name="test", points=[{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}]).model_dump()
+    elif store_cls is BinStore:
+        return BinModel(id="item-1").model_dump()
+    elif store_cls is SessionStore:
+        return Session(id="item-1").model_dump()
+    elif store_cls is ProjectStore:
+        return BinProject(id="item-1", name="test").model_dump()

--- a/backend/tests/test_store_load_errors.py
+++ b/backend/tests/test_store_load_errors.py
@@ -5,6 +5,7 @@ file exists but can't be read (e.g. PermissionError from UID mismatch).
 """
 
 import json
+import logging
 import os
 import stat
 
@@ -14,6 +15,8 @@ from app.services.tool_store import ToolStore
 from app.services.bin_store import BinStore
 from app.services.session_store import SessionStore
 from app.services.project_store import ProjectStore
+
+# DrawerStore excluded: DrawerModel doesn't exist in schemas (dead code)
 
 
 # -- helpers --
@@ -65,7 +68,6 @@ class TestPermissionError:
 
         try:
             with pytest.raises(PermissionError):
-                import logging
                 with caplog.at_level(logging.ERROR):
                     store_cls(tmp_path)
 
@@ -90,7 +92,6 @@ class TestCorruptJson:
         file_path = tmp_path / filename
         file_path.write_text("{invalid json!!!")
 
-        import logging
         with caplog.at_level(logging.ERROR):
             store_cls(tmp_path)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,18 @@ for dir in $DIRS; do
     mkdir -p "$dir" 2>/dev/null || echo "warning: cannot create $dir" >&2
 done
 
+# check storage is readable/writable by the running user.
+# pre-rootless volumes may be owned by root:0 -- surface this clearly
+# rather than letting stores silently fail at load time.
+STORAGE_DIR="${STORAGE_PATH:-/app/storage}"
+if [ -d "$STORAGE_DIR" ]; then
+    if ! touch "$STORAGE_DIR/.write-check" 2>/dev/null; then
+        echo "ERROR: storage directory $STORAGE_DIR is not writable by UID $(id -u)." >&2
+        echo "If upgrading from a pre-rootless image, fix with:" >&2
+        echo "  docker run --rm -v <your-volume>:/app/storage busybox chown -R 1000:1000 /app/storage" >&2
+        exit 1
+    fi
+    rm -f "$STORAGE_DIR/.write-check"
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary

Fixes a production incident where rootless container deployment (PR #50) against existing root-owned volumes caused all stores to silently cache empty dicts. API returned 200 with empty data, no errors in logs.

Closes #66

## Changes

- **Store _load() error handling** (all 5 stores): bare `except Exception` split into `except OSError` (re-raises -- data exists but unreadable) and `except Exception` (logs + empty dict -- corrupt/invalid data). Prevents cache poisoning on permission or filesystem errors.
- **Docker entrypoint**: startup writability check on storage directory. Exits with actionable chown instructions if storage is not writable by the running user.
- **Tests**: 24 new tests covering PermissionError re-raise, corrupt JSON graceful handling, and error logging for all active stores.

## Test evidence

- 96/96 backend tests pass
- 24 new tests in `test_store_load_errors.py` covering all 4 active stores
- DrawerStore excluded from tests (DrawerModel doesn't exist -- dead code)