### PR TITLE
Add A3 and Tabloid paper sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## How It Works
 
-1. Place tools on A4/Letter paper (tools can overflow the edges)
+1. Place tools on A4, Letter, A3, or Tabloid paper (tools can overflow the edges)
 2. Take a photo from above
 3. Upload and adjust paper corners for scale calibration
 4. AI traces tool outlines automatically

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,1 +1,13 @@
+from typing import Literal
+
+
 GF_GRID = 42.0
+
+PaperSize = Literal["a4", "letter", "a3", "tabloid"]
+
+PAPER_SIZES: dict[PaperSize, tuple[float, float]] = {
+    "a4": (210, 297),
+    "letter": (215.9, 279.4),
+    "a3": (297, 420),
+    "tabloid": (279.4, 431.8),
+}

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pydantic import BaseModel, field_validator
 from typing import Literal, Optional
 
+from app.constants import PaperSize
+
 
 class Point(BaseModel):
     x: float
@@ -48,7 +50,7 @@ class UploadResponse(BaseModel):
 
 class CornersRequest(BaseModel):
     corners: list[Point]
-    paper_size: Literal["a4", "letter"]
+    paper_size: PaperSize
 
 
 class CornersResponse(BaseModel):
@@ -180,7 +182,7 @@ class Session(BaseModel):
     corrected_image_path: str | None = None
     mask_image_path: str | None = None
     corners: list[Point] | None = None
-    paper_size: Literal["a4", "letter"] | None = None
+    paper_size: PaperSize | None = None
     scale_factor: float | None = None
     polygons: list[Polygon] | None = None
     stl_path: str | None = None

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -5,14 +5,10 @@ import logging
 import math
 import numpy as np
 from pathlib import Path
-from typing import Literal
+
+from app.constants import PAPER_SIZES, PaperSize
 
 logger = logging.getLogger(__name__)
-
-PAPER_SIZES = {
-    "a4": (210, 297),
-    "letter": (215.9, 279.4),
-}
 
 PX_PER_MM = 10
 
@@ -238,7 +234,7 @@ class ImageProcessor:
                 logger.debug("paper candidate rejected: fill_ratio=%.2f at thresh=%d", fill_ratio, thresh_val)
                 continue
 
-            # check aspect ratio is paper-like (A4=0.707, Letter=0.77)
+            # check aspect ratio is paper-like (A-series=0.707, Letter=0.77, Tabloid=0.65)
             rect_w, rect_h = rect[1]
             if rect_w == 0 or rect_h == 0:
                 continue
@@ -341,7 +337,7 @@ class ImageProcessor:
         self,
         image_path: str,
         corners: list[tuple[float, float]],
