### PR TITLE
Fix duplicate project tool keys

### DIFF
--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -28,6 +28,7 @@ import { binDefaultsFromConfig, buildBinConfig, getDefaultBinConfig, getDefaultB
 import { projectScopedHref } from '@/lib/projectNavigation'
 import {
   binLabel,
+  getUniqueBinTools,
   getProjectCollections,
   projectStatusLabels,
   projectNameMap,
@@ -800,7 +801,7 @@ export default function ProjectPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
               {projectBins.map(bin => {
                 const isExpanded = expandedBinIds.has(bin.id)
-                const binTools = (bin.tool_ids || []).map(toolId => toolById.get(toolId)).filter(Boolean) as ToolSummary[]
+                const binTools = getUniqueBinTools(bin, toolById)
                 const outsideTools = binTools.filter(tool => !projectToolIds.has(tool.id))
                 const projectToolsInBin = binTools.filter(tool => projectToolIds.has(tool.id))
                 const stillNeedsTools = projectTools.filter(tool => unplacedToolIds.has(tool.id))

--- a/frontend/src/lib/projectSelectors.test.ts
+++ b/frontend/src/lib/projectSelectors.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { getProjectCollections, getUniqueBinTools } from './projectSelectors'
+import type { BinProject, BinSummary, ToolSummary } from '@/types'
+
+const tool = (id: string): ToolSummary => ({
+  id,
+  name: id,
+  created_at: null,
+  point_count: 0,
+  points: [],
+  interior_rings: [],
+  smoothed: false,
+  smooth_level: 0,
+  thumbnail_url: null,
+  image_transform: null,
+  image_context: null,
+  category: null,
+  drawer: null,
+  tags: [],
+  project_ids: [],
+  review_status: null,
+  needs_cleanup: false,
+})
+
+const bin = (toolIds: string[]): BinSummary => ({
+  id: 'bin-1',
+  name: 'Bin 1',
+  project_id: 'project-1',
+  created_at: null,
+  tool_ids: toolIds,
+  tool_count: toolIds.length,
+  has_stl: false,
+  grid_x: 2,
+  grid_y: 2,
+  preview_tools: [],
+})
+
+const project: BinProject = {
+  id: 'project-1',
+  name: 'Project 1',
+  description: null,
+  status: 'active',
+  tool_ids: ['tool-1', 'tool-2'],
+  bin_ids: ['bin-1'],
+  placed_tool_ids: ['tool-1'],
+  unplaced_tool_ids: ['tool-2'],
+  target_grid_x: null,
+  target_grid_y: null,
+  default_bin_config: null,
+  notes: null,
+  created_at: null,
+  updated_at: null,
+}
+
+describe('project selectors', () => {
+  it('deduplicates repeated tool placements for linked-bin display', () => {
+    const toolById = new Map([tool('tool-1'), tool('tool-2')].map(item => [item.id, item]))
+
+    expect(getUniqueBinTools(bin(['tool-1', 'tool-1', 'tool-2']), toolById).map(item => item.id))
+      .toEqual(['tool-1', 'tool-2'])
+  })
+
+  it('counts a bin once per tool when building project tool metadata', () => {
+    const toolOne = tool('tool-1')
+    const collections = getProjectCollections(project, [toolOne, tool('tool-2')], [bin(['tool-1', 'tool-1'])], {
+      projectSearch: '',
+      addToolSearch: '',
+      statusFilter: 'all',
+      allowReassignBins: false,
+    })
+
+    expect(collections.toolBins.get(toolOne.id)?.map(item => item.id)).toEqual(['bin-1'])
+  })
+})

--- a/frontend/src/lib/projectSelectors.ts
+++ b/frontend/src/lib/projectSelectors.ts
@@ -34,6 +34,15 @@ export function projectNameMap(projects: BinProjectSummary[]) {
 
 export type ProjectToolFilter = 'all' | 'unplaced' | 'placed'
 
+export function getUniqueBinTools(
+  bin: BinSummary,
+  toolById: Map<string, ToolSummary>,
+) {
+  return Array.from(new Set(bin.tool_ids || []))
+    .map(toolId => toolById.get(toolId))
+    .filter(Boolean) as ToolSummary[]
+}
+
 export function getProjectCollections(
   project: BinProject | null,
   tools: ToolSummary[],
@@ -69,7 +78,7 @@ export function getProjectCollections(
 
   const toolBins = new Map<string, BinSummary[]>()
   for (const bin of projectBins) {
-    for (const toolId of bin.tool_ids || []) {
+    for (const toolId of new Set(bin.tool_ids || [])) {
       const current = toolBins.get(toolId) || []
       current.push(bin)
       toolBins.set(toolId, current)


### PR DESCRIPTION
## Summary
- Deduplicate repeated bin tool IDs when building project tool metadata
- Reuse the same unique-tool mapping for linked-bin tool rows
- Add selector coverage for repeated tool placements in a bin

## Why
A bin can contain multiple placed instances of the same tool, so the bin summary may include the same `tool_id` more than once. The project page renders tool rows keyed by tool ID, which means repeated IDs can produce duplicate React keys and duplicated linked-bin metadata. Project placement status only needs to know whether a tool appears in a bin at least once, so the project selectors should treat repeated tool IDs as a single display/metadata entry.

## Validation
- `frontend/node_modules/.bin/vitest.cmd run src/lib/projectSelectors.test.ts`
- `frontend/node_modules/.bin/tsc.cmd --noEmit`

Code and PR drafted with Codex