### PR TITLE
Drop armv7 from multi-arch builds (Turbopack unsupported)

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run -p 3000:3000 -v ./data:/app/storage --user "$(id -u):$(id -g)" ghcr.i
 
 With a remote provider the corrected paper crop is sent to that provider for masking. fal is called with `sync_mode`, so the result is not kept in request history; Replicate API predictions (including the input image) auto-purge after about an hour, which is the only retention control Replicate exposes (it has no API to delete them sooner).
 
-The Docker image supports **linux/amd64**, **linux/arm64**, and **linux/arm/v7**. Apple Silicon Macs run arm64 natively via Docker Desktop. ARM devices need at least 2GB RAM (for U2-Net paper detection), so a Raspberry Pi 4/5 with 4GB+ works but a Pi 3B+ (1GB) does not.
+The Docker image supports **linux/amd64** and **linux/arm64**. Apple Silicon Macs run arm64 natively via Docker Desktop. ARM devices need at least 2GB RAM (for U2-Net paper detection), so a Raspberry Pi 4/5 with 4GB+ works.
 
 Open http://localhost:3000
 

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -18,7 +18,7 @@ RAM figures are measured in Linux containers with both models loaded. Models loa
 
 Any modern x86-64 processor. All local models use ONNX Runtime on CPU by default. CUDA acceleration is available for NVIDIA GPUs (see README).
 
-ARM is supported: the Docker image ships linux/arm64 and linux/arm/v7 builds. Raspberry Pi 4/5 with 4GB+ RAM works (IS-Net or a remote tracer). Pi 3B+ (1GB) does not have enough memory.
+ARM is supported: the Docker image ships linux/arm64 builds. Raspberry Pi 4/5 with 4GB+ RAM works (IS-Net or a remote tracer).
 
 ## Disk
 
@@ -72,6 +72,5 @@ For BiRefNet Lite, request 8Gi with a limit of 10Gi. The 128Mi placeholder in ea
 |-|-|
 | linux/amd64 | Supported |
 | linux/arm64 | Supported (Apple Silicon via Docker Desktop, Pi 4/5) |
-| linux/arm/v7 | Supported (Pi 4 32-bit, other armv7 boards) |
 | macOS (from source) | Works on Intel and Apple Silicon |
 | Windows (from source) | Works via WSL2 or native Python/Node |


### PR DESCRIPTION
## Summary

Removes linux/arm/v7 from multi-arch Docker builds. Turbopack (Next.js) has no native bindings for 32-bit ARM, and the only common armv7 device (Pi 3) has 1GB RAM which is below the 2GB minimum.

Keeps linux/amd64 and linux/arm64.

## Changes

- `.github/workflows/docker-dev.yml` -- remove arm/v7 from platforms
- `.github/workflows/docker-release.yml` -- same
- `README.md` -- update platform support line
- `docs/resource-requirements.md` -- remove armv7 from platform table and CPU section