### PR TITLE
Add resource requirements documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Tool tracing app that generates 3D-printable gridfinity bins from photos. Backen
 - [docs/stl-generation.md](docs/stl-generation.md) -- STL geometry, gridfinity constants, splitting
 - [docs/gotchas.md](docs/gotchas.md) -- Y-axis inversion, memory leaks, Docker, hard-won lessons
 - [docs/features.md](docs/features.md) -- complete feature inventory (what the app can do)
+- [docs/resource-requirements.md](docs/resource-requirements.md) -- RAM, CPU, disk, Docker limits, platform support
 - [docs/usage/](docs/usage/) -- user-facing guides (getting started, tracing, editing, bins, projects, exporting)
 - [DESIGN.md](DESIGN.md) -- design principles and contribution guidelines
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ When no API key is configured, Tracefinity runs a local salient object detection
 
 Paper corner detection runs [U2-Net Portable](https://github.com/xuebinqin/U-2-Net) alongside the tracer. RAM figures include both models. All models load at startup.
 
-**Minimum RAM: 2GB** (IS-Net). BiRefNet Lite needs **8GB**.
+**Minimum RAM: 2GB** (IS-Net). BiRefNet Lite needs **8GB**. See [Resource Requirements](docs/resource-requirements.md) for full details including Docker memory limits and platform support.
 
 BiRefNet General is available as an opt-in GPU tracer. For NVIDIA GPU tracing from
 source, install the optional GPU requirements after the default backend

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -1,0 +1,77 @@
+# Resource Requirements
+
+## RAM
+
+Two models run simultaneously: a tracer for tool outlines and U2-Net Portable for paper detection. U2-Net always runs locally regardless of tracing mode, establishing a ~2GB floor.
+
+| Mode | Tracer RAM | Total (with U2-Net) |
+|-|-|-|
+| IS-Net (default) | ~0.5GB | ~2GB |
+| InSPyReNet | ~4GB | ~6GB |
+| BiRefNet Lite | ~6GB | ~8GB |
+| Gemini API | none (remote) | ~2GB |
+| Replicate / fal | none (remote) | ~2GB |
+
+RAM figures are measured in Linux containers with both models loaded. Models load at startup and stay resident.
+
+## CPU
+
+Any modern x86-64 processor. All local models use ONNX Runtime on CPU by default. CUDA acceleration is available for NVIDIA GPUs (see README).
+
+ARM is supported: the Docker image ships linux/arm64 and linux/arm/v7 builds. Raspberry Pi 4/5 with 4GB+ RAM works (IS-Net or a remote tracer). Pi 3B+ (1GB) does not have enough memory.
+
+## Disk
+
+Storage scales with usage. Rough sizing:
+
+| What | Size |
+|-|-|
+| Docker image | ~2.5GB (includes model weights) |
+| Model weights (from-source, first run) | ~500MB downloaded |
+| Per photo (corrected + masks) | ~2-5MB |
+| Per tool (JSON + SVG) | ~10-50KB |
+| Per bin (JSON + STL/3MF) | ~1-10MB |
+
+A volume with 1GB free is plenty for a personal tool library of a few hundred tools and dozens of bins. Scale accordingly for shared instances.
+
+## Docker Resource Limits
+
+Sensible `--memory` defaults based on tracer choice:
+
+```bash
+# IS-Net or remote tracer (Gemini/Replicate/fal)
+docker run --memory=3g -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/tracefinity
+
+# InSPyReNet
+docker run --memory=8g -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/tracefinity
+
+# BiRefNet Lite
+docker run --memory=10g -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/tracefinity
+```
+
+Headroom above the model figures accounts for OpenCV image processing, STL generation, and the Node.js frontend server.
+
+### Kubernetes / Helm
+
+Set `resources.requests.memory` to match the tracer. Example for IS-Net:
+
+```yaml
+resources:
+  requests:
+    memory: "2Gi"
+    cpu: "500m"
+  limits:
+    memory: "3Gi"
+```
+
+For BiRefNet Lite, request 8Gi with a limit of 10Gi. The 128Mi placeholder in early Helm values is not viable for any configuration.
+
+## Platform Support
+
+| Platform | Status |
+|-|-|
+| linux/amd64 | Supported |
+| linux/arm64 | Supported (Apple Silicon via Docker Desktop, Pi 4/5) |
+| linux/arm/v7 | Supported (Pi 4 32-bit, other armv7 boards) |
+| macOS (from source) | Works on Intel and Apple Silicon |
+| Windows (from source) | Works via WSL2 or native Python/Node |


### PR DESCRIPTION
## Summary

Adds `docs/resource-requirements.md` covering RAM, CPU, disk, Docker limits, and platform support. Linked from README and CLAUDE.md.

Closes #88

## Changes

- `docs/resource-requirements.md` (new) -- canonical resource requirements reference
- `README.md` -- link to new doc
- `CLAUDE.md` -- add to docs index

## Test evidence

160 backend tests pass. Doc-only change.