### PR TITLE
Fix raised rim when stacking lip is disabled

### DIFF
--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -896,7 +896,7 @@ class ManifoldSTLGenerator:
         # protruding tool sits in the open volume inside the collar, and the
         # stacking lip (if enabled) rides on top so a stacked bin clears the
         # tool.  Cutouts still pocket down from wall_top_z, unaffected by the rim.
-        rim_units = getattr(config, "rim_units", 0) or 0
+        rim_units = (getattr(config, "rim_units", 0) or 0) if config.stacking_lip else 0
         rim_height = rim_units * GF_HEIGHT_UNIT
         lip_base_z = wall_top_z + rim_height
         # inner opening matches the stacking-lip inner opening so the collar wall

--- a/backend/tests/test_raise_lip.py
+++ b/backend/tests/test_raise_lip.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from app.models.schemas import GenerateRequest
+from app.services.stl_generator_manifold import ManifoldSTLGenerator
+
+
+def test_raise_lip_is_ignored_when_stacking_lip_disabled(tmp_path: Path):
+    config = GenerateRequest(
+        grid_x=2,
+        grid_y=1,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        rim_units=0,
+        bed_size=0,
+    )
+    generator = ManifoldSTLGenerator()
+
+    standard_body, _ = generator.generate_bin([], config, str(tmp_path / "standard.stl"))
+    stale_rim_body, _ = generator.generate_bin([], config.model_copy(update={"rim_units": 3}), str(tmp_path / "stale_rim.stl"))
+
+    assert stale_rim_body.volume() == standard_body.volume()

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -357,6 +357,7 @@ export default function BinPage() {
   const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null
   const binW = config.grid_x * GRID_UNIT
   const binH = config.grid_y * GRID_UNIT
+  const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0
   const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl
 
   return (
@@ -403,7 +404,7 @@ export default function BinPage() {
             <div className="text-[11px] text-text-secondary space-y-0.5">
               <div className="flex justify-between"><span>Width</span><span>{binW} mm</span></div>
               <div className="flex justify-between"><span>Depth</span><span>{binH} mm</span></div>
-              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + config.rim_units * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
+              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + effectiveRimUnits * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -253,7 +253,11 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
           checked={config.stacking_lip}
           onChange={(v) => {
             const newMax = calcMaxCutoutDepth(config.height_units, v)
-            update({ stacking_lip: v, cutout_depth: Math.min(config.cutout_depth, newMax) })
+            update({
+              stacking_lip: v,
+              rim_units: v ? config.rim_units : 0,
+              cutout_depth: Math.min(config.cutout_depth, newMax),
+            })
           }}
           label="Stacking lip"
           help="Raised rim at the top so bins can stack securely on top of each other."


### PR DESCRIPTION
Fixes a follow-up bug from PR #83.

PR #83 added `rim_units` so the stacking lip can be raised above the bin floor face, letting a stacked bin clear tools that protrude above shallow-bin cutouts. The original UI only exposed "Raise Lip" when `stacking_lip` was enabled, and the feature was described as moving the stacking lip onto a raised hollow collar.

However, the backend generator still honored `rim_units` even when `stacking_lip` was false. That meant a saved or stale config could silently generate a raised perimeter wall even though the stacking lip was disabled and the UI no longer showed the control. This made `rim_units` hidden state affect STL geometry outside the feature's intended scope.

This change:
- ignores `rim_units` in STL generation unless `stacking_lip` is enabled
- clears `rim_units` when the stacking lip toggle is turned off in the configurator
- keeps the dimensions readout consistent with the effective generated height
- adds a regression test proving stale `rim_units` does not change generated volume when stacking lip is disabled

Code and PR drafted with Codex

Testing:
- `python -m pytest backend/tests/test_raise_lip.py backend/tests/test_max_cutout_depth.py`
- `frontend\node_modules\.bin\vitest.cmd run frontend/src/components/BinConfigurator.test.ts --config frontend/vitest.config.ts`
