### PR TITLE
 Symmetric editing + adjustable node detail for the tool editor

### DIFF
--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -835,8 +835,12 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
         onAxisMouseDown={handleAxisMouseDown}
       />
 
-      {/* floating toolbar: top centre */}
-      <div className="absolute top-3.5 left-1/2 -translate-x-1/2 z-20 glass-toolbar px-2 py-1 pointer-events-auto">
+      {/* floating toolbar: centred in the free space to the right of the
+          breadcrumb / projects panels (left-[330px]) so it never overlaps and
+          intercepts their clicks. The band is click-through; only the panel
+          itself catches pointer events. */}
+      <div className="absolute top-3.5 left-[330px] right-3.5 z-20 flex justify-center pointer-events-none">
+        <div className="glass-toolbar px-2 py-1 max-w-full pointer-events-auto">
         <ToolEditorToolbar
           editMode={editMode}
           setEditMode={setEditMode}
@@ -878,6 +882,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           autoRotating={autoRotating}
           hasInteriorRings={currentRings.length > 0}
         />
+        </div>
       </div>
 
       {mirrorNote && (

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -3,9 +3,14 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { Plus, Circle, Disc, Square, RectangleHorizontal, Fingerprint, ImageIcon, Eye, EyeOff } from 'lucide-react'
 import type { Point, FingerHole, ToolImageContext, AffineMatrix } from '@/types'
-import { simplifyPolygon, smoothEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
+import { simplifyPolygon, smoothEpsilon, simplifyEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
 import { rotateAround, flipAround } from '@/lib/affine'
 import { rotateGeometry, centroidOf } from '@/lib/geometry'
+import {
+  symmetrize, reflectPoint, reflectHole, constrainToAxis, partnerIndex,
+  insertMirroredVertex, deleteMirroredVertex, findHolePartner, isHoleOnAxis,
+  type SymmetryAxis, type KeepSide,
+} from '@/lib/symmetry'
 import { DISPLAY_SCALE, SNAP_GRID, ZOOM_FACTOR } from '@/lib/constants'
 import { useHistory } from '@/hooks/useHistory'
 import { ToolEditorToolbar } from '@/components/ToolEditorToolbar'
@@ -37,11 +42,12 @@ const PADDING_MM = 20
 
 type DragState =
   | { type: 'vertex'; pointIdx: number }
-  | { type: 'hole'; holeId: string; startX: number; startY: number; origX: number; origY: number }
-  | { type: 'resize'; holeId: string; startX: number; startY: number; origRadius: number; origWidth?: number; origHeight?: number; centerX: number; centerY: number; anchorX?: number; anchorY?: number; rotation?: number }
-  | { type: 'rotate-hole'; holeId: string; centerX: number; centerY: number; startAngle: number; origRotation: number }
+  | { type: 'hole'; holeId: string; startX: number; startY: number; origX: number; origY: number; mirrorId?: string; onAxis?: boolean }
+  | { type: 'resize'; holeId: string; startX: number; startY: number; origRadius: number; origWidth?: number; origHeight?: number; centerX: number; centerY: number; anchorX?: number; anchorY?: number; rotation?: number; mirrorId?: string }
+  | { type: 'rotate-hole'; holeId: string; centerX: number; centerY: number; startAngle: number; origRotation: number; mirrorId?: string }
   | { type: 'rotate-polygon'; centerX: number; centerY: number; startAngle: number; origPoints: Point[]; origHoles: FingerHole[]; origRings: Point[][] }
   | { type: 'pan'; startClientX: number; startClientY: number; origPanX: number; origPanY: number; svgScale: number }
+  | { type: 'axis' }
   | null
 
 interface HistoryEntry {
@@ -59,11 +65,26 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   // would quantise corrections by up to ~3.5mm
   const [snapEnabled, setSnapEnabled] = useState(false)
   const [snapGrid, setSnapGrid] = useState(SNAP_GRID)
+  const [mirrorMode, setMirrorMode] = useState(false)
+  const [symmetryAxis, setSymmetryAxis] = useState<SymmetryAxis | null>(null)
+  const [keepSide, setKeepSide] = useState<KeepSide>('low')
+  const [mirrorNote, setMirrorNote] = useState<string | null>(null)
+  const [simplifyLevel, setSimplifyLevel] = useState(1)
+  const simplifyLevelRef = useRef(1)
+  // session-scoped "most accurate available" reference the slider re-derives from
+  const baseRef = useRef<Point[] | null>(null)
+  if (baseRef.current === null && points.length > 0) baseRef.current = points
   const [zoom, setZoom] = useState(1)
   const [pan, setPan] = useState({ x: 0, y: 0 })
   const [cutoutOpen, setCutoutOpen] = useState(false)
   const spaceHeld = useRef(false)
   const didPanRef = useRef(false)
+  const mirrorModeRef = useRef(mirrorMode)
+  const axisRef = useRef(symmetryAxis)
+  const keepSideRef = useRef(keepSide)
+  useEffect(() => { mirrorModeRef.current = mirrorMode }, [mirrorMode])
+  useEffect(() => { axisRef.current = symmetryAxis }, [symmetryAxis])
+  useEffect(() => { keepSideRef.current = keepSide }, [keepSide])
 
   // undo/redo
   const historyOnChange = useCallback((entry: HistoryEntry) => {
@@ -250,6 +271,80 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   const snapRef = useRef(snapToGrid)
   useEffect(() => { snapRef.current = snapToGrid }, [snapToGrid])
 
+  // ---- symmetric editing ----
+  const idCounter = useRef(0)
+  const newHoleId = useCallback((seed: string) => `${seed}-m${++idCounter.current}`, [])
+
+  // mirror one half onto the other, establishing the canonical symmetric order
+  const applySymmetrize = useCallback((axis: SymmetryAxis, keep: KeepSide): boolean => {
+    const result = symmetrize(pointsRef.current, holesRef.current, axis, keep, newHoleId)
+    if (!result) {
+      setMirrorNote('Outline crosses the axis more than twice — can’t mirror cleanly here.')
+      return false
+    }
+    setMirrorNote(null)
+    pushHistory({ points: result.points, fingerHoles: result.fingerHoles, interiorRings: currentRingsRef.current })
+    onPointsRef.current(result.points)
+    onHolesRef.current(result.fingerHoles)
+    return true
+  }, [newHoleId, pushHistory])
+
+  const applySymmetrizeRef = useRef(applySymmetrize)
+  useEffect(() => { applySymmetrizeRef.current = applySymmetrize }, [applySymmetrize])
+
+  // ---- node-count slider (simplify <-> accurate) ----
+  // Always re-derives from the session base, so it's lossless within a session.
+  const deriveSimplified = useCallback((level: number): Point[] | null => {
+    const base = baseRef.current
+    if (!base) return null
+    return level >= 1 ? [...base] : simplifyPolygon(base, simplifyEpsilon(base, level))
+  }, [])
+
+  const previewSimplify = useCallback((level: number) => {
+    simplifyLevelRef.current = level
+    setSimplifyLevel(level)
+    const next = deriveSimplified(level)
+    if (next) onPointsRef.current(next)
+  }, [deriveSimplified])
+
+  const commitSimplify = useCallback(() => {
+    const next = deriveSimplified(simplifyLevelRef.current)
+    if (!next) return
+    pushHistory({ points: next, fingerHoles: holesRef.current, interiorRings: currentRingsRef.current })
+    onPointsRef.current(next)
+  }, [deriveSimplified, pushHistory])
+
+  const toggleMirror = useCallback(() => {
+    if (mirrorMode) {
+      setMirrorMode(false)
+      setMirrorNote(null)
+      return
+    }
+    const pts = pointsRef.current
+    if (pts.length < 3) return
+    const c = centroidOf(pts)
+    const axis: SymmetryAxis = { orientation: 'vertical', pos: c.x }
+    if (applySymmetrize(axis, keepSide)) {
+      setSymmetryAxis(axis)
+      setMirrorMode(true)
+    }
+  }, [mirrorMode, keepSide, applySymmetrize])
+
+  // re-mirror when the user changes orientation or which half is kept
+  const setAxisOrientation = useCallback((orientation: SymmetryAxis['orientation']) => {
+    const pts = pointsRef.current
+    const c = centroidOf(pts)
+    const axis: SymmetryAxis = { orientation, pos: orientation === 'vertical' ? c.x : c.y }
+    if (applySymmetrize(axis, keepSide)) setSymmetryAxis(axis)
+  }, [keepSide, applySymmetrize])
+
+  const flipKeepSide = useCallback(() => {
+    const axis = axisRef.current
+    if (!axis) return
+    const next: KeepSide = keepSide === 'low' ? 'high' : 'low'
+    if (applySymmetrize(axis, next)) setKeepSide(next)
+  }, [keepSide, applySymmetrize])
+
   const centroid = (() => {
     if (displayPoints.length === 0) return { x: 0, y: 0 }
     const cx = displayPoints.reduce((s, p) => s + p.x, 0) / displayPoints.length
@@ -354,10 +449,36 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     }
   }
 
+  // add a cutout, mirroring it across the axis when symmetric editing is on
+  const commitCutout = (xMm: number, yMm: number) => {
+    const cutout = createCutout(xMm, yMm)
+    if (!cutout) return
+    const axis = axisRef.current
+    let updated: FingerHole[]
+    if (mirrorModeRef.current && axis) {
+      if (isHoleOnAxis(cutout, axis)) {
+        updated = [...fingerHoles, { ...cutout, ...constrainToAxis({ x: xMm, y: yMm }, axis) }]
+      } else {
+        updated = [...fingerHoles, cutout, reflectHole(cutout, axis, newHoleId(cutout.id))]
+      }
+    } else {
+      updated = [...fingerHoles, cutout]
+    }
+    pushHistory({ points, fingerHoles: updated, interiorRings: currentRings })
+    onFingerHolesChange(updated)
+  }
+
   // vertex interactions
   const handleVertexMouseDown = (pointIdx: number) => (e: React.MouseEvent) => {
     e.stopPropagation()
     if (editMode === 'delete-vertex') {
+      if (mirrorModeRef.current && axisRef.current) {
+        const updated = deleteMirroredVertex(points, pointIdx)
+        if (!updated) return
+        pushHistory({ points: updated, fingerHoles, interiorRings: currentRings })
+        onPointsChange(updated)
+        return
+      }
       if (points.length <= 3) return
       const updated = [...points]
       updated.splice(pointIdx, 1)
@@ -373,8 +494,10 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     e.stopPropagation()
     if (editMode !== 'add-vertex') return
     const pos = screenToMm(e.clientX, e.clientY)
-    const updated = [...points]
-    updated.splice(edgeIdx + 1, 0, pos)
+    const axis = axisRef.current
+    const updated = mirrorModeRef.current && axis
+      ? insertMirroredVertex(points, edgeIdx, pos, axis)
+      : (() => { const u = [...points]; u.splice(edgeIdx + 1, 0, pos); return u })()
     pushHistory({ points: updated, fingerHoles, interiorRings: currentRings })
     onPointsChange(updated)
   }
@@ -384,19 +507,17 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     e.stopPropagation()
     if (editMode !== 'select' && editMode !== 'fill-ring') {
       const pos = screenToMm(e.clientX, e.clientY)
-      const cutout = createCutout(pos.x, pos.y)
-      if (cutout) {
-        const updated = [...fingerHoles, cutout]
-        pushHistory({ points, fingerHoles: updated, interiorRings: currentRings })
-        onFingerHolesChange(updated)
-      }
+      commitCutout(pos.x, pos.y)
       return
     }
     const hole = fingerHoles.find(fh => fh.id === holeId)
     if (!hole) return
     setSelection({ type: 'hole', holeId })
     const pos = screenToMm(e.clientX, e.clientY)
-    setDragging({ type: 'hole', holeId, startX: pos.x, startY: pos.y, origX: hole.x, origY: hole.y })
+    const axis = axisRef.current
+    const mirror = mirrorModeRef.current && axis ? findHolePartner(hole, fingerHoles, axis) : undefined
+    const onAxis = !!(mirrorModeRef.current && axis && isHoleOnAxis(hole, axis))
+    setDragging({ type: 'hole', holeId, startX: pos.x, startY: pos.y, origX: hole.x, origY: hole.y, mirrorId: mirror?.id, onAxis })
   }
 
   const handleResizeMouseDown = (holeId: string, cornerIndex?: number) => (e: React.MouseEvent) => {
@@ -417,11 +538,13 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       anchorX = hole.x + lx * cosR - ly * sinR
       anchorY = hole.y + lx * sinR + ly * cosR
     }
+    const axisR = axisRef.current
+    const mirrorR = mirrorModeRef.current && axisR ? findHolePartner(hole, fingerHoles, axisR) : undefined
     setDragging({
       type: 'resize', holeId, startX: pos.x, startY: pos.y,
       origRadius: hole.radius, origWidth: hole.width, origHeight: hole.height,
       centerX: hole.x, centerY: hole.y,
-      anchorX, anchorY, rotation: hole.rotation,
+      anchorX, anchorY, rotation: hole.rotation, mirrorId: mirrorR?.id,
     })
   }
 
@@ -431,7 +554,9 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     if (!hole) return
     const pos = screenToMm(e.clientX, e.clientY)
     const startAngle = Math.atan2(pos.y - hole.y, pos.x - hole.x)
-    setDragging({ type: 'rotate-hole', holeId, centerX: hole.x, centerY: hole.y, startAngle, origRotation: hole.rotation || 0 })
+    const axisRo = axisRef.current
+    const mirrorRo = mirrorModeRef.current && axisRo ? findHolePartner(hole, fingerHoles, axisRo) : undefined
+    setDragging({ type: 'rotate-hole', holeId, centerX: hole.x, centerY: hole.y, startAngle, origRotation: hole.rotation || 0, mirrorId: mirrorRo?.id })
   }
 
   const handleBackgroundClick = (e: React.MouseEvent) => {
@@ -441,12 +566,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     }
     if (editMode === 'finger-hole' || editMode === 'circle' || editMode === 'cylinder' || editMode === 'square' || editMode === 'rectangle') {
       const pos = screenToMm(e.clientX, e.clientY)
-      const cutout = createCutout(snapToGrid(pos.x), snapToGrid(pos.y))
-      if (cutout) {
-        const updated = [...fingerHoles, cutout]
-        pushHistory({ points, fingerHoles: updated, interiorRings: currentRings })
-        onFingerHolesChange(updated)
-      }
+      commitCutout(snapToGrid(pos.x), snapToGrid(pos.y))
       return
     }
     setSelection(null)
@@ -481,20 +601,38 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     const currentPoints = dragPointsRef.current ?? pointsRef.current
     const currentHoles = dragHolesRef.current ?? holesRef.current
 
+    const axis = axisRef.current
+    const mirror = mirrorModeRef.current && axis
+
     if (dragging.type === 'vertex') {
       const updated = [...currentPoints]
-      updated[dragging.pointIdx] = { x: snap(pos.x), y: snap(pos.y) }
+      if (mirror && axis) {
+        const n = updated.length
+        const j = partnerIndex(dragging.pointIdx, n)
+        let np = { x: snap(pos.x), y: snap(pos.y) }
+        if (j === dragging.pointIdx) np = constrainToAxis(np, axis) // seam: stays on axis
+        updated[dragging.pointIdx] = np
+        if (j !== dragging.pointIdx) updated[j] = reflectPoint(np, axis)
+      } else {
+        updated[dragging.pointIdx] = { x: snap(pos.x), y: snap(pos.y) }
+      }
       setDragPoints(updated)
     } else if (dragging.type === 'hole') {
       const dx = pos.x - dragging.startX
       const dy = pos.y - dragging.startY
+      let nx = snap(dragging.origX + dx)
+      let ny = snap(dragging.origY + dy)
+      if (dragging.onAxis && axis) { const c = constrainToAxis({ x: nx, y: ny }, axis); nx = c.x; ny = c.y }
+      const twin = mirror && axis && dragging.mirrorId ? reflectPoint({ x: nx, y: ny }, axis) : null
       const updated = currentHoles.map(fh => {
-        if (fh.id !== dragging.holeId) return fh
-        return { ...fh, x: snap(dragging.origX + dx), y: snap(dragging.origY + dy) }
+        if (fh.id === dragging.holeId) return { ...fh, x: nx, y: ny }
+        if (twin && fh.id === dragging.mirrorId) return { ...fh, x: twin.x, y: twin.y }
+        return fh
       })
       setDragHoles(updated)
     } else if (dragging.type === 'resize') {
-      const updated = currentHoles.map(fh => {
+      let resized: FingerHole | null = null
+      let updated = currentHoles.map(fh => {
         if (fh.id !== dragging.holeId) return fh
         if (fh.shape === 'rectangle' && dragging.anchorX !== undefined && dragging.anchorY !== undefined) {
           // pinned corner resize: anchor stays fixed, dragged corner follows mouse
@@ -510,22 +648,36 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           // new centre = midpoint of anchor and dragged corner
           const cx = (dragging.anchorX + pos.x) / 2
           const cy = (dragging.anchorY + pos.y) / 2
-          return { ...fh, x: snap(cx), y: snap(cy), width: newW, height: newH, radius: Math.max(newW, newH) / 2 }
+          resized = { ...fh, x: snap(cx), y: snap(cy), width: newW, height: newH, radius: Math.max(newW, newH) / 2 }
+          return resized
         }
         // circle / square: distance from centre
         const dx = pos.x - dragging.centerX
         const dy = pos.y - dragging.centerY
-        return { ...fh, radius: Math.max(5, Math.sqrt(dx * dx + dy * dy)) }
+        resized = { ...fh, radius: Math.max(5, Math.sqrt(dx * dx + dy * dy)) }
+        return resized
       })
+      if (mirror && axis && dragging.mirrorId && resized) {
+        const r = resized as FingerHole
+        const c = reflectPoint({ x: r.x, y: r.y }, axis)
+        updated = updated.map(fh => fh.id === dragging.mirrorId
+          ? { ...fh, x: c.x, y: c.y, radius: r.radius, width: r.width, height: r.height }
+          : fh)
+      }
       setDragHoles(updated)
     } else if (dragging.type === 'rotate-hole') {
       const currentAngle = Math.atan2(pos.y - dragging.centerY, pos.x - dragging.centerX)
       const deltaAngle = (currentAngle - dragging.startAngle) * (180 / Math.PI)
+      const newRot = (dragging.origRotation + deltaAngle) % 360
+      const mirrorRot = ((-newRot % 360) + 360) % 360
       const updated = currentHoles.map(fh => {
-        if (fh.id !== dragging.holeId) return fh
-        return { ...fh, rotation: (dragging.origRotation + deltaAngle) % 360 }
+        if (fh.id === dragging.holeId) return { ...fh, rotation: newRot }
+        if (mirror && fh.id === dragging.mirrorId) return { ...fh, rotation: mirrorRot }
+        return fh
       })
       setDragHoles(updated)
+    } else if (dragging.type === 'axis') {
+      if (axis) setSymmetryAxis({ ...axis, pos: axis.orientation === 'vertical' ? pos.x : pos.y })
     } else if (dragging.type === 'rotate-polygon') {
       const currentAngle = Math.atan2(pos.y - dragging.centerY, pos.x - dragging.centerX)
       const delta = currentAngle - dragging.startAngle
@@ -557,6 +709,12 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     if (dragging) {
       if (dragging.type === 'pan') {
         setDragging(null)
+        return
+      }
+      if (dragging.type === 'axis') {
+        setDragging(null)
+        const axis = axisRef.current
+        if (axis) applySymmetrizeRef.current(axis, keepSideRef.current)
         return
       }
       const finalPoints = dragPointsRef.current ?? pointsRef.current
@@ -596,10 +754,19 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
 
   const handleDeleteHole = () => {
     if (selection?.type !== 'hole') return
-    const updated = fingerHoles.filter(fh => fh.id !== selection.holeId)
+    const target = fingerHoles.find(fh => fh.id === selection.holeId)
+    const axis = axisRef.current
+    const partner = mirrorModeRef.current && axis && target ? findHolePartner(target, fingerHoles, axis) : undefined
+    const remove = new Set([selection.holeId, ...(partner ? [partner.id] : [])])
+    const updated = fingerHoles.filter(fh => !remove.has(fh.id))
     pushHistory({ points, fingerHoles: updated, interiorRings: currentRings })
     onFingerHolesChange(updated)
     setSelection(null)
+  }
+
+  const handleAxisMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setDragging({ type: 'axis' })
   }
 
   const selectedHole = selection?.type === 'hole'
@@ -664,6 +831,8 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
         sourceImageContext={sourceImageContext}
         showSourceImage={showSourceImage}
         sourceImageOpacity={sourceImageOpacity}
+        symmetryAxis={mirrorMode ? symmetryAxis : null}
+        onAxisMouseDown={handleAxisMouseDown}
       />
 
       {/* floating toolbar: top centre */}
@@ -679,6 +848,17 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           setSnapEnabled={setSnapEnabled}
           snapGrid={snapGrid}
           setSnapGrid={setSnapGrid}
+          mirrorMode={mirrorMode}
+          toggleMirror={toggleMirror}
+          axisOrientation={symmetryAxis?.orientation ?? 'vertical'}
+          setAxisOrientation={setAxisOrientation}
+          keepSide={keepSide}
+          flipKeepSide={flipKeepSide}
+          simplifyLevel={simplifyLevel}
+          onSimplifyPreview={previewSimplify}
+          onSimplifyCommit={commitSimplify}
+          simplifyDisabled={mirrorMode}
+          nodeCount={points.length}
           canUndo={canUndo}
           canRedo={canRedo}
           handleUndo={handleUndo}
@@ -699,6 +879,12 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
           hasInteriorRings={currentRings.length > 0}
         />
       </div>
+
+      {mirrorNote && (
+        <div className="absolute top-[58px] left-1/2 -translate-x-1/2 z-20 glass-toolbar px-3 py-1.5 text-[11px] text-amber-300 max-w-[320px] text-center pointer-events-none">
+          {mirrorNote}
+        </div>
+      )}
 
       {/* floating properties panel: right edge, shown when hole selected */}
       {selectedHole && (

--- a/frontend/src/components/ToolEditorCanvas.tsx
+++ b/frontend/src/components/ToolEditorCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { RefObject, useState } from 'react'
 import type { Point, FingerHole, ToolImageContext } from '@/types'
+import type { SymmetryAxis } from '@/lib/symmetry'
 import { polygonPathData, smoothPathData } from '@/lib/svg'
 import { DISPLAY_SCALE } from '@/lib/constants'
 import { CutoutOverlay } from '@/components/CutoutOverlay'
@@ -48,6 +49,9 @@ interface Props {
   showSourceImage: boolean
   sourceImageOpacity: number
 
+  // symmetric editing
+  symmetryAxis?: SymmetryAxis | null
+  onAxisMouseDown?: (e: React.MouseEvent) => void
 }
 
 export function ToolEditorCanvas({
@@ -60,6 +64,7 @@ export function ToolEditorCanvas({
   displayHoles, handleHoleMouseDown, handleResizeMouseDown, handleHoleRotateMouseDown,
   handleRotatePolygonMouseDown, onRingClick,
   sourceImageContext, showSourceImage, sourceImageOpacity,
+  symmetryAxis, onAxisMouseDown,
 }: Props) {
   const stopClick = (e: React.MouseEvent) => e.stopPropagation()
   const [hoveredRing, setHoveredRing] = useState<number | null>(null)
@@ -141,6 +146,36 @@ export function ToolEditorCanvas({
             stroke={sourceImage ? 'rgb(226, 232, 240)' : 'rgb(148, 163, 184)'}
             strokeWidth={(sourceImage ? 2.5 : 2) / zoom}
           />
+
+          {/* symmetry axis */}
+          {symmetryAxis && (() => {
+            const ds = DISPLAY_SCALE
+            const vertical = symmetryAxis.orientation === 'vertical'
+            const pos = symmetryAxis.pos * ds
+            const x1 = vertical ? pos : zvbX
+            const y1 = vertical ? zvbY : pos
+            const x2 = vertical ? pos : zvbX + zvbW
+            const y2 = vertical ? zvbY + zvbH : pos
+            const hx = vertical ? pos : zvbX + zvbW * 0.5
+            const hy = vertical ? zvbY + zvbH * 0.12 : pos
+            return (
+              <g>
+                <line
+                  x1={x1} y1={y1} x2={x2} y2={y2}
+                  stroke="rgb(72, 168, 214)" strokeWidth={1.5 / zoom}
+                  strokeDasharray={`${8 / zoom},${6 / zoom}`}
+                  className="pointer-events-none"
+                />
+                <circle
+                  cx={hx} cy={hy} r={9 / zoom}
+                  fill="#1e293b" stroke="rgb(72, 168, 214)" strokeWidth={2 / zoom}
+                  className={vertical ? 'cursor-ew-resize' : 'cursor-ns-resize'}
+                  onMouseDown={onAxisMouseDown}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </g>
+            )
+          })()}
 
           {/* per-ring hit areas for fill-ring mode */}
           {editMode === 'fill-ring' && interiorRings?.map((ring, idx) => {

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket, Locate } from 'lucide-react'
+import { MousePointer2, Plus, Minus, Undo2, Redo2, Trash2, Circle, Disc, Square, RectangleHorizontal, Fingerprint, Magnet, RotateCw, RotateCcw, FlipHorizontal2, FlipVertical2, ChevronDown, PaintBucket, Locate, Columns2, Rows2, ArrowLeftRight, Waypoints } from 'lucide-react'
+import type { AxisOrientation, KeepSide } from '@/lib/symmetry'
 import type { FingerHole } from '@/types'
 import { SNAP_GRID_MIN, SNAP_GRID_MAX } from '@/lib/constants'
 import { NumericInput } from '@/components/NumericInput'
@@ -24,6 +25,17 @@ interface Props {
   setSnapEnabled: (enabled: boolean) => void
   snapGrid: number
   setSnapGrid: (grid: number) => void
+  mirrorMode: boolean
+  toggleMirror: () => void
+  axisOrientation: AxisOrientation
+  setAxisOrientation: (o: AxisOrientation) => void
+  keepSide: KeepSide
+  flipKeepSide: () => void
+  simplifyLevel: number
+  onSimplifyPreview: (level: number) => void
+  onSimplifyCommit: () => void
+  simplifyDisabled: boolean
+  nodeCount: number
   canUndo: boolean
   canRedo: boolean
   handleUndo: () => void
@@ -48,6 +60,8 @@ export function ToolEditorToolbar({
   editMode, setEditMode,
   smoothed, smoothLevel, onSmoothedChange, onSmoothLevelChange,
   snapEnabled, setSnapEnabled, snapGrid, setSnapGrid,
+  mirrorMode, toggleMirror, axisOrientation, setAxisOrientation, keepSide, flipKeepSide,
+  simplifyLevel, onSimplifyPreview, onSimplifyCommit, simplifyDisabled, nodeCount,
   canUndo, canRedo, handleUndo, handleRedo,
   cutoutOpen, setCutoutOpen,
   isCutoutMode, cutoutModeIcon, cutoutModeLabel,
@@ -211,6 +225,45 @@ export function ToolEditorToolbar({
             className="w-12 px-1 py-1 bg-elevated border border-border-subtle rounded-[6px] text-text-primary text-[10px] text-center outline-none focus:border-accent"
           />
         )}
+
+        <button
+          onClick={toggleMirror}
+          className={`px-2 py-1 rounded-[7px] text-[11px] flex items-center gap-1 transition-colors ${
+            mirrorMode ? 'bg-accent-muted text-accent' : 'hover:bg-border/50 text-text-secondary'
+          }`}
+          title="Symmetric editing — mirror one half onto the other and keep edits symmetric"
+        >
+          <FlipHorizontal2 className="w-3.5 h-3.5" />
+          Mirror
+        </button>
+        {mirrorMode && (
+          <>
+            <div className="flex items-center rounded-[7px] overflow-hidden border border-border-subtle">
+              <button
+                onClick={() => setAxisOrientation('vertical')}
+                className={`px-1.5 py-1 transition-colors ${axisOrientation === 'vertical' ? 'bg-accent-muted text-accent' : 'text-text-muted hover:text-text-secondary'}`}
+                title="Vertical axis (mirror left/right)"
+              >
+                <Columns2 className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => setAxisOrientation('horizontal')}
+                className={`px-1.5 py-1 transition-colors ${axisOrientation === 'horizontal' ? 'bg-accent-muted text-accent' : 'text-text-muted hover:text-text-secondary'}`}
+                title="Horizontal axis (mirror top/bottom)"
+              >
+                <Rows2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
+            <button
+              onClick={flipKeepSide}
+              className="px-1.5 py-1 rounded-[7px] text-[11px] flex items-center gap-1 transition-colors hover:bg-border/50 text-text-secondary"
+              title={`Keep ${axisOrientation === 'vertical' ? (keepSide === 'low' ? 'left' : 'right') : (keepSide === 'low' ? 'top' : 'bottom')} half — click to swap`}
+            >
+              <ArrowLeftRight className="w-3.5 h-3.5" />
+            </button>
+          </>
+        )}
+
         <div className="flex items-center rounded-[7px] overflow-hidden border border-border-subtle text-[11px]">
           <button
             onClick={() => onSmoothedChange(false)}
@@ -237,6 +290,31 @@ export function ToolEditorToolbar({
             title={`Smooth level: ${Math.round(smoothLevel * 100)}%`}
           />
         )}
+
+        <div className="h-4 w-px bg-border-subtle mx-0.5" />
+
+        {/* node-count slider: simple <-> accurate (re-derives from the original trace) */}
+        <div
+          className={`flex items-center gap-1.5 text-text-muted ${simplifyDisabled ? 'opacity-30' : ''}`}
+          title={simplifyDisabled
+            ? 'Detail is unavailable while Mirror mode is on'
+            : `Detail: ${nodeCount} nodes — drag toward Accurate for full trace detail, Simple for fewer nodes`}
+        >
+          <Waypoints className="w-3.5 h-3.5" />
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={simplifyLevel}
+            disabled={simplifyDisabled}
+            onChange={e => onSimplifyPreview(parseFloat(e.target.value))}
+            onPointerUp={onSimplifyCommit}
+            onKeyUp={onSimplifyCommit}
+            className="w-20 h-1 accent-accent disabled:cursor-not-allowed"
+          />
+          <span className="text-[10px] tabular-nums w-7 text-right">{nodeCount}</span>
+        </div>
 
         <div className="h-4 w-px bg-border-subtle mx-0.5" />
 

--- a/frontend/src/components/ToolEditorToolbar.tsx
+++ b/frontend/src/components/ToolEditorToolbar.tsx
@@ -70,7 +70,7 @@ export function ToolEditorToolbar({
 }: Props) {
   return (
     <>
-      <div className="flex items-center gap-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-center gap-2">
         {/* mode selector */}
         <div className="flex rounded-[7px] p-0.5">
           <button

--- a/frontend/src/lib/svg.ts
+++ b/frontend/src/lib/svg.ts
@@ -113,6 +113,18 @@ export function smoothEpsilon(level: number): number {
   return 0.3 + lv * 1.2
 }
 
+// RDP tolerance for the node-count slider. `accuracy` runs 1 (keep every vertex)
+// down to 0 (aggressive). Quadratic so the accurate end stays fine-grained while
+// the simple end decimates hard (up to ~6% of the bounding-box diagonal).
+export function simplifyEpsilon(points: Point[], accuracy: number): number {
+  if (accuracy >= 1) return 0
+  let mnX = Infinity, mnY = Infinity, mxX = -Infinity, mxY = -Infinity
+  for (const p of points) { mnX = Math.min(mnX, p.x); mnY = Math.min(mnY, p.y); mxX = Math.max(mxX, p.x); mxY = Math.max(mxY, p.y) }
+  const diag = Math.hypot(mxX - mnX, mxY - mnY)
+  const t = 1 - Math.max(0, accuracy)
+  return diag * 0.06 * t * t
+}
+
 export function snapToGrid(v: number, grid: number): number {
   return Math.round(v / grid) * grid
 }

--- a/frontend/src/lib/symmetry.ts
+++ b/frontend/src/lib/symmetry.ts
@@ -1,0 +1,262 @@
+import type { Point, FingerHole } from '@/types'
+
+// Symmetry helpers for the tool editor.
+//
+// A traced outline is never perfectly symmetric, so symmetry must first be
+// *established* (symmetrize: mirror one half onto the other) before it can be
+// *maintained* during live editing. `symmetrize` produces a polygon in a fixed
+// canonical order so that the mirror partner of any vertex is a pure index
+// function (`partnerIndex`):
+//
+//   [ A, k_1, k_2, ..., k_m, B, r_m, ..., r_1 ]
+//
+// where A and B are the two seam points lying on the axis, k_i are the kept-side
+// vertices and r_i = reflect(k_i). With n = 2m + 2 total points, partner(i) =
+// (n - i) % n, an involution whose only fixed points are the seams at 0 and n/2.
+
+export type AxisOrientation = 'vertical' | 'horizontal'
+export type KeepSide = 'low' | 'high' // low = left/top, high = right/bottom
+
+export interface SymmetryAxis {
+  orientation: AxisOrientation
+  pos: number // x for vertical, y for horizontal (mm)
+}
+
+export interface SymmetrizeResult {
+  points: Point[]
+  fingerHoles: FingerHole[]
+}
+
+const SEAM_EPS = 1e-4 // a point this close to the axis is treated as on it
+const HOLE_AXIS_TOL = 0.5 // mm; a hole centre this close to the axis is centred on it
+
+// signed distance from the axis: negative = low side, positive = high side
+function sideValue(p: Point, axis: SymmetryAxis): number {
+  return axis.orientation === 'vertical' ? p.x - axis.pos : p.y - axis.pos
+}
+
+export function reflectPoint(p: Point, axis: SymmetryAxis): Point {
+  return axis.orientation === 'vertical'
+    ? { x: 2 * axis.pos - p.x, y: p.y }
+    : { x: p.x, y: 2 * axis.pos - p.y }
+}
+
+// pin the on-axis coordinate exactly to the axis, leaving the free axis untouched
+export function constrainToAxis(p: Point, axis: SymmetryAxis): Point {
+  return axis.orientation === 'vertical' ? { x: axis.pos, y: p.y } : { x: p.x, y: axis.pos }
+}
+
+// mirror partner of vertex i in a canonical symmetric polygon of n points
+export function partnerIndex(i: number, n: number): number {
+  return (n - i) % n
+}
+
+// reflect a finger hole across the axis (centre + orientation)
+export function reflectHole(fh: FingerHole, axis: SymmetryAxis, id: string): FingerHole {
+  const c = reflectPoint({ x: fh.x, y: fh.y }, axis)
+  const rot = fh.rotation ?? 0
+  // reflection negates the orientation angle (matches the editor's flip convention)
+  const newRot = ((-rot % 360) + 360) % 360
+  return { ...fh, id, x: c.x, y: c.y, rotation: newRot }
+}
+
+function signedArea(pts: Point[]): number {
+  let a = 0
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i]
+    const q = pts[(i + 1) % pts.length]
+    a += p.x * q.y - q.x * p.y
+  }
+  return a / 2
+}
+
+// Sutherland–Hodgman clip of a polygon to the kept half-plane.
+function clipHalfPlane(poly: Point[], axis: SymmetryAxis, keep: KeepSide): Point[] {
+  const inside = (p: Point) =>
+    keep === 'low' ? sideValue(p, axis) <= SEAM_EPS : sideValue(p, axis) >= -SEAM_EPS
+  const intersect = (a: Point, b: Point): Point => {
+    const sa = sideValue(a, axis)
+    const sb = sideValue(b, axis)
+    const t = sa / (sa - sb)
+    return { x: a.x + t * (b.x - a.x), y: a.y + t * (b.y - a.y) }
+  }
+  const out: Point[] = []
+  const n = poly.length
+  for (let i = 0; i < n; i++) {
+    const cur = poly[i]
+    const prev = poly[(i + n - 1) % n]
+    const curIn = inside(cur)
+    const prevIn = inside(prev)
+    if (curIn) {
+      if (!prevIn) out.push(intersect(prev, cur))
+      out.push(cur)
+    } else if (prevIn) {
+      out.push(intersect(prev, cur))
+    }
+  }
+  return out
+}
+
+/**
+ * From a half-plane-clipped polygon, return the longest arc of off-axis vertices
+ * bounded by two seam (on-axis) points. This is the real body outline; the small
+ * arcs are tracing noise where a jagged edge re-crosses the axis. Endpoints are
+ * the two seam points (included). Returns null if there is no such arc.
+ */
+function longestArc(clipped: Point[], axis: SymmetryAxis): Point[] | null {
+  const n = clipped.length
+  const isSeam = (p: Point) => Math.abs(sideValue(p, axis)) < SEAM_EPS * 10
+  const seam = clipped.map(isSeam)
+  const start = seam.indexOf(true)
+  if (start < 0) return null // axis doesn't intersect the kept outline
+
+  let best: Point[] | null = null
+  let bestLen = -1
+  let i = start
+  do {
+    if (seam[i]) {
+      // collect the off-axis run that starts after seam i, up to the next seam
+      const arc: Point[] = [clipped[i]]
+      let j = (i + 1) % n
+      while (!seam[j] && j !== i) { arc.push(clipped[j]); j = (j + 1) % n }
+      arc.push(clipped[j])
+      if (arc.length > 2) {
+        let len = 0
+        for (let k = 1; k < arc.length; k++) {
+          len += Math.hypot(arc[k].x - arc[k - 1].x, arc[k].y - arc[k - 1].y)
+        }
+        if (len > bestLen) { bestLen = len; best = arc }
+      }
+    }
+    i = (i + 1) % n
+  } while (i !== start)
+
+  return best
+}
+
+// build the canonical [A, mids, B, reflect(mids) reversed] loop from a kept arc
+function buildSymmetric(keptArc: Point[], axis: SymmetryAxis): Point[] {
+  const A = constrainToAxis(keptArc[0], axis)
+  const B = constrainToAxis(keptArc[keptArc.length - 1], axis)
+  const mids = keptArc.slice(1, -1)
+  const reflectedRev = mids.map(p => reflectPoint(p, axis)).reverse()
+  return [A, ...mids, B, ...reflectedRev]
+}
+
+/**
+ * Mirror one half of the polygon onto the other, producing a perfectly
+ * symmetric outline in canonical order (see module header). Finger holes on the
+ * kept side are mirrored; holes on the axis are centred; holes on the discarded
+ * side are dropped.
+ *
+ * Robust to noisy traced outlines: a jagged outline crosses the axis many times
+ * near the top/bottom, so rather than requiring exactly two crossings we take the
+ * single longest off-axis arc (the real body) and discard the small wiggles near
+ * the seam. Returns null only when the axis doesn't actually pass through the
+ * outline.
+ */
+export function symmetrize(
+  points: Point[],
+  fingerHoles: FingerHole[],
+  axis: SymmetryAxis,
+  keep: KeepSide,
+  newId: (seed: string) => string,
+): SymmetrizeResult | null {
+  if (points.length < 3) return null
+  const clipped = clipHalfPlane(points, axis, keep)
+  if (clipped.length < 3) return null
+
+  let keptArc = longestArc(clipped, axis)
+  if (!keptArc) return null
+
+  let full = buildSymmetric(keptArc, axis)
+  // preserve the original winding so downstream geometry stays valid
+  if (Math.sign(signedArea(full)) !== Math.sign(signedArea(points))) {
+    keptArc = [...keptArc].reverse()
+    full = buildSymmetric(keptArc, axis)
+  }
+
+  const holes = symmetrizeHoles(fingerHoles, axis, keep, newId)
+  return { points: full, fingerHoles: holes }
+}
+
+function symmetrizeHoles(
+  holes: FingerHole[],
+  axis: SymmetryAxis,
+  keep: KeepSide,
+  newId: (seed: string) => string,
+): FingerHole[] {
+  const result: FingerHole[] = []
+  for (const fh of holes) {
+    const s = sideValue({ x: fh.x, y: fh.y }, axis)
+    if (Math.abs(s) < HOLE_AXIS_TOL) {
+      result.push({ ...fh, ...constrainToAxis({ x: fh.x, y: fh.y }, axis) })
+    } else if (keep === 'low' ? s < 0 : s > 0) {
+      result.push(fh)
+      result.push(reflectHole(fh, axis, newId(fh.id)))
+    }
+    // holes on the discarded side are dropped (regenerated as mirrors of the kept side)
+  }
+  return result
+}
+
+/**
+ * Insert a vertex on a clicked edge and its mirror on the partner edge, keeping
+ * the canonical symmetric order intact. Walks the array once, emitting each
+ * inserted point after its edge's start vertex (handles the wrap edge cleanly).
+ */
+export function insertMirroredVertex(
+  points: Point[],
+  edgeIdx: number,
+  v: Point,
+  axis: SymmetryAxis,
+): Point[] {
+  const n = points.length
+  const next = (edgeIdx + 1) % n
+  const vm = reflectPoint(v, axis)
+  const pA = partnerIndex(edgeIdx, n)
+  const pB = partnerIndex(next, n)
+
+  // array-order start vertex of an adjacent pair (wrap edge starts at n-1)
+  const edgeStart = (a: number, b: number) =>
+    (a === n - 1 && b === 0) || (b === n - 1 && a === 0) ? n - 1 : Math.min(a, b)
+
+  const clickedStart = edgeIdx
+  const mirrorStart = edgeStart(pA, pB)
+
+  const out: Point[] = []
+  for (let i = 0; i < n; i++) {
+    out.push(points[i])
+    if (i === clickedStart) out.push(v)
+    if (i === mirrorStart && mirrorStart !== clickedStart) out.push(vm)
+  }
+  return out
+}
+
+/** Remove a vertex and its mirror partner. Returns null if it can't (seam, or too few points). */
+export function deleteMirroredVertex(points: Point[], i: number): Point[] | null {
+  const n = points.length
+  const j = partnerIndex(i, n)
+  if (j === i) return null // seam point — removing it would break the structure
+  if (n - 2 < 4) return null
+  const [hi, lo] = [i, j].sort((a, b) => b - a)
+  const out = [...points]
+  out.splice(hi, 1)
+  out.splice(lo, 1)
+  return out
+}
+
+/** Find the mirror partner of a hole by reflected-centre match, if any. */
+export function findHolePartner(
+  fh: FingerHole,
+  holes: FingerHole[],
+  axis: SymmetryAxis,
+): FingerHole | undefined {
+  const t = reflectPoint({ x: fh.x, y: fh.y }, axis)
+  return holes.find(h => h.id !== fh.id && Math.hypot(h.x - t.x, h.y - t.y) < HOLE_AXIS_TOL)
+}
+
+/** True when a hole sits on the axis (no distinct mirror twin). */
+export function isHoleOnAxis(fh: FingerHole, axis: SymmetryAxis): boolean {
+  return Math.abs(sideValue({ x: fh.x, y: fh.y }, axis)) < HOLE_AXIS_TOL
+}


### PR DESCRIPTION
Fixes #61 

This PR adds a couple tools to the tool editor toolbar. 

<img width="1204" height="134" alt="image" src="https://github.com/user-attachments/assets/d36a2f15-55fe-43be-a1ad-416ba45f9f44" />


A) is a slider that will remove node detail. 

Drag toward Accurate for the full traced detail (default), toward Simple for fewer nodes. Each move re-derives from the originally-loaded outline via Ramer–Douglas–Peucker (simplifyEpsilon in  frontend/src/lib/svg.ts), so it's lossless within a session — you can dial back and forth freely. Live preview during the drag; a  single undo entry on release.

B) Toggles the symmetric editing mode.


<img width="1607" height="904" alt="image" src="https://github.com/user-attachments/assets/8265adec-a680-41ae-b7c4-86ac41bbd493" />

When symmetric editing is enabled (1)  A symmetry line (2) is placed in the vertical axis.  This can be toggled horizontal with (3) or dragged to fine tune the placement.

In symmetric mode, nodes are paired across the symmetry line.  Dragging on one side duplicates the action on the other side.


Both changes are frontend-only — the editor still emits plain points / finger_holes /  interior_rings, so nothing downstream (STL pipeline, storage, API) changes.

---
Everything routes through the existing undo/redo history.

How it works (frontend/src/lib/symmetry.ts): the outline is clipped to the kept  half-plane (Sutherland–Hodgman), the longest off-axis arc is taken as the real body —  which makes it robust to jagged traces that re-cross the axis many times — then stitched  with its reflection into a canonical vertex order where each vertex's mirror partner is  a pure index function. Live edits use that pairing.


Limitations: vertical/horizontal axes only (no arbitrary angle); a shape pinched into separate lobes across the axis keeps the largest lobe; a warning appears if the axis genuinely doesn't pass through the outline.




