### PR TITLE
Fix image downscale test import

### DIFF
--- a/backend/tests/test_image_downscale.py
+++ b/backend/tests/test_image_downscale.py
@@ -2,7 +2,8 @@ from io import BytesIO
 
 from PIL import Image
 
-from app.api.routes import MAX_UPLOAD_DIM, _downscale_image
+from app.api.routes import MAX_UPLOAD_DIM
+from app.services.image_ingest import ingest_image
 
 
 def _png_bytes(size: tuple[int, int]) -> bytes:
@@ -13,7 +14,7 @@ def _png_bytes(size: tuple[int, int]) -> bytes:
 
 def test_downscale_returns_actual_integer_resize_ratio():
     original_width = 6041
-    content, ratio = _downscale_image(_png_bytes((original_width, 10)), ".png")
+    content, _, ratio = ingest_image(_png_bytes((original_width, 10)), ".png", MAX_UPLOAD_DIM)
     resized = Image.open(BytesIO(content))
 
     assert resized.width == MAX_UPLOAD_DIM


### PR DESCRIPTION
## Summary
- update the stale image downscale test to call the current `ingest_image` service API
- keep the existing assertion that the returned ratio matches the actual resized image width

## Root cause
`_downscale_image` was moved out of `app.api.routes` before `backend/tests/test_image_downscale.py` was added, so full backend test collection failed on an import error before the suite could run.

## Validation
- `python -m pytest backend/tests/test_image_downscale.py -q` -> 1 passed
- `$env:DEVELOPMENT_MODE='1'; python -m pytest backend/tests -q` -> 153 passed, 8 failed in existing `backend/tests/test_store_load_errors.py` Windows permission scenarios; the stale import/collection blocker is fixed
- `corepack pnpm exec vitest run` -> 6 files passed, 73 tests passed
- `E2E_TEST_MODE=1 GOOGLE_API_KEY=mock corepack pnpm exec playwright test` with local backend/frontend servers -> 19 passed

Code and PR drafted with Codex
