### PR TITLE
Add remote tracing providers (Replicate, fal.ai)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Remote providers (hosted GPU, swap only the saliency step, all OpenCV stays
 local). Selected via `TRACERS` or auto-detected from a token when no `TRACERS`
 and no LLM key is set:
 - `replicate` -- runs `REPLICATE_MODEL` (default `men1scus/birefnet`) on
-  Replicate. Needs `REPLICATE_API_TOKEN`. API predictions auto-purge after ~1h.
+  Replicate. Needs `REPLICATE_API_TOKEN`. Resolves the model's latest version
+  (community models need a version); pin one with `owner/name:hash`. API
+  predictions auto-purge after ~1h.
 - `fal` -- runs `FAL_MODEL` (default `fal-ai/birefnet/v2`) on fal.ai. Needs
   `FAL_KEY`. Uses `mask_only` + `sync_mode` (result not stored in history).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,15 @@ Tracers (configurable via `TRACERS` env var):
 - `isnet` (default) -- IS-Net, good quality, ~0.8s/image, min 2GB
 - `birefnet-lite` -- BiRefNet Lite, best quality, ~3.6s/image, min 8GB
 - `inspyrenet` -- InSPyReNet, ~2.8s/image, min 6GB
+
+Remote providers (hosted GPU, swap only the saliency step, all OpenCV stays
+local). Selected via `TRACERS` or auto-detected from a token when no `TRACERS`
+and no LLM key is set:
+- `replicate` -- runs `REPLICATE_MODEL` (default `men1scus/birefnet`) on
+  Replicate. Needs `REPLICATE_API_TOKEN`. API predictions auto-purge after ~1h.
+- `fal` -- runs `FAL_MODEL` (default `fal-ai/birefnet/v2`) on fal.ai. Needs
+  `FAL_KEY`. Uses `mask_only` + `sync_mode` (result not stored in history).
+
+Tuning: `FAL_OPERATING_RESOLUTION` (default `1024x1024`), `REPLICATE_RESOLUTION`
+(default model resolution). User photos transit the provider when a remote
+tracer is active.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,17 @@ docker run -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/tracefinity
 # or with Gemini API
 docker run -p 3000:3000 -v ./data:/app/storage -e GOOGLE_API_KEY=your-key ghcr.io/tracefinity/tracefinity
 