-        paper_size: Literal["a4", "letter"],
+        paper_size: PaperSize,
     ) -> tuple[str, float]:
         """warp image to top-down view and return output path + scale factor.
         includes the full visible area beyond the paper so oversized tools

--- a/backend/tests/test_image_downscale.py
+++ b/backend/tests/test_image_downscale.py
@@ -1,0 +1,20 @@
+from io import BytesIO
+
+from PIL import Image
+
+from app.api.routes import MAX_UPLOAD_DIM, _downscale_image
+
+
+def _png_bytes(size: tuple[int, int]) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, color=(32, 64, 96)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_downscale_returns_actual_integer_resize_ratio():
+    original_width = 6041
+    content, ratio = _downscale_image(_png_bytes((original_width, 10)), ".png")
+    resized = Image.open(BytesIO(content))
+
+    assert resized.width == MAX_UPLOAD_DIM
+    assert ratio == resized.width / original_width

--- a/backend/tests/test_paper_sizes.py
+++ b/backend/tests/test_paper_sizes.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from app.constants import PAPER_SIZES
+from app.models.schemas import CornersRequest, Session
+
+
+def test_paper_sizes_include_larger_mapping_presets():
+    assert PAPER_SIZES["a3"] == (297, 420)
+    assert PAPER_SIZES["tabloid"] == (279.4, 431.8)
+
+
+@pytest.mark.parametrize("paper_size", ["a4", "letter", "a3", "tabloid"])
+def test_corners_request_accepts_supported_paper_sizes(paper_size):
+    req = CornersRequest(
+        paper_size=paper_size,
+        corners=[
+            {"x": 0, "y": 0},
+            {"x": 100, "y": 0},
+            {"x": 100, "y": 100},
+            {"x": 0, "y": 100},
+        ],
+    )
+
+    assert req.paper_size == paper_size
+
+
+def test_session_accepts_tabloid_paper_size():
+    session = Session(id="session-1", paper_size="tabloid")
+
+    assert session.paper_size == "tabloid"
+
+
+def test_corners_request_rejects_unknown_paper_size():
+    with pytest.raises(ValidationError):
+        CornersRequest(
+            paper_size="legal",
+            corners=[
+                {"x": 0, "y": 0},
+                {"x": 100, "y": 0},
+                {"x": 100, "y": 100},
+                {"x": 0, "y": 100},
+            ],
+        )

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ Reference for AI agents. Check here before suggesting new features or claiming s
 
 - Image upload (drag-drop or file picker, JPG/PNG/WebP/HEIC)
 - Paper corner detection with draggable handles
-- Paper size presets (A4, Letter)
+- Paper size presets (A4, Letter, A3, Tabloid)
 - AI tracing (multiple tracer backends: IS-Net, BiRefNet, InSPyReNet)
 - Remote tracing via Replicate (`REPLICATE_API_TOKEN`, model `men1scus/birefnet` by default; `REPLICATE_RESOLUTION` optional)
 - Remote tracing via fal.ai (`FAL_KEY`, model `fal-ai/birefnet/v2` by default; `FAL_OPERATING_RESOLUTION` default `1024x1024`). Uses `sync_mode` so results are not stored in fal request history; Replicate predictions auto-purge after ~1h.

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -51,7 +51,7 @@ Boolean operations (add, subtract) are single-threaded in OCCT. More cores don't
 
 Uses a two-stage approach: U2-Net Portable generates a rough tool mask (~0.17s), tool pixels are blacked out, then OpenCV brightness thresholding finds the paper rectangle in the cleaned image. This prevents tools (especially dark ones on white paper) from fragmenting the paper region during detection.
 
-The brightness detection tries multiple thresholds (200, 190, 180), picks the largest valid candidate, and validates against aspect ratio (0.55-0.85, covering A4 and Letter) and fill ratio (>35% of the bounding rectangle is bright). A convex hull merge step handles cases where the paper is split into fragments.
+The brightness detection tries multiple thresholds (200, 190, 180), picks the largest valid candidate, and validates against aspect ratio (0.55-0.85, covering A-series, Letter, and Tabloid) and fill ratio (>35% of the bounding rectangle is bright). A convex hull merge step handles cases where the paper is split into fragments.
 
 Difficult cases: hands in the frame, sticks/rods crossing the paper, very heavy tool overflow with minimal visible paper. These may need manual corner adjustment.
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -20,10 +20,10 @@ Without an API key, tracing uses a local model (IS-Net by default). See [tracing
 
 ## Your first trace
 
-1. Place tools flat on a sheet of A4 or Letter paper. Use a contrasting surface underneath.
+1. Place tools flat on a sheet of A4, Letter, A3, or Tabloid paper. Use a contrasting surface underneath.
 2. Photograph from above. Directly overhead gives the best scale accuracy.
 3. From the home page, drag and drop your photo onto the uploader (or click to browse). JPG, PNG, WebP, and HEIC are accepted.
-4. Drag the four corner handles onto the paper edges. Select A4 or Letter.
+4. Drag the four corner handles onto the paper edges. Select A4, Letter, A3, or Tabloid.
 5. Tracing starts automatically. The AI generates silhouette masks for each tool, typically in a few seconds.
 6. Click to select which traced tools to keep. Selected tools are saved to your library.
 

--- a/docs/usage/uploading-photos.md
+++ b/docs/usage/uploading-photos.md
@@ -2,7 +2,7 @@
 
 ## Paper as a size reference
 
-Tracefinity uses a sheet of paper as a known-size reference to scale outlines to real-world dimensions. Place tools flat on A4 or Letter paper.
+Tracefinity uses a sheet of paper as a known-size reference to scale outlines to real-world dimensions. Place tools flat on A4, Letter, A3, or Tabloid paper.
 
 The paper is for scale only. Tools can overflow the paper edges. The full visible area beyond the paper is included in the corrected image.
 
@@ -22,4 +22,4 @@ Images are automatically downscaled to a maximum of 2048px on the longest edge. 
 
 ## Paper size
 
-After uploading, select A4 or Letter. Pick whichever you actually used. This determines the scale of everything downstream: tool outlines, bin dimensions, and exported STL geometry.
+After uploading, select A4, Letter, A3, or Tabloid. Pick whichever you actually used. This determines the scale of everything downstream: tool outlines, bin dimensions, and exported STL geometry.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -742,7 +742,7 @@ export default function HomePage() {
           {!collapsedSections.howItWorks && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
             {[
-              { Illustration: PhotoIllustration, label: '1. Photograph', caption: 'Place tools on A4 or Letter paper and photograph from above' },
+              { Illustration: PhotoIllustration, label: '1. Photograph', caption: 'Place tools on A4, Letter, A3, or Tabloid paper and photograph from above' },
               { Illustration: CornersIllustration, label: '2. Corners', caption: 'Adjust the paper corners so we know the scale' },
               { Illustration: TraceIllustration, label: '3. Trace', caption: 'AI traces tool outlines into precise silhouettes' },
               { Illustration: OrganiseIllustration, label: '4. Organise', caption: 'Arrange tools in a bin and export the STL for printing' },

--- a/frontend/src/app/trace/[id]/page.tsx
+++ b/frontend/src/app/trace/[id]/page.tsx
@@ -11,9 +11,16 @@ import { Alert } from '@/components/Alert'
 import { getSession, setCorners, traceTools, updatePolygons, updateSession, getImageUrl, getAvailableKeys, traceFromMask, saveToolsFromSession } from '@/lib/api'
 import { CornersHint, TraceHint, EditHint } from '@/components/OnboardingIllustrations'
 import { StepBar } from '@/components/StepBar'
-import type { Point, Polygon, Session } from '@/types'
+import type { PaperSize, Point, Polygon, Session } from '@/types'
 
 type Step = 'corners' | 'trace' | 'edit'
+
+const PAPER_SIZE_OPTIONS: { value: PaperSize; label: string }[] = [
+  { value: 'a4', label: 'A4' },
+  { value: 'letter', label: 'Letter' },
+  { value: 'a3', label: 'A3' },
+  { value: 'tabloid', label: 'Tabloid' },
+]
 
 const MASK_PROMPT = `Generate a pure black and white silhouette mask of ONLY the tools/objects in this image.
 - Tools should be solid BLACK (#000000)
@@ -42,7 +49,7 @@ export default function TracePage() {
   const [error, setError] = useState<string | null>(null)
 
   const [corners, setLocalCorners] = useState<Point[]>([])
-  const [paperSize, setPaperSize] = useState<'a4' | 'letter'>('a4')
+  const [paperSize, setPaperSize] = useState<PaperSize>('a4')
   const [imageUrl, setImageUrl] = useState<string>('')
   const [correctedImageUrl, setCorrectedImageUrl] = useState<string>('')
   const [polygons, setPolygons] = useState<Polygon[]>([])
@@ -97,6 +104,9 @@ export default function TracePage() {
 
         if (s.corners) {
           setLocalCorners(s.corners)
+        }
+        if (s.paper_size) {
+          setPaperSize(s.paper_size)
         }
         if (s.corrected_image_path) {
           setCorrectedImageUrl(`/storage/${s.corrected_image_path}`)
@@ -354,27 +364,20 @@ export default function TracePage() {
 
               <div>
                 <span className="text-xs text-text-primary tracking-[0.3px]">Paper Size</span>
-                <div className="inline-flex rounded-[10px] glass p-0.5 mt-1.5">
-                  <button
-                    onClick={() => setPaperSize('a4')}
-                    className={`px-3 py-1 rounded text-xs font-medium ${
-                      paperSize === 'a4'
-                        ? 'bg-surface text-text-primary shadow-sm'
-                        : 'text-text-muted hover:text-text-primary'
-                    }`}
-                  >
-                    A4
-                  </button>
-                  <button
-                    onClick={() => setPaperSize('letter')}
-                    className={`px-3 py-1 rounded text-xs font-medium ${
-                      paperSize === 'letter'
-                        ? 'bg-surface text-text-primary shadow-sm'
-                        : 'text-text-muted hover:text-text-primary'
-                    }`}
-                  >
-                    Letter
-                  </button>
+                <div className="grid grid-cols-2 gap-0.5 rounded-[10px] glass p-0.5 mt-1.5 w-full">
+                  {PAPER_SIZE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      onClick={() => setPaperSize(option.value)}
+                      className={`h-7 px-2 rounded text-xs font-medium whitespace-nowrap ${
+                        paperSize === option.value
+                          ? 'bg-surface text-text-primary shadow-sm'
+                          : 'text-text-muted hover:text-text-primary'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const STEPS = [
-  { Illustration: PhotoIllustration, label: '1. Photograph', caption: 'Place your tools on a sheet of A4 or Letter paper and take a photo from above.' },
+  { Illustration: PhotoIllustration, label: '1. Photograph', caption: 'Place your tools on a sheet of A4, Letter, A3, or Tabloid paper and take a photo from above.' },
   { Illustration: CornersIllustration, label: '2. Adjust corners', caption: 'Drag the corner handles to match the paper edges. This gives us the scale.' },
   { Illustration: TraceIllustration, label: '3. Trace', caption: 'AI generates a silhouette mask and traces the tool outlines automatically.' },
   { Illustration: OrganiseIllustration, label: '4. Organise & export', caption: 'Arrange tools in a gridfinity bin layout and download the STL for 3D printing.' },

--- a/frontend/src/components/ImageUploader.tsx
+++ b/frontend/src/components/ImageUploader.tsx
@@ -220,7 +220,7 @@ export function ImageUploader({ onUpload, disabled }: Props) {
             <ul className="text-sm text-text-secondary leading-relaxed space-y-1.5 mb-5">
               <li className="flex items-start gap-2 justify-center sm:justify-start">
                 <span className="mt-[7px] block w-1.5 h-1.5 rounded-full bg-accent/50 flex-shrink-0" />
-                Place tools on A4 or Letter paper
+                Place tools on A4, Letter, A3, or Tabloid paper
               </li>
               <li className="flex items-start gap-2 justify-center sm:justify-start">
                 <span className="mt-[7px] block w-1.5 h-1.5 rounded-full bg-accent/50 flex-shrink-0" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   BinSummary,
   PlacedTool,
   TextLabel,
+  PaperSize,
 } from '@/types'
 
 export class ApiError extends Error {
@@ -73,7 +74,7 @@ export async function uploadImage(file: File): Promise<UploadResponse> {
 export async function setCorners(
   sessionId: string,
   corners: Point[],
-  paperSize: 'a4' | 'letter'
+  paperSize: PaperSize
 ): Promise<CornersResponse> {
   return fetchApi(`/api/sessions/${sessionId}/corners`, {
     method: 'POST',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,8 @@ export interface Point {
   y: number
 }
 
+export type PaperSize = 'a4' | 'letter' | 'a3' | 'tabloid'
+
 export interface FingerHole {
   id: string
   x: number
@@ -52,7 +54,7 @@ export interface Session {
   corrected_image_path: string | null
   mask_image_path: string | null
   corners: Point[] | null
-  paper_size: 'a4' | 'letter' | null
+  paper_size: PaperSize | null
   scale_factor: number | null
   polygons: Polygon[] | null
   stl_path: string | null


### PR DESCRIPTION
## Summary

- Add A3 and Tabloid as supported paper-size presets for trace calibration.
- Keep backend constants, request/session schemas, frontend types, and the trace-page selector in sync.
- Preserve saved session paper size when reloading the trace page so A3/Tabloid sessions do not fall back to A4.
- Fix corrected-image downscale ratio reporting to use the actual integer resize ratio.
- Update user-facing docs and onboarding copy for the expanded paper-size list.

## Validation

- `git diff --check`
- `D:\Development\tracefinity\backend\venv\Scripts\python.exe -m pytest backend\tests\test_paper_sizes.py backend\tests\test_image_downscale.py -q`
  - `8 passed`
- `corepack pnpm@10.29.2 --dir frontend exec tsc --noEmit`
- `corepack pnpm@10.29.2 --dir frontend build`

Code and PR drafted with Codex