### PR TITLE
Add zoom and pan support to paper alignment view

### DIFF
--- a/frontend/src/components/PaperCornerEditor.tsx
+++ b/frontend/src/components/PaperCornerEditor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { ZOOM_FACTOR } from '@/lib/constants'
 import type { Point } from '@/types'
 
 interface Props {
@@ -12,6 +13,11 @@ interface Props {
 const HANDLE_RADIUS = 12
 const HANDLE_HIT_RADIUS = 24
 
+type DragState =
+  | { type: 'corner'; index: number }
+  | { type: 'pan'; startClientX: number; startClientY: number; origPanX: number; origPanY: number }
+  | null
+
 export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -20,8 +26,14 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
   const rafRef = useRef<number | null>(null)
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 })
   const [fitted, setFitted] = useState({ width: 0, height: 0 })
-  const [dragging, setDragging] = useState<number | null>(null)
+  const [dragging, setDragging] = useState<DragState>(null)
   const [draftCorners, setDraftCorners] = useState<Point[] | null>(null)
+  const [zoom, setZoom] = useState(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+  const zoomRef = useRef(zoom)
+  const panRef = useRef(pan)
+  useEffect(() => { zoomRef.current = zoom }, [zoom])
+  useEffect(() => { panRef.current = pan }, [pan])
   const displayCorners = draftCorners ?? corners
 
   useEffect(() => {
@@ -75,10 +87,13 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
 
   const displayScale = imageSize.width > 0 && fitted.width > 0 ? fitted.width / imageSize.width : 1
 
+  // convert client coords to image-space coords, accounting for zoom and pan
   const getScaledPoint = useCallback(
     (clientX: number, clientY: number): Point => {
       if (!containerRef.current) return { x: 0, y: 0 }
 
+      // getBoundingClientRect reflects the CSS transform, giving us
+      // the actual on-screen position and size of the scaled container
       const rect = containerRef.current.getBoundingClientRect()
       const scaleX = imageSize.width / rect.width
       const scaleY = imageSize.height / rect.height
@@ -94,16 +109,18 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
   const startDrag = useCallback((index: number) => {
     draftCornersRef.current = corners
     setDraftCorners(corners)
-    setDragging(index)
+    setDragging({ type: 'corner', index })
   }, [corners])
 
   const handleMouseDown = (index: number) => (e: React.MouseEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     startDrag(index)
   }
 
   const handleTouchStart = (index: number) => (e: React.TouchEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     startDrag(index)
   }
 
@@ -132,32 +149,48 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
 
   const updateDrag = useCallback(
     (clientX: number, clientY: number) => {
-      if (dragging === null) return
+      if (!dragging || dragging.type !== 'corner') return
       const point = getScaledPoint(clientX, clientY)
-      queueDraftCorner(dragging, point)
+      queueDraftCorner(dragging.index, point)
     },
     [dragging, getScaledPoint, queueDraftCorner]
   )
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
+      if (!dragging) return
+      if (dragging.type === 'pan') {
+        const dx = e.clientX - dragging.startClientX
+        const dy = e.clientY - dragging.startClientY
+        // pan is in image-pixel units; convert screen pixels by dividing
+        // by the combined displayScale * zoom
+        const pixPerImg = displayScale * zoomRef.current
+        setPan({ x: dragging.origPanX - dx / pixPerImg, y: dragging.origPanY - dy / pixPerImg })
+        return
+      }
       updateDrag(e.clientX, e.clientY)
     },
-    [updateDrag]
+    [dragging, updateDrag, displayScale]
   )
 
   const handleTouchMove = useCallback(
     (e: TouchEvent) => {
+      if (!dragging || dragging.type !== 'corner') return
       e.preventDefault()
       const t = e.touches[0]
       if (!t) return
       updateDrag(t.clientX, t.clientY)
     },
-    [updateDrag]
+    [dragging, updateDrag]
   )
 
   const finishDrag = useCallback(() => {
-    if (dragging === null) return
+    if (!dragging) return
+    if (dragging.type === 'pan') {
+      setDragging(null)
+      return
+    }
+    if (dragging.type !== 'corner') return
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current)
       rafRef.current = null
@@ -168,7 +201,7 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
     let finalCorners = draftCornersRef.current ?? corners
     if (pending) {
       finalCorners = [...finalCorners]
-      finalCorners[dragging] = pending
+      finalCorners[dragging.index] = pending
     }
 
     draftCornersRef.current = null
@@ -200,6 +233,64 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
     }
   }, [dragging, handleMouseMove, handleMouseUp, handleTouchMove, handleTouchEnd])
 
+  // scroll-to-zoom with cursor-aware panning
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      const factor = e.deltaY < 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR
+      const oldZoom = zoomRef.current
+      const newZoom = Math.min(20, Math.max(0.5, oldZoom * factor))
+      if (newZoom === oldZoom) return
+
+      if (!containerRef.current) {
+        setZoom(newZoom)
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+      const curPan = panRef.current
+
+      // image-pixel coord under cursor (rect already reflects CSS transform)
+      const imgX = (e.clientX - rect.left) * (imageSize.width / rect.width)
+      const imgY = (e.clientY - rect.top) * (imageSize.height / rect.height)
+
+      // keep the point under cursor fixed across zoom change.
+      // derived from the CSS transform chain (see comment above getScaledPoint).
+      const halfW = imageSize.width / 2
+      const halfH = imageSize.height / 2
+      const ratio = 1 / newZoom - 1 / oldZoom
+      setPan({
+        x: curPan.x + (imgX - halfW) * ratio,
+        y: curPan.y + (imgY - halfH) * ratio,
+      })
+      setZoom(newZoom)
+    }
+    wrapper.addEventListener('wheel', handleWheel, { passive: false })
+    return () => wrapper.removeEventListener('wheel', handleWheel)
+  }, [displayScale, imageSize])
+
+  // background mousedown on wrapper = pan
+  const handleWrapperMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0) return
+    // only start pan if the click target is the wrapper itself or the image
+    // (not a handle, which calls stopPropagation)
+    e.preventDefault()
+    setDragging({
+      type: 'pan',
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      origPanX: pan.x,
+      origPanY: pan.y,
+    })
+  }
+
+  const handleResetZoom = () => {
+    setZoom(1)
+    setPan({ x: 0, y: 0 })
+  }
+
   if (!imageSize.width || !fitted.width) {
     return (
       <div ref={wrapperRef} className="w-full h-full">
@@ -209,11 +300,21 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
   }
 
   return (
-    <div ref={wrapperRef} className="w-full h-full flex items-center justify-center">
+    <div
+      ref={wrapperRef}
+      className="w-full h-full flex items-center justify-center relative overflow-hidden"
+      style={{ cursor: dragging?.type === 'pan' ? 'grabbing' : zoom > 1 ? 'grab' : 'default' }}
+      onMouseDown={handleWrapperMouseDown}
+    >
       <div
         ref={containerRef}
-        className="relative bg-inset rounded-lg overflow-hidden"
-        style={{ width: fitted.width, height: fitted.height }}
+        className="relative bg-inset rounded-lg overflow-visible"
+        style={{
+          width: fitted.width,
+          height: fitted.height,
+          transform: `scale(${zoom}) translate(${-pan.x * displayScale}px, ${-pan.y * displayScale}px)`,
+          transformOrigin: 'center center',
+        }}
       >
         <img
           src={imageUrl}
@@ -230,7 +331,7 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
                 .join(' ')}
               fill="rgba(90, 180, 222, 0.1)"
               stroke="rgb(90, 180, 222)"
-              strokeWidth={2}
+              strokeWidth={2 / zoom}
             />
           )}
 