+# remote saliency via fal.ai
+docker run -p 3000:3000 -v ./data:/app/storage -e FAL_KEY=your-key ghcr.io/tracefinity/tracefinity
+
+# remote saliency via Replicate
+docker run -p 3000:3000 -v ./data:/app/storage -e REPLICATE_API_TOKEN=your-token ghcr.io/tracefinity/tracefinity
+
 # run as your host user (files in ./data owned by you, not root)
 docker run -p 3000:3000 -v ./data:/app/storage --user "$(id -u):$(id -g)" ghcr.io/tracefinity/tracefinity
 ```
+
+With a remote provider the corrected paper crop is sent to that provider for masking. fal is called with `sync_mode`, so the result is not kept in request history; Replicate API predictions auto-purge after about an hour and the code also issues a best-effort delete.
 
 Open http://localhost:3000
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -610,8 +610,9 @@ async def trace_tools(request: Request, session_id: str, req: TraceRequest, user
             mask_output_path,
         )
     except TimeoutError:
-        logging.warning("gemini timed out after 60s")
-        raise HTTPException(status_code=504, detail="Gemini timed out — the model may be overloaded. Try again shortly.")
+        label = TRACER_LABELS.get(tracer_id, tracer_id)
+        logging.warning("%s timed out", tracer_id)
+        raise HTTPException(status_code=504, detail=f"{label} timed out; the model may be overloaded. Try again shortly.")
     except Exception as e:
         error_msg = str(e)
         if "insufficient_quota" in error_msg or "exceeded" in error_msg.lower():
@@ -620,6 +621,10 @@ async def trace_tools(request: Request, session_id: str, req: TraceRequest, user
             raise HTTPException(status_code=401, detail="Invalid API key")
         if "rate_limit" in error_msg.lower():
             raise HTTPException(status_code=429, detail="Rate limited - try again shortly")
+        if tracer_kind(tracer_id) == "remote":
+            label = TRACER_LABELS.get(tracer_id, tracer_id)
+            logging.error("%s provider error: %s", tracer_id, error_msg[:500], exc_info=True)
+            raise HTTPException(status_code=502, detail=f"{label} provider error; try again shortly.")
         logging.error("ai tracing failed: %s", error_msg[:500], exc_info=True)
         detail = f"AI tracing failed ({type(e).__name__}: {error_msg[:200]})"
         raise HTTPException(status_code=500, detail=detail)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -138,17 +138,25 @@ def _get_tracer(tracer_id: str | None = None) -> AITracer:
     """get or create a tracer for the given ID."""
     tid = tracer_id or settings.available_tracers[0]
     if tid not in _tracers:
-        if tid == "gemini":
+        kind = tracer_kind(tid)
+        if kind == "gemini":
             _tracers[tid] = AITracer(
                 model=settings.gemini_image_model,
                 openrouter_key=settings.openrouter_api_key,
                 openrouter_image_model=settings.openrouter_image_model,
             )
-        else:
+        elif kind == "remote":
+            token = settings.replicate_api_token if tid == "replicate" else settings.fal_key
+            model = settings.replicate_model if tid == "replicate" else settings.fal_model
             _tracers[tid] = AITracer(
-                local_model=True,
-                local_model_name=tid,
+                saliency_tracer=tid,
+                remote_model=model,
+                remote_token=token,
+                fal_operating_resolution=settings.fal_operating_resolution,
+                replicate_resolution=settings.replicate_resolution,
             )
+        else:
+            _tracers[tid] = AITracer(saliency_tracer=tid)
     return _tracers[tid]
 
 polygon_scaler = PolygonScaler()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -73,7 +73,7 @@ from app.services.bin_store import BinStore
 from app.services.project_store import ProjectStore
 from app.services.bin_service import sync_placed_tools
 from app.services.image_service import generate_tool_thumbnail
-from app.services.tracer_registry import TRACER_LABELS, validate_tracer_ids
+from app.services.tracer_registry import TRACER_LABELS, tracer_kind, validate_tracer_ids
 from app.services.geometry import optimal_rotation_angle as _optimal_rotation_angle
 from app.services.project_service import (
     add_bin_to_project,
@@ -553,11 +553,12 @@ async def get_available_keys(request: Request):
     """return available tracers and provider info."""
     tracers = settings.available_tracers
     has_cloud = bool(settings.google_api_key) or bool(settings.openrouter_api_key)
-    has_local = settings.use_local_model
+    has_saliency = settings.primary_is_saliency
     primary = tracers[0] if tracers else None
     return {
-        "google": has_cloud or has_local,
-        "provider": "local" if has_local else "gemini" if has_cloud else None,
+        # google: server can trace without a user-supplied key (cloud env key, local, or remote)
+        "google": has_cloud or has_saliency,
+        "provider": tracer_kind(primary) if primary else None,
         "provider_label": TRACER_LABELS.get(primary, primary) if primary else None,
         "tracers": [
             {"id": t, "label": TRACER_LABELS.get(t, t)}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -134,6 +134,10 @@ image_processor = ImageProcessor()
 _tracers: dict[str, AITracer] = {}
 
 
+def _remote_token(tracer_id: str) -> str | None:
+    return settings.replicate_api_token if tracer_id == "replicate" else settings.fal_key
+
+
 def _get_tracer(tracer_id: str | None = None) -> AITracer:
     """get or create a tracer for the given ID."""
     tid = tracer_id or settings.available_tracers[0]
@@ -146,7 +150,7 @@ def _get_tracer(tracer_id: str | None = None) -> AITracer:
                 openrouter_image_model=settings.openrouter_image_model,
             )
         elif kind == "remote":
-            token = settings.replicate_api_token if tid == "replicate" else settings.fal_key
+            token = _remote_token(tid)
             model = settings.replicate_model if tid == "replicate" else settings.fal_model
             _tracers[tid] = AITracer(
                 saliency_tracer=tid,
@@ -589,6 +593,11 @@ async def trace_tools(request: Request, session_id: str, req: TraceRequest, user
     api_key = settings.google_api_key or req.api_key
     if tracer_id == "gemini" and not api_key and not settings.openrouter_api_key:
         raise HTTPException(status_code=400, detail="no api key provided")
+
+    if tracer_kind(tracer_id) == "remote":
+        if not _remote_token(tracer_id):
+            env = "REPLICATE_API_TOKEN" if tracer_id == "replicate" else "FAL_KEY"
+            raise HTTPException(status_code=400, detail=f"{tracer_id} token not set; set {env}")
 
     up = _user_path(user_id)
     mask_output_path = str(up / "processed" / f"{session_id}_mask.png")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
     proxy_secret: Optional[str] = None
     cors_origins: list[str] = ["http://localhost:3000", "http://localhost:4001"]
     tracers: Optional[str] = None
+    replicate_api_token: Optional[str] = None
+    fal_key: Optional[str] = None
+    replicate_model: str = "men1scus/birefnet"
+    fal_model: str = "fal-ai/birefnet/v2"
+    replicate_resolution: Optional[str] = None  # "WxH"; None => model default
+    fal_operating_resolution: str = "1024x1024"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
@@ -28,19 +34,34 @@ class Settings(BaseSettings):
         """list of tracer IDs available to users.
 
         set TRACERS env var to a comma-separated list, e.g. "birefnet-lite,isnet"
-        or "gemini,birefnet-lite". if not set, auto-detects from API keys.
+        or "gemini,birefnet-lite". if not set, auto-detects: an LLM key picks
+        gemini, else a remote token picks that provider, else local models.
         """
         if self.tracers:
             return validate_tracer_ids([t.strip() for t in self.tracers.split(",") if t.strip()])
-        # auto-detect
         if self.google_api_key or self.openrouter_api_key:
             return ["gemini"]
+        remote = []
+        if self.replicate_api_token:
+            remote.append("replicate")
+        if self.fal_key:
+            remote.append("fal")
+        if remote:
+            return remote
         return list(DEFAULT_LOCAL_TRACERS)
 
     @property
-    def use_local_model(self) -> bool:
-        """true when the primary tracer is a local model (not gemini)."""
-        return self.available_tracers[0] != "gemini" if self.available_tracers else True
+    def primary_tracer(self) -> str | None:
+        """the primary (first) available tracer id, or none."""
+        tracers = self.available_tracers
+        return tracers[0] if tracers else None
+
+    @property
+    def primary_is_saliency(self) -> bool:
+        """true when the primary tracer uses the saliency pipeline (local or
+        remote), not the gemini llm path."""
+        primary = self.primary_tracer
+        return primary is not None and primary != "gemini"
 
 
 settings = Settings()

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -11,7 +11,13 @@ import cv2
 import numpy as np
 
 from app.models.schemas import Polygon, Point
-from app.services.tracer_registry import GPU_REQUIRED_TRACERS, LOCAL_MODEL_LABELS, REMBG_MODELS
+from app.services.tracer_registry import (
+    GPU_REQUIRED_TRACERS,
+    LOCAL_MODEL_LABELS,
+    REMBG_MODELS,
+    REMOTE_TRACERS,
+    TRACER_LABELS,
+)
 
 
 # gemini-3-pro respects output dimensions precisely, so a direct
@@ -70,20 +76,27 @@ class AITracer:
         openrouter_key: str | None = None,
         openrouter_image_model: str | None = None,
         openrouter_label_model: str | None = None,
-        local_model: bool = False,
-        local_model_name: str = "inspyrenet",
+        saliency_tracer: str | None = None,
+        remote_model: str | None = None,
+        remote_token: str | None = None,
+        fal_operating_resolution: str = "1024x1024",
+        replicate_resolution: str | None = None,
     ):
         self.model = model
         self.label_model = label_model
         self.openrouter_key = openrouter_key
         self.openrouter_image_model = openrouter_image_model or f"google/{model}"
         self.openrouter_label_model = openrouter_label_model or f"google/{label_model}"
-        self.local_model = local_model
-        self.local_model_name = local_model_name
-        self._local_remover = None
+        self.saliency_tracer = saliency_tracer
+        self.remote_model = remote_model
+        self.remote_token = remote_token
+        self.fal_operating_resolution = fal_operating_resolution
+        self.replicate_resolution = replicate_resolution
+        self.uses_saliency = saliency_tracer is not None
+        self._saliency_backend = None
 
-        if local_model:
-            self._load_local_model()
+        if self.uses_saliency:
+            self._init_saliency_backend()
 
     def _mask_prompt(self, width: int, height: int) -> str:
         if self.model in _NEEDS_ALIGNMENT:
@@ -101,15 +114,15 @@ class AITracer:
         if os.environ.get("E2E_TEST_MODE"):
             return self._mock_trace(mask_output_path)
 
-        if self.local_model:
-            mask_path = await self._generate_mask_local(image_path, mask_output_path)
+        if self.uses_saliency:
+            mask_path = await self._generate_mask_saliency(image_path, mask_output_path)
         else:
             mask_path = await self._generate_mask_gemini(image_path, api_key, mask_output_path)
 
         if not mask_path:
             return [], None
 
-        align = not self.local_model and self.model in _NEEDS_ALIGNMENT
+        align = not self.uses_saliency and self.model in _NEEDS_ALIGNMENT
         contours = self._trace_mask(mask_path, image_path, align=align)
         if not contours:
             return [], mask_output_path
@@ -132,11 +145,23 @@ class AITracer:
 
         return polygons, mask_output_path
 
-    def _load_local_model(self):
-        """load local model weights when the tracer is first constructed."""
-        if self._local_remover is not None:
+    def _init_saliency_backend(self):
+        """prepare the saliency backend: load local weights, or build a remote
+        config (no heavy import on the remote path)."""
+        if self._saliency_backend is not None:
             return
-        name = self.local_model_name
+        name = self.saliency_tracer
+        if name in REMOTE_TRACERS:
+            from app.services.remote_saliency import RemoteSaliencyConfig
+            cfg = RemoteSaliencyConfig(
+                provider=name,
+                model=self.remote_model,
+                token=self.remote_token,
+                fal_operating_resolution=self.fal_operating_resolution,
+                replicate_resolution=self.replicate_resolution,
+            )
+            self._saliency_backend = (name, cfg)
+            return
         label = LOCAL_MODEL_LABELS.get(name, name)
         if name in REMBG_MODELS:
             from rembg import new_session
@@ -145,15 +170,15 @@ class AITracer:
             logging.info("loading %s via rembg with providers: %s", label, providers)
             session = new_session(REMBG_MODELS[name], providers=providers)
             logging.info("%s actual ONNX providers: %s", label, session.inner_session.get_providers())
-            self._local_remover = ("rembg", session)
+            self._saliency_backend = ("rembg", session)
         elif name == "inspyrenet":
             from transparent_background import Remover
             import torch
             device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
             logging.info("loading %s on %s", label, device)
-            self._local_remover = ("inspyrenet", Remover(mode="base", device=device))
+            self._saliency_backend = ("inspyrenet", Remover(mode="base", device=device))
         else:
-            raise ValueError(f"unsupported local tracer: {name}")
+            raise ValueError(f"unsupported saliency model: {name}")
 
     @staticmethod
     def _detect_paper_rect(img: np.ndarray) -> tuple[int, int, int, int] | None:
@@ -188,30 +213,41 @@ class AITracer:
             return None
         return best[1], best[2], best[3], best[4]
 
-    def _saliency_on_image(self, pil_img):
-        """run the configured local model, return foreground mask (fg=255)."""
-        backend, remover = self._local_remover
-        if backend == "rembg":
+    async def _saliency_on_image(self, pil_img):
+        """run the configured saliency backend, return foreground mask (fg=255)."""
+        kind, handle = self._saliency_backend
+        if kind in REMOTE_TRACERS:
+            return await self._saliency_remote(pil_img, handle)
+        if kind == "rembg":
             from rembg import remove
-            result = remove(pil_img, session=remover)
+            result = remove(pil_img, session=handle)
             alpha = np.array(result)[:, :, 3]
             _, binary = cv2.threshold(alpha, 127, 255, cv2.THRESH_BINARY)
             return binary
-        result = remover.process(pil_img, type="map")
+        result = handle.process(pil_img, type="map")
         mask_np = np.array(result.convert("L"))
         _, binary = cv2.threshold(mask_np, 127, 255, cv2.THRESH_BINARY)
         return binary
 
-    async def _generate_mask_local(self, image_path: str, output_path: str | None = None) -> str | None:
-        """generate a foreground mask using a local model (no API key).
+    async def _saliency_remote(self, pil_img, cfg):
+        """post the crop to a hosted model, return foreground mask (fg=255)."""
+        import io
+        from app.services.remote_saliency import remote_saliency_mask
+        buf = io.BytesIO()
+        pil_img.convert("RGB").save(buf, format="PNG")
+        logging.info("generating mask via %s (%s)", cfg.provider, cfg.model)
+        return await remote_saliency_mask(cfg, buf.getvalue(), pil_img.size)
+
+    async def _generate_mask_saliency(self, image_path: str, output_path: str | None = None) -> str | None:
+        """generate a foreground mask using a saliency model (local or remote).
 
         crop to the paper rect before running the model. saliency models pick
-        the most salient object — on the full corrected image that's the bright
+        the most salient object; on the full corrected image that is the bright
         paper, not the tool. cropped to the paper, the tool becomes salient."""
         from PIL import Image
 
-        label = LOCAL_MODEL_LABELS.get(self.local_model_name, self.local_model_name)
-        logging.info("generating mask with %s (local)", label)
+        label = TRACER_LABELS.get(self.saliency_tracer, self.saliency_tracer)
+        logging.info("generating mask with %s", label)
         pil_img = Image.open(image_path).convert("RGB")
         np_bgr = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
@@ -220,12 +256,12 @@ class AITracer:
             x, y, rw, rh = rect
             logging.info("cropping to paper rect %dx%d at (%d,%d) before saliency", rw, rh, x, y)
             cropped = pil_img.crop((x, y, x + rw, y + rh))
-            inside = self._saliency_on_image(cropped)
+            inside = await self._saliency_on_image(cropped)
             full = np.zeros((np_bgr.shape[0], np_bgr.shape[1]), dtype=np.uint8)
             full[y:y + rh, x:x + rw] = inside
         else:
             logging.info("paper rect not detected; running saliency on full image")
-            full = self._saliency_on_image(pil_img)
+            full = await self._saliency_on_image(pil_img)
 
         # tool=BLACK, bg=WHITE
         mask_out = cv2.bitwise_not(full)

--- a/backend/app/services/remote_saliency.py
+++ b/backend/app/services/remote_saliency.py
@@ -51,6 +51,24 @@ async def _fetch_image_bytes(client: httpx.AsyncClient, ref: str) -> bytes:
     return resp.content
 
 
+async def _via_fal(client: httpx.AsyncClient, cfg: RemoteSaliencyConfig, data_uri: str) -> bytes:
+    payload = {
+        "image_url": data_uri,
+        "mask_only": True,
+        "sync_mode": True,
+        "output_format": "png",
+        "operating_resolution": cfg.fal_operating_resolution,
+    }
+    resp = await client.post(
+        f"{FAL_BASE}/{cfg.model}",
+        json=payload,
+        headers={"Authorization": f"Key {cfg.token}", "Content-Type": "application/json"},
+    )
+    resp.raise_for_status()
+    ref = resp.json()["image"]["url"]
+    return await _fetch_image_bytes(client, ref)
+
+
 async def remote_saliency_mask(
     cfg: RemoteSaliencyConfig,
     image_png: bytes,
@@ -59,4 +77,19 @@ async def remote_saliency_mask(
     client: httpx.AsyncClient | None = None,
     timeout: float = 90.0,
 ) -> np.ndarray:
-    raise NotImplementedError
+    """run a hosted saliency model, return a binary fg mask (fg=255) at
+    target_size (w, h). raises on provider failure."""
+    data_uri = _data_uri(image_png)
+    owns = client is None
+    client = client or httpx.AsyncClient(timeout=timeout)
+    try:
+        if cfg.provider == "fal":
+            img_bytes = await asyncio.wait_for(_via_fal(client, cfg, data_uri), timeout=timeout)
+        elif cfg.provider == "replicate":
+            img_bytes = await asyncio.wait_for(_via_replicate(client, cfg, data_uri), timeout=timeout)
+        else:
+            raise ValueError(f"unknown remote provider: {cfg.provider}")
+    finally:
+        if owns:
+            await client.aclose()
+    return _to_binary(img_bytes, target_size)

--- a/backend/app/services/remote_saliency.py
+++ b/backend/app/services/remote_saliency.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import logging
+from dataclasses import dataclass
+
+import cv2
+import httpx
+import numpy as np
+from PIL import Image
+
+FAL_BASE = "https://fal.run"
+REPLICATE_BASE = "https://api.replicate.com/v1"
+
+
+@dataclass(frozen=True)
+class RemoteSaliencyConfig:
+    provider: str  # "replicate" | "fal"
+    model: str  # slug, e.g. "men1scus/birefnet" or "fal-ai/birefnet/v2"
+    token: str
+    fal_operating_resolution: str = "1024x1024"
+    replicate_resolution: str | None = None
+
+
+def _data_uri(image_png: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(image_png).decode()
+
+
+def _to_binary(img_bytes: bytes, target_size: tuple[int, int]) -> np.ndarray:
+    """decode a provider mask or cutout to a binary fg mask (fg=255) at
+    target_size (w, h). cutout => alpha is foreground; mask => luminance."""
+    img = Image.open(io.BytesIO(img_bytes))
+    if "A" in img.getbands():
+        chan = np.array(img.convert("RGBA"))[:, :, 3]
+    else:
+        chan = np.array(img.convert("L"))
+    w, h = target_size
+    if chan.shape[:2] != (h, w):
+        chan = cv2.resize(chan, (w, h), interpolation=cv2.INTER_AREA)
+    _, binary = cv2.threshold(chan, 127, 255, cv2.THRESH_BINARY)
+    return binary
+
+
+async def _fetch_image_bytes(client: httpx.AsyncClient, ref: str) -> bytes:
+    if ref.startswith("data:"):
+        return base64.b64decode(ref.split(",", 1)[1])
+    resp = await client.get(ref)
+    resp.raise_for_status()
+    return resp.content
+
+
+async def remote_saliency_mask(
+    cfg: RemoteSaliencyConfig,
+    image_png: bytes,
+    target_size: tuple[int, int],
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 90.0,
+) -> np.ndarray:
+    raise NotImplementedError

--- a/backend/app/services/remote_saliency.py
+++ b/backend/app/services/remote_saliency.py
@@ -13,6 +13,10 @@ from PIL import Image
 FAL_BASE = "https://fal.run"
 REPLICATE_BASE = "https://api.replicate.com/v1"
 
+# community models run via POST /v1/predictions with a version hash. cache the
+# resolved latest version per model slug for the process lifetime.
+_REPLICATE_VERSIONS: dict[str, str] = {}
+
 
 @dataclass(frozen=True)
 class RemoteSaliencyConfig:
@@ -124,13 +128,31 @@ async def _best_effort_delete(client, cfg, pred) -> None:
         pass
 
 
+async def _resolve_replicate_version(client: httpx.AsyncClient, cfg: RemoteSaliencyConfig) -> str:
+    """resolve the version hash to run. `owner/name:version` pins explicitly;
+    `owner/name` resolves (and caches) the model's latest version."""
+    if ":" in cfg.model:
+        return cfg.model.split(":", 1)[1]
+    if cfg.model in _REPLICATE_VERSIONS:
+        return _REPLICATE_VERSIONS[cfg.model]
+    resp = await client.get(
+        f"{REPLICATE_BASE}/models/{cfg.model}",
+        headers={"Authorization": f"Bearer {cfg.token}"},
+    )
+    resp.raise_for_status()
+    version = resp.json()["latest_version"]["id"]
+    _REPLICATE_VERSIONS[cfg.model] = version
+    return version
+
+
 async def _via_replicate(client: httpx.AsyncClient, cfg: RemoteSaliencyConfig, data_uri: str) -> bytes:
+    version = await _resolve_replicate_version(client, cfg)
     image_input = {"image": data_uri}
     if cfg.replicate_resolution:
         image_input["resolution"] = cfg.replicate_resolution
     resp = await client.post(
-        f"{REPLICATE_BASE}/models/{cfg.model}/predictions",
-        json={"input": image_input},
+        f"{REPLICATE_BASE}/predictions",
+        json={"version": version, "input": image_input},
         headers={
             "Authorization": f"Bearer {cfg.token}",
             "Content-Type": "application/json",

--- a/backend/app/services/remote_saliency.py
+++ b/backend/app/services/remote_saliency.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import io
-import logging
 from dataclasses import dataclass
 
 import cv2
@@ -93,3 +92,58 @@ async def remote_saliency_mask(
         if owns:
             await client.aclose()
     return _to_binary(img_bytes, target_size)
+
+
+async def _poll_replicate(client: httpx.AsyncClient, cfg: RemoteSaliencyConfig, pred: dict, attempts: int = 30, delay: float = 2.0):
+    """if Prefer: wait did not reach a terminal state, poll urls.get."""
+    headers = {"Authorization": f"Bearer {cfg.token}"}
+    for _ in range(attempts):
+        status = pred.get("status")
+        if status == "succeeded":
+            return pred
+        if status in ("failed", "canceled"):
+            raise ValueError(f"replicate prediction {status}: {pred.get('error')}")
+        get_url = pred.get("urls", {}).get("get")
+        if not get_url:
+            raise ValueError("replicate prediction not terminal and no poll url")
+        await asyncio.sleep(delay)
+        resp = await client.get(get_url, headers=headers)
+        resp.raise_for_status()
+        pred = resp.json()
+    raise TimeoutError("replicate prediction did not finish in time")
+
+
+async def _best_effort_delete(client, cfg, pred) -> None:
+    """opportunistic purge; api predictions also auto-expire after ~1h."""
+    url = pred.get("urls", {}).get("get")
+    if not url:
+        return
+    try:
+        await client.delete(url, headers={"Authorization": f"Bearer {cfg.token}"})
+    except Exception:
+        pass
+
+
+async def _via_replicate(client: httpx.AsyncClient, cfg: RemoteSaliencyConfig, data_uri: str) -> bytes:
+    image_input = {"image": data_uri}
+    if cfg.replicate_resolution:
+        image_input["resolution"] = cfg.replicate_resolution
+    resp = await client.post(
+        f"{REPLICATE_BASE}/models/{cfg.model}/predictions",
+        json={"input": image_input},
+        headers={
+            "Authorization": f"Bearer {cfg.token}",
+            "Content-Type": "application/json",
+            "Prefer": "wait",
+        },
+    )
+    resp.raise_for_status()
+    pred = await _poll_replicate(client, cfg, resp.json())
+    output = pred.get("output")
+    if isinstance(output, list):
+        output = output[0] if output else None
+    if not output:
+        raise ValueError("replicate prediction returned no output")
+    img = await _fetch_image_bytes(client, output)
+    await _best_effort_delete(client, cfg, pred)
+    return img

--- a/backend/app/services/tracer_registry.py
+++ b/backend/app/services/tracer_registry.py
@@ -17,12 +17,29 @@ LOCAL_MODEL_LABELS = {
 
 GPU_REQUIRED_TRACERS = frozenset({"birefnet-general"})
 
+REMOTE_TRACERS = frozenset({"replicate", "fal"})
+
+REMOTE_TRACER_LABELS = {
+    "replicate": "Replicate",
+    "fal": "fal.ai",
+}
+
 TRACER_LABELS = {
     "gemini": "Gemini API",
     **LOCAL_MODEL_LABELS,
+    **REMOTE_TRACER_LABELS,
 }
 
 SUPPORTED_TRACERS = frozenset(TRACER_LABELS)
+
+
+def tracer_kind(tracer_id: str) -> str:
+    """classify a tracer id: gemini, remote, or local."""
+    if tracer_id == "gemini":
+        return "gemini"
+    if tracer_id in REMOTE_TRACERS:
+        return "remote"
+    return "local"
 
 
 def validate_tracer_ids(tracers: list[str]) -> list[str]:

--- a/backend/tests/test_ai_tracer_saliency.py
+++ b/backend/tests/test_ai_tracer_saliency.py
@@ -1,0 +1,37 @@
+"""Tests for AITracer saliency dispatch (local vs remote)."""
+
+import asyncio
+
+import numpy as np
+from PIL import Image
+
+from app.services.ai_tracer import AITracer
+
+
+def test_no_saliency_tracer_is_gemini_path():
+    t = AITracer(model="gemini-x")
+    assert t.uses_saliency is False
+    assert t._saliency_backend is None
+
+
+def test_remote_tracer_builds_config_and_calls_module(monkeypatch):
+    import app.services.remote_saliency as rs
+
+    called = {}
+
+    async def fake(cfg, image_png, target_size, **kw):
+        called["cfg"] = cfg
+        called["target"] = target_size
+        return np.full((target_size[1], target_size[0]), 255, np.uint8)
+
+    monkeypatch.setattr(rs, "remote_saliency_mask", fake)
+
+    t = AITracer(saliency_tracer="fal", remote_model="fal-ai/birefnet/v2", remote_token="x")
+    assert t.uses_saliency is True
+    assert t._saliency_backend[0] == "fal"
+
+    out = asyncio.run(t._saliency_on_image(Image.new("RGB", (12, 9))))
+    assert out.shape == (9, 12)  # (h, w)
+    assert called["cfg"].provider == "fal"
+    assert called["cfg"].model == "fal-ai/birefnet/v2"
+    assert called["target"] == (12, 9)  # (w, h)

--- a/backend/tests/test_remote_saliency.py
+++ b/backend/tests/test_remote_saliency.py
@@ -68,14 +68,20 @@ def test_fal_request_uses_mask_only_and_sync_mode():
     assert out.shape == (8, 8)
 
 
-def test_replicate_request_uses_prefer_wait_and_model_endpoint():
+def test_replicate_resolves_version_and_posts_prediction():
+    import app.services.remote_saliency as rs
+    rs._REPLICATE_VERSIONS.clear()
     seen = {}
     mask = np.full((8, 8), 255, np.uint8)
     mask_url = "https://replicate.delivery/mask.png"
 
     def handler(request):
+        url = str(request.url)
+        if request.method == "GET" and "/v1/models/" in url:
+            seen["model_url"] = url
+            return httpx.Response(200, json={"latest_version": {"id": "ver123"}})
         if request.method == "POST":
-            seen["url"] = str(request.url)
+            seen["post_url"] = url
             seen["prefer"] = request.headers.get("prefer")
             seen["auth"] = request.headers.get("authorization")
             seen["body"] = json.loads(request.content)
@@ -97,10 +103,46 @@ def test_replicate_request_uses_prefer_wait_and_model_endpoint():
     out = asyncio.run(remote_saliency_mask(cfg, _png(mask), (8, 8), client=client))
     asyncio.run(client.aclose())
 
-    assert seen["url"].endswith("/v1/models/men1scus/birefnet/predictions")
+    assert seen["model_url"].endswith("/v1/models/men1scus/birefnet")
+    assert seen["post_url"].endswith("/v1/predictions")
     assert seen["prefer"] == "wait"
     assert seen["auth"] == "Bearer r8_x"
+    assert seen["body"]["version"] == "ver123"
     assert seen["body"]["input"]["image"].startswith("data:image/png;base64,")
+    assert out.shape == (8, 8)
+
+
+def test_replicate_pinned_version_skips_lookup():
+    import app.services.remote_saliency as rs
+    rs._REPLICATE_VERSIONS.clear()
+    seen = {}
+    mask = np.full((8, 8), 255, np.uint8)
+
+    def handler(request):
+        if request.method == "GET" and "/v1/models/" in str(request.url):
+            seen["resolved"] = True  # must not happen for a pinned version
+            return httpx.Response(200, json={"latest_version": {"id": "nope"}})
+        if request.method == "POST":
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(
+                201,
+                json={
+                    "status": "succeeded",
+                    "output": "https://replicate.delivery/m.png",
+                    "urls": {"get": "https://api.replicate.com/v1/predictions/abc"},
+                },
+            )
+        if request.method == "DELETE":
+            return httpx.Response(204)
+        return httpx.Response(200, content=_png(mask), headers={"content-type": "image/png"})
+
+    cfg = RemoteSaliencyConfig(provider="replicate", model="men1scus/birefnet:pinned123", token="r8_x")
+    client = _client(handler)
+    out = asyncio.run(remote_saliency_mask(cfg, _png(mask), (8, 8), client=client))
+    asyncio.run(client.aclose())
+
+    assert "resolved" not in seen
+    assert seen["body"]["version"] == "pinned123"
     assert out.shape == (8, 8)
 
 

--- a/backend/tests/test_remote_saliency.py
+++ b/backend/tests/test_remote_saliency.py
@@ -1,0 +1,40 @@
+"""Tests for the hosted-inference saliency module (mocked HTTP)."""
+
+import asyncio
+import base64
+import io
+import json
+
+import httpx
+import numpy as np
+import pytest
+from PIL import Image
+
+from app.services.remote_saliency import (
+    RemoteSaliencyConfig,
+    _to_binary,
+    remote_saliency_mask,
+)
+
+
+def _png(arr: np.ndarray) -> bytes:
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_to_binary_from_grayscale_mask_resizes_and_thresholds():
+    mask = np.zeros((10, 10), np.uint8)
+    mask[2:8, 2:8] = 255
+    out = _to_binary(_png(mask), (20, 20))
+    assert out.shape == (20, 20)
+    assert set(np.unique(out)) <= {0, 255}
+    assert out[10, 10] == 255  # centre is foreground
+
+
+def test_to_binary_from_rgba_cutout_uses_alpha():
+    rgba = np.zeros((10, 10, 4), np.uint8)
+    rgba[3:7, 3:7, 3] = 255  # opaque square = foreground
+    out = _to_binary(_png(rgba), (10, 10))
+    assert out[5, 5] == 255
+    assert out[0, 0] == 0

--- a/backend/tests/test_remote_saliency.py
+++ b/backend/tests/test_remote_saliency.py
@@ -66,3 +66,50 @@ def test_fal_request_uses_mask_only_and_sync_mode():
     assert seen["body"]["sync_mode"] is True
     assert seen["body"]["image_url"].startswith("data:image/png;base64,")
     assert out.shape == (8, 8)
+
+
+def test_replicate_request_uses_prefer_wait_and_model_endpoint():
+    seen = {}
+    mask = np.full((8, 8), 255, np.uint8)
+    mask_url = "https://replicate.delivery/mask.png"
+
+    def handler(request):
+        if request.method == "POST":
+            seen["url"] = str(request.url)
+            seen["prefer"] = request.headers.get("prefer")
+            seen["auth"] = request.headers.get("authorization")
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(
+                201,
+                json={
+                    "status": "succeeded",
+                    "output": mask_url,
+                    "urls": {"get": "https://api.replicate.com/v1/predictions/abc"},
+                },
+            )
+        if request.method == "DELETE":
+            seen["deleted"] = True
+            return httpx.Response(204)
+        return httpx.Response(200, content=_png(mask), headers={"content-type": "image/png"})
+
+    cfg = RemoteSaliencyConfig(provider="replicate", model="men1scus/birefnet", token="r8_x")
+    client = _client(handler)
+    out = asyncio.run(remote_saliency_mask(cfg, _png(mask), (8, 8), client=client))
+    asyncio.run(client.aclose())
+
+    assert seen["url"].endswith("/v1/models/men1scus/birefnet/predictions")
+    assert seen["prefer"] == "wait"
+    assert seen["auth"] == "Bearer r8_x"
+    assert seen["body"]["input"]["image"].startswith("data:image/png;base64,")
+    assert out.shape == (8, 8)
+
+
+def test_provider_http_error_propagates():
+    def handler(request):
+        return httpx.Response(500, text="boom")
+
+    cfg = RemoteSaliencyConfig(provider="fal", model="fal-ai/birefnet/v2", token="x")
+    client = _client(handler)
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(remote_saliency_mask(cfg, b"x", (8, 8), client=client))
+    asyncio.run(client.aclose())

--- a/backend/tests/test_remote_saliency.py
+++ b/backend/tests/test_remote_saliency.py
@@ -38,3 +38,31 @@ def test_to_binary_from_rgba_cutout_uses_alpha():
     out = _to_binary(_png(rgba), (10, 10))
     assert out[5, 5] == 255
     assert out[0, 0] == 0
+
+
+def _client(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_fal_request_uses_mask_only_and_sync_mode():
+    seen = {}
+    mask = np.full((8, 8), 255, np.uint8)
+    data_uri = "data:image/png;base64," + base64.b64encode(_png(mask)).decode()
+
+    def handler(request):
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("authorization")
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"image": {"url": data_uri}})
+
+    cfg = RemoteSaliencyConfig(provider="fal", model="fal-ai/birefnet/v2", token="fal_x")
+    client = _client(handler)
+    out = asyncio.run(remote_saliency_mask(cfg, _png(mask), (8, 8), client=client))
+    asyncio.run(client.aclose())
+
+    assert seen["url"] == "https://fal.run/fal-ai/birefnet/v2"
+    assert seen["auth"] == "Key fal_x"
+    assert seen["body"]["mask_only"] is True
+    assert seen["body"]["sync_mode"] is True
+    assert seen["body"]["image_url"].startswith("data:image/png;base64,")
+    assert out.shape == (8, 8)

--- a/backend/tests/test_routes_remote_tracer.py
+++ b/backend/tests/test_routes_remote_tracer.py
@@ -38,3 +38,46 @@ def test_trace_remote_missing_token_returns_400(tmp_path, monkeypatch):
     resp = client.post("/api/sessions/s1/trace", json={"tracer": "fal"})
     assert resp.status_code == 400
     assert "token" in resp.json()["detail"].lower()
+
+
+def _seed_remote_session(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes.settings, "tracers", "fal")
+    monkeypatch.setattr(routes.settings, "fal_key", "fal_x")
+    client = _client(tmp_path, monkeypatch)
+    proc = tmp_path / "default" / "processed"
+    proc.mkdir(parents=True, exist_ok=True)
+    from PIL import Image
+    Image.new("RGB", (32, 32), "white").save(proc / "c.png")
+    sessions, _, _ = routes.get_stores("default")
+    sessions.set("s1", Session(id="s1", corrected_image_path="default/processed/c.png"))
+    return client
+
+
+def test_trace_remote_provider_error_returns_502(tmp_path, monkeypatch):
+    import httpx
+    import app.services.remote_saliency as rs
+    client = _seed_remote_session(tmp_path, monkeypatch)
+
+    async def boom(*a, **k):
+        raise httpx.HTTPStatusError(
+            "500", request=httpx.Request("POST", "https://fal.run/x"), response=httpx.Response(500)
+        )
+
+    monkeypatch.setattr(rs, "remote_saliency_mask", boom)
+    resp = client.post("/api/sessions/s1/trace", json={"tracer": "fal"})
+    assert resp.status_code == 502
+    assert "fal.ai" in resp.json()["detail"]
+
+
+def test_trace_remote_timeout_message_is_provider_aware(tmp_path, monkeypatch):
+    import app.services.remote_saliency as rs
+    client = _seed_remote_session(tmp_path, monkeypatch)
+
+    async def slow(*a, **k):
+        raise TimeoutError()
+
+    monkeypatch.setattr(rs, "remote_saliency_mask", slow)
+    resp = client.post("/api/sessions/s1/trace", json={"tracer": "fal"})
+    assert resp.status_code == 504
+    assert "Gemini" not in resp.json()["detail"]
+    assert "fal.ai" in resp.json()["detail"]

--- a/backend/tests/test_routes_remote_tracer.py
+++ b/backend/tests/test_routes_remote_tracer.py
@@ -1,0 +1,40 @@
+"""Route-level tests for remote tracers."""
+
+from fastapi.testclient import TestClient
+
+import app.api.routes as routes
+from app.config import ensure_user_dirs
+from app.main import app
+from app.models.schemas import Session
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    routes._tracers.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def test_api_keys_reports_remote_provider(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes.settings, "tracers", "fal")
+    monkeypatch.setattr(routes.settings, "fal_key", "fal_x")
+    client = _client(tmp_path, monkeypatch)
+
+    body = client.get("/api/api-keys").json()
+    assert body["google"] is True
+    assert body["provider"] == "remote"
+    assert {"id": "fal", "label": "fal.ai"} in body["tracers"]
+
+
+def test_trace_remote_missing_token_returns_400(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes.settings, "tracers", "fal")
+    monkeypatch.setattr(routes.settings, "fal_key", None)
+    client = _client(tmp_path, monkeypatch)
+
+    sessions, _, _ = routes.get_stores("default")
+    sessions.set("s1", Session(id="s1", corrected_image_path="default/processed/x.png"))
+
+    resp = client.post("/api/sessions/s1/trace", json={"tracer": "fal"})
+    assert resp.status_code == 400
+    assert "token" in resp.json()["detail"].lower()

--- a/backend/tests/test_tracer_config.py
+++ b/backend/tests/test_tracer_config.py
@@ -29,3 +29,34 @@ def test_invalid_tracer_config_fails_fast():
 
     with pytest.raises(ValueError, match="unsupported tracer"):
         settings.available_tracers
+
+
+def test_replicate_token_auto_selects_replicate():
+    settings = Settings(_env_file=None, replicate_api_token="r8_x")
+    assert settings.available_tracers == ["replicate"]
+
+
+def test_fal_key_auto_selects_fal():
+    settings = Settings(_env_file=None, fal_key="fal_x")
+    assert settings.available_tracers == ["fal"]
+
+
+def test_both_remote_tokens_list_both_replicate_first():
+    settings = Settings(_env_file=None, replicate_api_token="r8_x", fal_key="fal_x")
+    assert settings.available_tracers == ["replicate", "fal"]
+
+
+def test_llm_key_beats_remote_token():
+    settings = Settings(_env_file=None, google_api_key="g", replicate_api_token="r8_x")
+    assert settings.available_tracers == ["gemini"]
+
+
+def test_explicit_tracers_beats_remote_token():
+    settings = Settings(_env_file=None, tracers="isnet", fal_key="fal_x")
+    assert settings.available_tracers == ["isnet"]
+
+
+def test_primary_is_saliency_true_for_remote_and_local_false_for_gemini():
+    assert Settings(_env_file=None, replicate_api_token="r8_x").primary_is_saliency is True
+    assert Settings(_env_file=None).primary_is_saliency is True
+    assert Settings(_env_file=None, google_api_key="g").primary_is_saliency is False

--- a/backend/tests/test_tracer_registry.py
+++ b/backend/tests/test_tracer_registry.py
@@ -1,0 +1,40 @@
+"""Tests for tracer registry ids, labels and classification."""
+
+import pytest
+
+from app.services.tracer_registry import (
+    REMOTE_TRACERS,
+    SUPPORTED_TRACERS,
+    TRACER_LABELS,
+    tracer_kind,
+    validate_tracer_ids,
+)
+
+
+def test_remote_tracers_are_supported_and_labelled():
+    assert {"replicate", "fal"} <= SUPPORTED_TRACERS
+    assert REMOTE_TRACERS == frozenset({"replicate", "fal"})
+    assert TRACER_LABELS["replicate"] == "Replicate"
+    assert TRACER_LABELS["fal"] == "fal.ai"
+
+
+def test_validate_accepts_remote_tracers():
+    assert validate_tracer_ids(["replicate", "fal"]) == ["replicate", "fal"]
+
+
+def test_validate_still_rejects_unknown():
+    with pytest.raises(ValueError, match="unsupported tracer"):
+        validate_tracer_ids(["replicate", "nope"])
+
+
+def test_validate_rejects_mixed_valid_and_unknown():
+    with pytest.raises(ValueError, match="unsupported tracer"):
+        validate_tracer_ids(["isnet", "nope"])
+
+
+def test_tracer_kind_classifies():
+    assert tracer_kind("gemini") == "gemini"
+    assert tracer_kind("replicate") == "remote"
+    assert tracer_kind("fal") == "remote"
+    assert tracer_kind("isnet") == "local"
+    assert tracer_kind("inspyrenet") == "local"

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,15 @@
 - `GET /api/bin-projects/{id}/health` - report project/tool/bin link mismatches
 - `POST /api/bin-projects/{id}/repair` - repair safe project/tool/bin link mismatches
 
+## API Keys and tracer status
+- `GET /api-keys` - returns current provider and available tracers
+
+Response fields:
+- `google` (bool): true when the server can trace without a user-supplied key (cloud env key, local, or remote).
+- `provider` (string|null): one of `gemini` | `local` | `remote`.
+- `provider_label` (string|null): human label for the primary tracer, e.g. `Replicate`.
+- `tracers` (array): `{id, label}` entries. Remote tracers include `{"id":"replicate","label":"Replicate"}` and `{"id":"fal","label":"fal.ai"}` when the respective tokens are configured.
+
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL
 - `GET /api/files/{session_id}/bin.3mf` - session 3MF

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,8 @@ Reference for AI agents. Check here before suggesting new features or claiming s
 - Paper corner detection with draggable handles
 - Paper size presets (A4, Letter)
 - AI tracing (multiple tracer backends: IS-Net, BiRefNet, InSPyReNet)
+- Remote tracing via Replicate (`REPLICATE_API_TOKEN`, model `men1scus/birefnet` by default; `REPLICATE_RESOLUTION` optional)
+- Remote tracing via fal.ai (`FAL_KEY`, model `fal-ai/birefnet/v2` by default; `FAL_OPERATING_RESOLUTION` default `1024x1024`). Uses `sync_mode` so results are not stored in fal request history; Replicate predictions auto-purge after ~1h.
 - Manual mask upload
 - Corrected image download
 - Prompt copy to clipboard


### PR DESCRIPTION
## Summary
- Adds two remote tracing providers, `replicate` and `fal`, that run the saliency/background-removal step on a hosted GPU and replace only the local model call. All OpenCV (paper-rect crop, threshold, contour to polygon) stays local.
- Selection via `TRACERS`, or auto-detect when `TRACERS` is unset and no LLM key is present: `REPLICATE_API_TOKEN` selects `replicate`, `FAL_KEY` selects `fal`. Precedence: explicit `TRACERS` > LLM key (gemini) > remote token > local.
- New `remote_saliency` module does the HTTP call. `replicate` runs `REPLICATE_MODEL` (default `men1scus/birefnet`, resolving the model's latest version; pin with `owner/name:hash`); `fal` runs `FAL_MODEL` (default `fal-ai/birefnet/v2`, via `mask_only` + `sync_mode`).
- Privacy: no-persist by configuration (fal `sync_mode`, Replicate ~1h auto-purge plus a best-effort delete). User crops transit the provider only when a remote tracer is active.
- Renames the `local_model` family to `saliency_tracer` (it now covers local and remote). Fast-fails 400 when a remote tracer is selected without its token; maps provider outages to 502 and timeouts to 504.
- No frontend changes. Docs updated: CLAUDE.md, README, docs/api.md, docs/features.md.

## Test plan
- [x] Backend suite green (144 passed). New coverage: registry, config precedence, the `remote_saliency` module (mocked HTTP; fal, Replicate version-resolve, and pinned-version paths), AITracer local/remote dispatch, and route guards (missing-token 400, provider-error 502, timeout 504).
- [x] Live-validated both providers end-to-end on a real corrected photo: masks match the current tracer's coverage and are slightly crisper at tool edges.
- [x] Reviewer: spot-check no-persist behaviour in each provider dashboard.