### PR TITLE
Add multi-arch builds to dev image workflow

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

Adds the same QEMU + multi-platform build support from #89 to the dev image workflow. Dev images were still amd64-only.

## Changes

- Added `docker/setup-qemu-action@v3` before buildx setup
- Added `platforms: linux/amd64,linux/arm64,linux/arm/v7` to build-push-action