### PR TITLE
Increase max bed size to 500mm

### DIFF
--- a/docs/usage/bin-configuration.md
+++ b/docs/usage/bin-configuration.md
@@ -16,7 +16,7 @@ Gridfinity is a modular storage system where bins snap into a baseplate grid. Ea
 | Magnet depth | 1-5mm | 2.4mm | Slightly deeper than magnet for press-fit |
 | Insert height | 0.5-10mm | 1.0mm | Only shown when insert is enabled |
 | Insert fit | 0-1mm | 0.2mm | Clearance shaved off insert edges so it drops into the pocket |
-| Bed size | 150-400mm | 256mm | For auto-splitting oversized bins |
+| Bed size | 150-500mm | 256mm | For auto-splitting oversized bins |
 
 ## Toggles
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -44,7 +44,7 @@ In-progress traces are saved automatically. If you close the browser or navigate
 
 ## Settings
 
-Click the gear icon in the top bar to open settings. Currently this lets you set your default printer bed size (150-400mm). Bins wider than this threshold are automatically split into printable pieces on export.
+Click the gear icon in the top bar to open settings. Currently this lets you set your default printer bed size (150-500mm). Bins wider than this threshold are automatically split into printable pieces on export.
 
 ## Collapsible sections
 

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -3,6 +3,7 @@
 import { Info } from 'lucide-react'
 import type { BinConfig } from '@/types'
 import { NumericInput } from '@/components/NumericInput'
+import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from '@/lib/settings'
 
 const GF_HEIGHT_UNIT = 7.0
 const GF_BASE_HEIGHT = 4.75
@@ -308,8 +309,8 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
           label="Bed Size"
           help="Print bed size. Bins wider than this are automatically split into pieces."
           value={config.bed_size}
-          min={150}
-          max={400}
+          min={BED_SIZE_MIN_MM}
+          max={BED_SIZE_MAX_MM}
           step={1}
           unit="mm"
           onChange={(v) => update({ bed_size: v })}

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Settings } from 'lucide-react'
-import { getSettings, saveSettings } from '@/lib/settings'
+import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM, getSettings, saveSettings } from '@/lib/settings'
 import { IconButton } from '@/components/IconButton'
 import { NumericInput } from '@/components/NumericInput'
 
@@ -31,7 +31,7 @@ export function SettingsPopover() {
     saveSettings({ bedSize: v })
   }
 
-  const pct = ((bedSize - 150) / (400 - 150)) * 100
+  const pct = ((bedSize - BED_SIZE_MIN_MM) / (BED_SIZE_MAX_MM - BED_SIZE_MIN_MM)) * 100
 
   return (
     <div ref={ref} className="relative">
@@ -50,8 +50,8 @@ export function SettingsPopover() {
             <div className="flex items-center gap-2">
               <input
                 type="range"
-                min={150}
-                max={400}
+                min={BED_SIZE_MIN_MM}
+                max={BED_SIZE_MAX_MM}
                 step={1}
                 value={bedSize}
                 onChange={(e) => handleBedSizeChange(parseInt(e.target.value))}
@@ -60,8 +60,8 @@ export function SettingsPopover() {
               />
               <div className="flex items-center gap-1">
                 <NumericInput
-                  min={150}
-                  max={400}
+                  min={BED_SIZE_MIN_MM}
+                  max={BED_SIZE_MAX_MM}
                   step={1}
                   value={bedSize}
                   onChange={handleBedSizeChange}

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -5,6 +5,9 @@ export interface UserSettings {
   binDefaults?: Partial<BinDefaults>
 }
 
+export const BED_SIZE_MIN_MM = 150
+export const BED_SIZE_MAX_MM = 500
+
 const DEFAULTS: UserSettings = { bedSize: 256 }
 const KEY = 'tracefinity-settings'
 


### PR DESCRIPTION
## Summary
- Increase the configurable printer bed size ceiling to 500mm (configurable) with 256mm as the default size.
- Share the bed-size min/max constants between the bin configurator and settings popover.
- Update user docs to describe the new 150-500mm range.

## Impact
Users with larger-format printers can configure up to a 500mm bed size before Tracefinity splits oversized bins for export.

## Validation
- `git diff --check upstream/main...HEAD`
- `frontend\node_modules\.bin\vitest.CMD run src/lib/binDefaults.test.ts src/components/BinConfigurator.test.ts`
- `frontend\node_modules\.bin\tsc.CMD --noEmit`

Code and PR drafted with Codex