### PR TITLE
Add multi-arch Docker build and upstream sync workflows

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -1,0 +1,49 @@
+name: Build Multi-Arch Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,38 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/tracefinity/tracefinity.git
+
+      - name: Fetch upstream
+        run: git fetch upstream --tags
+
+      - name: Merge upstream main (fast-forward only)
+        run: |
+          git checkout main
+          git merge --ff-only upstream/main
+
+      - name: Push main and tags
+        run: |
+          git push origin main
+          git push origin --tags

--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ Step-by-step usage guides covering each part of the workflow:
 
 [Gridfinity](https://gridfinity.xyz/) is a modular storage system designed by [Zack Freedman](https://www.youtube.com/watch?v=ra_9zU-mnl8). Bins snap into baseplates on a 42mm grid, making it easy to organise tools, components, and supplies. The system is open source and hugely popular in the 3D printing community.
 
+## Self-Hosted ARM64
+
+This fork publishes a multi-arch Docker image to GitHub Container Registry that supports both `linux/amd64` and `linux/arm64` (e.g. Raspberry Pi 4/5, Apple Silicon servers, AWS Graviton).
+
+Pull the image:
+
+```bash
+docker run -p 3000:3000 -v ./data:/app/storage ghcr.io/OWNER/tracefinity:latest
+```
+
+Replace `OWNER` with the GitHub username or organisation that owns this fork.
+
+> **First-time setup:** after the first successful build, go to **Settings → Packages** on GitHub, find the `tracefinity` package, and set its visibility to **Public** so the image can be pulled without authentication.
+
+The image is kept in sync with upstream releases automatically via a scheduled workflow that runs every 6 hours.
+
 ## Licence
 
 MIT


### PR DESCRIPTION
- .github/workflows/sync-upstream.yml: merges upstream tracefinity/tracefinity main into fork every 6 hours and pushes new tags
- .github/workflows/build-multiarch.yml: builds linux/amd64 + linux/arm64 image to ghcr.io on tag push, using QEMU + Buildx with GHA cache
- README.md: add Self-Hosted ARM64 section documenting the ghcr.io image and the one-time package visibility step


Claude-Session: https://claude.ai/code/session_015VZCTu71wtyKSmPWfLaDZZ