### PR TITLE
Add configurable raised lip (rim_units) for stacking clearance

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1561,6 +1561,7 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
         magnet_depth=bc.magnet_depth,
         magnet_corners_only=bc.magnet_corners_only,
         stacking_lip=bc.stacking_lip,
+        rim_units=bc.rim_units,
         wall_thickness=bc.wall_thickness,
         cutout_depth=bc.cutout_depth,
         cutout_clearance=bc.cutout_clearance,

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -82,6 +82,7 @@ class BinParams(BaseModel):
     magnet_depth: float = 2.4
     magnet_corners_only: bool = False
     stacking_lip: bool = True
+    rim_units: int = 0  # extra height units (×7mm) the wall/lip rises above the floor face
     wall_thickness: float = 1.6
     cutout_depth: float = 20.0
     cutout_clearance: float = 1.0
@@ -102,6 +103,13 @@ class BinParams(BaseModel):
     def validate_height(cls, v: int) -> int:
         if v < 1 or v > 20:
             raise ValueError("height must be between 1 and 20 units")
+        return v
+
+    @field_validator("rim_units")
+    @classmethod
+    def validate_rim(cls, v: int) -> int:
+        if v < 0 or v > 20:
+            raise ValueError("rim must be between 0 and 20 units")
         return v
 
     @field_validator("cutout_depth")

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -888,22 +888,47 @@ class ManifoldSTLGenerator:
         bin_body = _build_shell(config)
         logger.info("shell: %.2fs", time.monotonic() - t1)
 
-        # stacking lip: build groove into a separate lip solid (z=wall_top_z to
-        # z=wall_top_z+lip_total) and add it to the bin body.  The notch extends
-        # below wall_top_z but only cuts the lip solid (not the wall body), so
-        # the groove is invisible below wall_top_z — matching gf.Bin behaviour
+        outer_w = config.grid_x * GF_GRID - 0.5
+        outer_h = config.grid_y * GF_GRID - 0.5
+
+        # raised rim ("collar"): a hollow perimeter wall extending the bin wall
+        # above the floor face (wall_top_z) without filling the interior.  A
+        # protruding tool sits in the open volume inside the collar, and the
+        # stacking lip (if enabled) rides on top so a stacked bin clears the
+        # tool.  Cutouts still pocket down from wall_top_z, unaffected by the rim.
+        rim_units = getattr(config, "rim_units", 0) or 0
+        rim_height = rim_units * GF_HEIGHT_UNIT
+        lip_base_z = wall_top_z + rim_height
+        # inner opening matches the stacking-lip inner opening so the collar wall
+        # is flush with the lip's inner face (no inward overhang/ledge).
+        rim_inner_w = outer_w - 2 * (LIP_D0 + LIP_D2)
+        rim_inner_h = outer_h - 2 * (LIP_D0 + LIP_D2)
+
+        if rim_height > 0:
+            outer_solid = mf.Manifold.extrude(
+                _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R)), rim_height
+            )
+            inner_solid = mf.Manifold.extrude(
+                _cs(_rounded_rect_pts(rim_inner_w, rim_inner_h, GF_CORNER_R)), rim_height
+            )
+            collar = (outer_solid - inner_solid).translate((0.0, 0.0, wall_top_z))
+            bin_body = bin_body + collar
+            logger.info("raised rim (%du): %.2fs", rim_units, time.monotonic() - t1)
+
+        # stacking lip: build groove into a separate lip solid (z=lip_base_z to
+        # z=lip_base_z+lip_total) and add it to the bin body.  The notch extends
+        # below lip_base_z but only cuts the lip solid (not the wall/collar), so
+        # the groove is invisible below lip_base_z — matching gf.Bin behaviour
         # and preserving the large top-floor face at z=wall_top_z.
         if config.stacking_lip:
             lip_total = LIP_D0 + LIP_D1 + LIP_D2
             notch_depth_below = LIP_D3 + LIP_D4
-            outer_w = config.grid_x * GF_GRID - 0.5
-            outer_h = config.grid_y * GF_GRID - 0.5
             cs_wall_lip = _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R))
             lip_solid = mf.Manifold.extrude(cs_wall_lip, lip_total).translate(
-                (0.0, 0.0, wall_top_z)
+                (0.0, 0.0, lip_base_z)
             )
             notch = _build_stacking_lip_notch(outer_w, outer_h).translate(
-                (0.0, 0.0, wall_top_z - notch_depth_below)
+                (0.0, 0.0, lip_base_z - notch_depth_below)
             )
             lip_with_groove = lip_solid - notch
             bin_body = bin_body + lip_with_groove

--- a/docs/features.md
+++ b/docs/features.md
@@ -55,6 +55,7 @@ Reference for AI agents. Check here before suggesting new features or claiming s
 - Magnet holes (enable/disable, diameter and depth)
 - Magnets at corners only option
 - Stacking lip toggle
