### PR TITLE
Fix Dockerfile ARM compatibility for libglib2.0-0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN pnpm run build
 
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     libgl1 \
-    libglib2.0-0 \
     libsm6 \
     libxext6 \
     libxrender1 \
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
     nginx \
     supervisor \
     git \
+    && (apt-get install -y libglib2.0-0t64 2>/dev/null || apt-get install -y libglib2.0-0) \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

ARM builds (armv7) fail because `libglib2.0-0` has been renamed to `libglib2.0-0t64` on ARM Debian (64-bit time_t transition). Adds a fallback that tries both names.

## Changes

- Dockerfile: try `libglib2.0-0t64` first, fall back to `libglib2.0-0`

## Context

Discovered after merging #89/#90 (multi-arch builds). CI failure: https://github.com/tracefinity/tracefinity/actions/runs/27789460113