### PR TITLE
Make the grid snapping distance configurable.

### DIFF
--- a/frontend/src/components/BinEditor.tsx
+++ b/frontend/src/components/BinEditor.tsx
@@ -62,6 +62,7 @@ export function BinEditor({
   const [activeTool, setActiveTool] = useState<Tool>('select')
   const [dragging, setDragging] = useState<DragState>(null)
   const [snapEnabled, setSnapEnabled] = useState(true)
+  const [snapGrid, setSnapGrid] = useState(SNAP_GRID)
   const [pendingLabel, setPendingLabel] = useState<{ x: number; y: number } | null>(null)
   const [pendingText, setPendingText] = useState('')
   const [editingLabelId, setEditingLabelId] = useState<string | null>(null)
@@ -142,8 +143,8 @@ export function BinEditor({
 
   const snapToGrid = useCallback((v: number) => {
     if (!snapEnabled) return v
-    return snapToGridUtil(v, SNAP_GRID)
-  }, [snapEnabled])
+    return snapToGridUtil(v, snapGrid)
+  }, [snapEnabled, snapGrid])
 
   const handleToolMouseDown = (toolId: string) => (e: React.MouseEvent) => {
     if (activeTool === 'text') return
@@ -511,6 +512,8 @@ export function BinEditor({
           setActiveTool={setActiveTool}
           snapEnabled={snapEnabled}
           setSnapEnabled={setSnapEnabled}
+          snapGrid={snapGrid}
+          setSnapGrid={setSnapGrid}
           handleRecenter={handleRecenter}
           selectedTool={selectedTool ?? null}
           selectedLabel={selectedLabel ?? null}

--- a/frontend/src/components/BinEditorToolbar.tsx
+++ b/frontend/src/components/BinEditorToolbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { MousePointer2, Trash2, Magnet, Type, Pencil, Maximize2 } from 'lucide-react'
 import type { FingerHole, PlacedTool, TextLabel } from '@/types'
-import { SNAP_GRID } from '@/lib/constants'
+import { SNAP_GRID_MIN, SNAP_GRID_MAX } from '@/lib/constants'
 import { NumericInput } from '@/components/NumericInput'
 
 interface DepthInputProps {
@@ -77,6 +77,8 @@ interface Props {
   setActiveTool: (tool: Tool) => void
   snapEnabled: boolean
   setSnapEnabled: (enabled: boolean) => void
+  snapGrid: number
+  setSnapGrid: (grid: number) => void
   handleRecenter: () => void
   selectedTool: PlacedTool | null
   selectedLabel: TextLabel | null
@@ -105,6 +107,8 @@ export function BinEditorToolbar({
   setActiveTool,
   snapEnabled,
   setSnapEnabled,
+  snapGrid,
+  setSnapGrid,
   handleRecenter,
   selectedTool,
   selectedLabel,
@@ -147,11 +151,22 @@ export function BinEditorToolbar({
       <button
         onClick={() => setSnapEnabled(!snapEnabled)}
         className={`${tbBtn} ${snapEnabled ? 'text-accent' : tbInactive}`}
-        title={`Snap to ${SNAP_GRID}mm grid${snapEnabled ? ' (on)' : ' (off)'}`}
+        title={`Snap to ${snapGrid}mm grid${snapEnabled ? ' (on)' : ' (off)'}`}
       >
         <Magnet className="w-3.5 h-3.5" />
         Snap
       </button>
+      {snapEnabled && (
+        <NumericInput
+          value={snapGrid}
+          onChange={setSnapGrid}
+          min={SNAP_GRID_MIN}
+          max={SNAP_GRID_MAX}
+          step={0.5}
+          title="Snap distance (mm) — how far apart the snap grid points are"
+          className="w-12 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
+        />
+      )}
       <button
         onClick={handleRecenter}
         className={`${tbBtn} ${tbInactive}`}

--- a/frontend/src/components/NumericInput.tsx
+++ b/frontend/src/components/NumericInput.tsx
@@ -10,6 +10,7 @@ interface Props {
   onChange: (v: number) => void
   className?: string
   disabled?: boolean
+  title?: string
 }
 
 export function clampNumericValue(raw: string, min: number, max: number, step: number, fallback: number): number {
@@ -21,7 +22,7 @@ export function clampNumericValue(raw: string, min: number, max: number, step: n
 }
 
 // defers min/max clamping to blur or Enter -- lets users type freely
-export function NumericInput({ value, min, max, step = 1, onChange, className, disabled }: Props) {
+export function NumericInput({ value, min, max, step = 1, onChange, className, disabled, title }: Props) {
   const [text, setText] = useState(String(value))
   const committedRef = useRef(value)
 
@@ -53,6 +54,7 @@ export function NumericInput({ value, min, max, step = 1, onChange, className, d
       step={step}
       value={text}
       disabled={disabled}
+      title={title}
       onChange={(e) => setText(e.target.value)}
       onBlur={(e) => commit(e.target.value)}
       onKeyDown={(e) => {

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -56,6 +56,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   const [editMode, setEditMode] = useState<EditMode>('select')
   const [dragging, setDragging] = useState<DragState>(null)
   const [snapEnabled, setSnapEnabled] = useState(true)
+  const [snapGrid, setSnapGrid] = useState(SNAP_GRID)
   const [zoom, setZoom] = useState(1)
   const [pan, setPan] = useState({ x: 0, y: 0 })
   const [cutoutOpen, setCutoutOpen] = useState(false)
@@ -235,8 +236,8 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
 
   const snapToGrid = useCallback((v: number) => {
     if (!snapEnabled) return v
-    return snapToGridUtil(v, SNAP_GRID)
-  }, [snapEnabled])
+    return snapToGridUtil(v, snapGrid)
+  }, [snapEnabled, snapGrid])
 
   const snapRef = useRef(snapToGrid)
   useEffect(() => { snapRef.current = snapToGrid }, [snapToGrid])
@@ -661,6 +662,8 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           onSmoothLevelChange={onSmoothLevelChange}
           snapEnabled={snapEnabled}
           setSnapEnabled={setSnapEnabled}
+          snapGrid={snapGrid}
+          setSnapGrid={setSnapGrid}
           canUndo={canUndo}
           canRedo={canRedo}
           handleUndo={handleUndo}

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -3,7 +3,8 @@
 import { ReactNode } from 'react'
 import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket, Locate } from 'lucide-react'
 import type { FingerHole } from '@/types'
-import { SNAP_GRID } from '@/lib/constants'
+import { SNAP_GRID_MIN, SNAP_GRID_MAX } from '@/lib/constants'
+import { NumericInput } from '@/components/NumericInput'
 
 export type EditMode = 'select' | 'add-vertex' | 'delete-vertex' | 'finger-hole' | 'circle' | 'cylinder' | 'square' | 'rectangle' | 'fill-ring'
 
@@ -21,6 +22,8 @@ interface Props {
   onSmoothLevelChange: (level: number) => void
   snapEnabled: boolean
   setSnapEnabled: (enabled: boolean) => void
+  snapGrid: number
+  setSnapGrid: (grid: number) => void
   canUndo: boolean
   canRedo: boolean
   handleUndo: () => void
@@ -44,7 +47,7 @@ interface Props {
 export function ToolEditorToolbar({
   editMode, setEditMode,
   smoothed, smoothLevel, onSmoothedChange, onSmoothLevelChange,
-  snapEnabled, setSnapEnabled,
+  snapEnabled, setSnapEnabled, snapGrid, setSnapGrid,
   canUndo, canRedo, handleUndo, handleRedo,
   cutoutOpen, setCutoutOpen,
   isCutoutMode, cutoutModeIcon, cutoutModeLabel,
@@ -192,11 +195,22 @@ export function ToolEditorToolbar({
           className={`px-2 py-1 rounded-[7px] text-[11px] flex items-center gap-1 transition-colors ${
             snapEnabled ? 'bg-accent-muted text-accent' : 'hover:bg-border/50 text-text-secondary'
           }`}
-          title={`Snap to ${SNAP_GRID}mm grid${snapEnabled ? ' (on)' : ' (off)'}`}
+          title={`Snap to ${snapGrid}mm grid${snapEnabled ? ' (on)' : ' (off)'}`}
         >
           <Magnet className="w-3.5 h-3.5" />
           Snap
         </button>
+        {snapEnabled && (
+          <NumericInput
+            value={snapGrid}
+            onChange={setSnapGrid}
+            min={SNAP_GRID_MIN}
+            max={SNAP_GRID_MAX}
+            step={0.5}
+            title="Snap distance (mm) — how far apart the snap grid points are"
+            className="w-12 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
+          />
+        )}
         <div className="flex items-center rounded-[7px] overflow-hidden border border-border-subtle text-[11px]">
           <button
             onClick={() => onSmoothedChange(false)}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,5 +1,7 @@
 export const GRID_UNIT = 42
 export const DISPLAY_SCALE = 8
-export const SNAP_GRID = 5
+export const SNAP_GRID = 5 // default snap increment in mm
+export const SNAP_GRID_MIN = 0.5
+export const SNAP_GRID_MAX = 42
 export const MAX_HISTORY = 50
 export const ZOOM_FACTOR = 1.15


### PR DESCRIPTION
adds a widget to the toolbar to allow user to set the snap distance.  Default=5mm.  increments to 1mm.  
Fixes #62 