+- Raise lip (extend wall/lip above the floor face in 7mm units so a stacked bin clears a protruding tool)
 - Insert mode (contrast insert with configurable height)
 - Bed size for auto-splitting large bins
 - Auto-size grid to fit placed tools

--- a/docs/stl-generation.md
+++ b/docs/stl-generation.md
@@ -7,8 +7,10 @@ STL generation uses manifold3d (mesh booleans, 10-100x faster than OCCT B-rep). 
 ## Z-Axis Reference Heights
 
 - **Base top**: 4.75mm (three tapered layers: 2.15 + 1.8 + 0.8). Infill starts here.
-- **Wall top**: `height_units * 7`. Infill stops here.
-- **Stacking lip top**: wall top + 4.4mm (d0=1.9 + d1=1.8 + d2=0.7). Do NOT use bounding box max Z.
+- **Wall top (floor face)**: `height_units * 7`. Infill stops here; cutouts pocket down from here.
+- **Raised rim**: with `rim_units > 0`, a hollow perimeter collar extends the wall from the floor face up by `rim_units * 7`mm, leaving the interior open. The stacking lip rides on top of the collar.
+- **Lip base**: `height_units * 7 + rim_units * 7` (= wall top when `rim_units == 0`).
+- **Stacking lip top**: lip base + 4.4mm (d0=1.9 + d1=1.8 + d2=0.7). Do NOT use bounding box max Z.
 - **Pocket extrude margin**: 0.01mm epsilon for boolean cleanliness.
 
 ## Gridfinity Constants

--- a/docs/usage/bin-configuration.md
+++ b/docs/usage/bin-configuration.md
@@ -26,6 +26,8 @@ Gridfinity is a modular storage system where bins snap into a baseplate grid. Ea
 
 **Stacking lip** -- raised rim so bins stack securely. On by default. Adds approximately 4.4mm to total height and reduces maximum cutout depth.
 
+**Raise lip** -- extends the wall and stacking lip upward by this many units (7mm each) above the floor face, leaving the interior open. Use it for shallow bins where a tool protrudes above the floor: the raised lip lets a stacked bin clear the protruding tool. 0 = standard (lip sits at the floor face). Shown only when the stacking lip is on.
+
 **Contrast insert** -- generates a separate STL to print in a different colour. The pocket is deepened automatically to accommodate the insert thickness.
 
 ## Auto grid sizing

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -403,7 +403,7 @@ export default function BinPage() {
             <div className="text-[11px] text-text-secondary space-y-0.5">
               <div className="flex justify-between"><span>Width</span><span>{binW} mm</span></div>
               <div className="flex justify-between"><span>Depth</span><span>{binH} mm</span></div>
-              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
+              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + config.rim_units * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -258,6 +258,19 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
           label="Stacking lip"
           help="Raised rim at the top so bins can stack securely on top of each other."
         />
+        {config.stacking_lip && (
+          <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+            <SliderRow
+              label="Raise Lip"
+              help="Extends the wall and lip this many units (7mm each) above the floor face, leaving the interior open. Lets a tool protrude above the floor while a stacked bin still clears it. 0 = standard."
+              value={config.rim_units}
+              min={0}
+              max={10}
+              unit="u"
+              onChange={(v) => update({ rim_units: v })}
+            />
+          </div>
+        )}
         <Toggle
           checked={config.insert_enabled}
           onChange={(v) => update({ insert_enabled: v })}

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -10,6 +10,7 @@ export const FACTORY_BIN_CONFIG: BinConfig = {
   magnet_depth: 2.4,
   magnet_corners_only: false,
   stacking_lip: true,
+  rim_units: 0,
   wall_thickness: 1.6,
   cutout_depth: 20,
   cutout_clearance: 1.0,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,6 +107,7 @@ export interface BinDefaults {
   magnet_depth: number
   magnet_corners_only: boolean
   stacking_lip: boolean
+  rim_units: number
   wall_thickness: number
   cutout_depth: number
   cutout_clearance: number


### PR DESCRIPTION
Fixes #76

The stacking lip was rigidly fixed to the bin's floor face, so a shallow bin holding a tool that protrudes above the floor could not be cleared by a stacked bin. Add a `rim_units` parameter (0-20, ×7mm) that extends a hollow perimeter collar above the floor face and rides the stacking lip on top of it, leaving the interior open so the protruding tool sits in the void while a stacked bin clears it. Cutouts still pocket from the floor face, so cutout-depth math is unchanged. rim_units=0 reproduces the previous geometry exactly.

- schemas: rim_units on BinParams (validated), flows via BinDefaults
- routes: map rim_units into GenerateRequest
- manifold generator: build hollow collar, relocate lip to lip_base_z
- frontend: "Raise Lip" slider (shown when stacking lip on), type, default, total-height readout
- docs: bin-configuration, features, stl-generation