### PR TITLE
Add multi-arch Docker builds (arm64, armv7)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,6 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ docker run -p 3000:3000 -v ./data:/app/storage --user "$(id -u):$(id -g)" ghcr.i
 
 With a remote provider the corrected paper crop is sent to that provider for masking. fal is called with `sync_mode`, so the result is not kept in request history; Replicate API predictions (including the input image) auto-purge after about an hour, which is the only retention control Replicate exposes (it has no API to delete them sooner).
 
+The Docker image supports **linux/amd64**, **linux/arm64**, and **linux/arm/v7**. Apple Silicon Macs run arm64 natively via Docker Desktop. ARM devices need at least 2GB RAM (for U2-Net paper detection), so a Raspberry Pi 4/5 with 4GB+ works but a Pi 3B+ (1GB) does not.
+
 Open http://localhost:3000
 
 By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for local tracing -- no API key needed. Set `GOOGLE_API_KEY` to use Gemini instead. See [Tracing Modes](#tracing-modes) for RAM requirements per model.


### PR DESCRIPTION
## Summary

Adds QEMU emulation and multi-platform build support to the Docker release workflow, producing images for linux/amd64, linux/arm64, and linux/arm/v7.

Closes #87

## Changes

- Added `docker/setup-qemu-action@v3` for cross-platform emulation
- Added `platforms: linux/amd64,linux/arm64,linux/arm/v7` to `docker/build-push-action`

## Test evidence

- 160 backend tests pass
- CI workflow syntax validated
- No application code changes