@@ -239,7 +340,7 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
               <circle
                 cx={corner.x * displayScale}
                 cy={corner.y * displayScale}
-                r={HANDLE_HIT_RADIUS}
+                r={HANDLE_HIT_RADIUS / zoom}
                 fill="transparent"
                 className="pointer-events-auto cursor-move touch-none"
                 onMouseDown={handleMouseDown(index)}
@@ -248,15 +349,39 @@ export function PaperCornerEditor({ imageUrl, corners, onCornersChange }: Props)
               <circle
                 cx={corner.x * displayScale}
                 cy={corner.y * displayScale}
-                r={HANDLE_RADIUS}
+                r={HANDLE_RADIUS / zoom}
                 fill="#27272a"
                 stroke="rgb(90, 180, 222)"
-                strokeWidth={2}
+                strokeWidth={2 / zoom}
                 className="pointer-events-none"
               />
             </g>
           ))}
         </svg>
+      </div>
+
+      {/* zoom controls */}
+      <div className="absolute bottom-3.5 right-3.5 z-20 glass-toolbar px-1 py-0.5 flex items-center gap-0.5 text-[11px]" onMouseDown={e => e.stopPropagation()}>
+        <button
+          onClick={() => setZoom(z => Math.max(0.5, z / ZOOM_FACTOR))}
+          className="px-2 py-1 rounded-[7px] text-text-muted hover:text-text-primary hover:bg-border/50 transition-colors"
+        >
+          -
+        </button>
+        <span className="px-1.5 text-text-secondary min-w-[36px] text-center">{Math.round(zoom * 100)}%</span>
+        <button
+          onClick={() => setZoom(z => Math.min(20, z * ZOOM_FACTOR))}
+          className="px-2 py-1 rounded-[7px] text-text-muted hover:text-text-primary hover:bg-border/50 transition-colors"
+        >
+          +
+        </button>
+        <div className="h-3.5 w-px bg-border-subtle mx-0.5" />
+        <button
+          onClick={handleResetZoom}
+          className="px-2 py-1 rounded-[7px] text-text-muted hover:text-text-primary hover:bg-border/50 transition-colors"
+        >
+          Fit
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Adds scroll-to-zoom and click-drag panning to the paper corner editor, matching the existing ToolEditor zoom/pan behaviour. Precise paper edge positioning directly affects scale_factor accuracy, which flows through to every tool trace and STL export.

Closes #107

## Changes

- **`PaperCornerEditor.tsx`** -- added cursor-aware scroll-to-zoom (0.5x-20x), background drag-to-pan, zoom controls UI, and consistent handle sizing across zoom levels. Follows the same pattern as ToolEditor.

## How to test

1. Upload an image and go to paper alignment
2. Scroll to zoom in/out — zoom should centre on cursor position
3. Click-drag background to pan when zoomed in
4. Drag corner handles — they should work correctly at all zoom levels
5. Zoom controls (bottom-right) should show current level and allow reset