### PR TITLE
feat: Add Partial Bins option

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1584,6 +1584,7 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
         partial_bins=bc.partial_bins,
         partial_bins_values=bc.partial_bins_values,
         partial_bins_connect=bc.partial_bins_connect,
+        partial_bins_retain_wall=bc.partial_bins_retain_wall,
         text_labels=bc.text_labels + bin_data.text_labels,
         bed_size=bc.bed_size,
         half_grid_base=bc.half_grid_base,

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -372,6 +372,7 @@ def _build_bin_from_tools(
             grid_y = max(1.0, math.ceil(needed_h / GF_GRID))
         bc.grid_x = min(grid_x, 10.0)
         bc.grid_y = min(grid_y, 10.0)
+        bc.partial_bins_values = [True] * (math.ceil(bc.grid_x) * math.ceil(bc.grid_y))
 
         bin_w = bc.grid_x * GF_GRID
         bin_h = bc.grid_y * GF_GRID
@@ -439,16 +440,17 @@ def _run_generate(
 
     stl_urls: list[str] = []
     zip_url = None
-    if gen_req.bed_size > 0:
-        output_dir = str(user_path / "outputs")
-        part_paths = stl_generator.split_bin(bin_body, text_body, gen_req, gen_req.bed_size, output_dir, entity_id)
-        if part_paths:
-            stl_urls = [f"/storage/{user_id}/outputs/{Path(p).name}" for p in part_paths]
-            part_bytes = [(Path(p).name, Path(p).read_bytes()) for p in part_paths]
-            with zipfile.ZipFile(str(zip_path), 'w', zipfile.ZIP_DEFLATED) as zf:
-                for fname, data in part_bytes:
-                    zf.writestr(fname, data)
-            zip_url = f"/storage/{user_id}/outputs/{entity_id}_parts.zip"
+    output_dir = str(user_path / "outputs")
+    part_paths = stl_generator.export_split_parts(
+        bin_body, text_body, gen_req, gen_req.bed_size, output_dir, entity_id
+    )
+    if part_paths:
+        stl_urls = [f"/storage/{user_id}/outputs/{Path(p).name}" for p in part_paths]
+        part_bytes = [(Path(p).name, Path(p).read_bytes()) for p in part_paths]
+        with zipfile.ZipFile(str(zip_path), 'w', zipfile.ZIP_DEFLATED) as zf:
+            for fname, data in part_bytes:
+                zf.writestr(fname, data)
+        zip_url = f"/storage/{user_id}/outputs/{entity_id}_parts.zip"
 
     insert_stl_url = None
     warning = None
@@ -1579,6 +1581,9 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
         insert_height=bc.insert_height,
         insert_clearance=bc.insert_clearance,
         cutout_chamfer=bc.cutout_chamfer,
+        partial_bins=bc.partial_bins,
+        partial_bins_values=bc.partial_bins_values,
+        partial_bins_connect=bc.partial_bins_connect,
         text_labels=bc.text_labels + bin_data.text_labels,
         bed_size=bc.bed_size,
         half_grid_base=bc.half_grid_base,

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -95,6 +95,7 @@ class BinParams(BaseModel):
     partial_bins: bool = False
     partial_bins_values: list[bool] = []
     partial_bins_connect: bool = False
+    partial_bins_retain_wall: bool = False
 
     @model_validator(mode="after")
     def normalize_partial_bins_values(self) -> "BinParams":
@@ -103,6 +104,8 @@ class BinParams(BaseModel):
         expected = math.ceil(self.grid_x) * math.ceil(self.grid_y)
         if len(self.partial_bins_values) != expected:
             self.partial_bins_values = [True] * expected
+        if not self.partial_bins_connect:
+            self.partial_bins_retain_wall = False
         return self
 
     @field_validator("grid_x", "grid_y")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -92,6 +92,18 @@ class BinParams(BaseModel):
     insert_clearance: float = 0.2  # mm shaved off the insert so it fits the pocket
     cutout_chamfer: float = 0.0
     half_grid_base: bool = False  # use 21mm half-grid cells for the bottom baseplate
+    partial_bins: bool = False
+    partial_bins_values: list[bool] = []
+    partial_bins_connect: bool = False
+
+    @model_validator(mode="after")
+    def normalize_partial_bins_values(self) -> "BinParams":
+        import math
+
+        expected = math.ceil(self.grid_x) * math.ceil(self.grid_y)
+        if len(self.partial_bins_values) != expected:
+            self.partial_bins_values = [True] * expected
+        return self
 
     @field_validator("grid_x", "grid_y")
     @classmethod

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -106,6 +106,8 @@ class BinParams(BaseModel):
             self.partial_bins_values = [True] * expected
         if not self.partial_bins_connect:
             self.partial_bins_retain_wall = False
+        if self.partial_bins and not any(self.partial_bins_values):
+            raise ValueError("at least one grid cell must remain enabled when partial bins is on")
         return self
 
     @field_validator("grid_x", "grid_y")

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -306,12 +306,17 @@ PARTIAL_BIN_CONNECT_PLATE_MM = 6.0 - PARTIAL_BIN_CONNECT_PLATE_Z_INSET
 PARTIAL_BIN_RETAIN_WALL_PRESERVE_MM = LIP_D0 + LIP_D2
 
 
+def _grid_cell_counts(config: GenerateRequest) -> tuple[int, int]:
+    return math.ceil(config.grid_x), math.ceil(config.grid_y)
+
+
 def _find_disabled_components(config: GenerateRequest) -> list[list[tuple[int, int]]]:
     components: list[list[tuple[int, int]]] = []
     visited: set[tuple[int, int]] = set()
+    grid_x, grid_y = _grid_cell_counts(config)
 
-    for iy in range(config.grid_y):
-        for ix in range(config.grid_x):
+    for iy in range(grid_y):
+        for ix in range(grid_x):
             if _cell_enabled(config, ix, iy) or (ix, iy) in visited:
                 continue
             cells: list[tuple[int, int]] = []
@@ -324,7 +329,7 @@ def _find_disabled_components(config: GenerateRequest) -> list[list[tuple[int, i
                 cells.append((x, y))
                 for dx, dy in ((0, 1), (0, -1), (1, 0), (-1, 0)):
                     nx, ny = x + dx, y + dy
-                    if 0 <= nx < config.grid_x and 0 <= ny < config.grid_y:
+                    if 0 <= nx < grid_x and 0 <= ny < grid_y:
                         stack.append((nx, ny))
             components.append(cells)
 
@@ -355,9 +360,10 @@ def _make_connect_mode_cell_cutters(config: GenerateRequest, top_z: float):
     bin_hh = (config.grid_y * GF_GRID - 0.5) / 2.0
     half = GF_GRID / 2.0
     preserve = PARTIAL_BIN_RETAIN_WALL_PRESERVE_MM
+    grid_x, grid_y = _grid_cell_counts(config)
 
-    for iy in range(config.grid_y):
-        for ix in range(config.grid_x):
+    for iy in range(grid_y):
+        for ix in range(grid_x):
             if _cell_enabled(config, ix, iy):
                 continue
             cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
@@ -366,11 +372,11 @@ def _make_connect_mode_cell_cutters(config: GenerateRequest, top_z: float):
                 y0, y1 = cy - half, cy + half
                 if ix == 0:
                     x0 = max(x0, -bin_hw + preserve)
-                if ix == config.grid_x - 1:
+                if ix == grid_x - 1:
                     x1 = min(x1, bin_hw - preserve)
                 if iy == 0:
                     y0 = max(y0, -bin_hh + preserve)
-                if iy == config.grid_y - 1:
+                if iy == grid_y - 1:
                     y1 = min(y1, bin_hh - preserve)
                 w, h = x1 - x0, y1 - y0
                 if w <= 0.1 or h <= 0.1:
@@ -401,6 +407,7 @@ def _make_connect_mode_stability_plates(config: GenerateRequest):
     outer_h = config.grid_y * GF_GRID - 0.5
     bin_hw = outer_w / 2.0
     bin_hh = outer_h / 2.0
+    grid_x, grid_y = _grid_cell_counts(config)
 
     for cells in _find_disabled_components(config):
         min_x, min_y, max_x, max_y = _component_world_bbox(config, cells)
@@ -408,7 +415,7 @@ def _make_connect_mode_stability_plates(config: GenerateRequest):
         for ix, iy in cells:
             for dx, dy in ((0, 1), (0, -1), (1, 0), (-1, 0)):
                 nx, ny = ix + dx, iy + dy
-                if not (0 <= nx < config.grid_x and 0 <= ny < config.grid_y):
+                if not (0 <= nx < grid_x and 0 <= ny < grid_y):
                     continue
                 if not _cell_enabled(config, nx, ny):
                     continue
@@ -446,9 +453,10 @@ def _make_disabled_cell_cutters(config: GenerateRequest, top_z: float):
     import manifold3d as mf
 
     cutters = []
+    grid_x, grid_y = _grid_cell_counts(config)
 
-    for iy in range(config.grid_y):
-        for ix in range(config.grid_x):
+    for iy in range(grid_y):
+        for ix in range(grid_x):
             if _cell_enabled(config, ix, iy):
                 continue
             cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -57,6 +57,12 @@ def _rounded_rect_pts(w: float, h: float, r: float, segs: int = CIRCLE_SEGS) -> 
     return np.array(pts, dtype=np.float64)
 
 
+def _sharp_rect_pts(w: float, h: float) -> np.ndarray:
+    """CCW axis-aligned rectangle centred at origin (no corner radius)."""
+    hw, hh = w / 2.0, h / 2.0
+    return np.array([(-hw, -hh), (hw, -hh), (hw, hh), (-hw, hh)], dtype=np.float64)
+
+
 def _cs(pts: np.ndarray):
     import manifold3d as mf
     return mf.CrossSection([np.asarray(pts, dtype=np.float64)])
@@ -171,6 +177,74 @@ def _base_cell_layout(grid_units: float, cell_size: float) -> list[tuple[float, 
     return cells
 
 
+def _cell_center(ix: int, iy: int, grid_x: int, grid_y: int) -> tuple[float, float]:
+    return (
+        (ix - (grid_x - 1) / 2.0) * GF_GRID,
+        (iy - (grid_y - 1) / 2.0) * GF_GRID,
+    )
+
+
+def _partial_cell_index(config: GenerateRequest, ix: int, iy: int) -> int:
+    """Map backend grid coords to UI row-major partial_bins_values (row 0 = top)."""
+    ui_row = math.ceil(config.grid_y) - 1 - iy
+    return ui_row * math.ceil(config.grid_x) + ix
+
+
+def _cell_enabled(config: GenerateRequest, ix: int, iy: int) -> bool:
+    if not getattr(config, "partial_bins", False):
+        return True
+    values = getattr(config, "partial_bins_values", None) or []
+    idx = _partial_cell_index(config, ix, iy)
+    if idx >= len(values):
+        return True
+    return bool(values[idx])
+
+
+def _all_cells_enabled(config: GenerateRequest) -> bool:
+    if not getattr(config, "partial_bins", False):
+        return True
+    values = config.partial_bins_values or []
+    expected = math.ceil(config.grid_x) * math.ceil(config.grid_y)
+    if len(values) != expected:
+        return True
+    return all(values)
+
+
+def _uses_partial_shell(config: GenerateRequest) -> bool:
+    return getattr(config, "partial_bins", False) and not _all_cells_enabled(config)
+
+
+def _partial_bins_connect_bases(config: GenerateRequest) -> bool:
+    return getattr(config, "partial_bins_connect", False) and _uses_partial_shell(config)
+
+
+def _exports_separated_partial_parts(config: GenerateRequest) -> bool:
+    return _uses_partial_shell(config) and not _partial_bins_connect_bases(config)
+
+
+def _partial_bounds(config: GenerateRequest) -> tuple[int, int, int, int]:
+    grid_x = math.ceil(config.grid_x)
+    grid_y = math.ceil(config.grid_y)
+    enabled = [
+        (ix, iy)
+        for iy in range(grid_y)
+        for ix in range(grid_x)
+        if _cell_enabled(config, ix, iy)
+    ]
+    if not enabled:
+        return 0, grid_x - 1, 0, grid_y - 1
+    ixs = [p[0] for p in enabled]
+    iys = [p[1] for p in enabled]
+    return min(ixs), max(ixs), min(iys), max(iys)
+
+
+def _effective_grid_span(config: GenerateRequest) -> tuple[int, int]:
+    if not _uses_partial_shell(config):
+        return math.ceil(config.grid_x), math.ceil(config.grid_y)
+    min_ix, max_ix, min_iy, max_iy = _partial_bounds(config)
+    return max_ix - min_ix + 1, max_iy - min_iy + 1
+
+
 def _build_shell(config: GenerateRequest):
     """Solid bin shell: base units + wall body to wall_top_z.
 
@@ -209,6 +283,197 @@ def _build_shell(config: GenerateRequest):
 
     parts = base_units + [wall_body]
     return mf.Manifold.batch_boolean(parts, mf.OpType.Add)
+
+
+def _bin_top_z(config: GenerateRequest, wall_top_z: float) -> float:
+    rim_units = (getattr(config, "rim_units", 0) or 0) if config.stacking_lip else 0
+    rim_height = rim_units * GF_HEIGHT_UNIT
+    lip_total = (LIP_D0 + LIP_D1 + LIP_D2) if config.stacking_lip else 0
+    return wall_top_z + rim_height + lip_total
+
+
+PARTIAL_BIN_CONNECT_PLATE_Z_INSET = 0.2
+PARTIAL_BIN_CONNECT_PLATE_MM = 6.0 - PARTIAL_BIN_CONNECT_PLATE_Z_INSET
+
+
+def _find_disabled_components(config: GenerateRequest) -> list[list[tuple[int, int]]]:
+    components: list[list[tuple[int, int]]] = []
+    visited: set[tuple[int, int]] = set()
+
+    for iy in range(config.grid_y):
+        for ix in range(config.grid_x):
+            if _cell_enabled(config, ix, iy) or (ix, iy) in visited:
+                continue
+            cells: list[tuple[int, int]] = []
+            stack = [(ix, iy)]
+            while stack:
+                x, y = stack.pop()
+                if (x, y) in visited or _cell_enabled(config, x, y):
+                    continue
+                visited.add((x, y))
+                cells.append((x, y))
+                for dx, dy in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+                    nx, ny = x + dx, y + dy
+                    if 0 <= nx < config.grid_x and 0 <= ny < config.grid_y:
+                        stack.append((nx, ny))
+            components.append(cells)
+
+    return components
+
+
+def _component_world_bbox(config: GenerateRequest, cells: list[tuple[int, int]]):
+    half = GF_GRID / 2.0
+    min_x = min_y = float("inf")
+    max_x = max_y = float("-inf")
+    for ix, iy in cells:
+        cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
+        min_x = min(min_x, cx - half)
+        max_x = max(max_x, cx + half)
+        min_y = min(min_y, cy - half)
+        max_y = max(max_y, cy + half)
+    return min_x, min_y, max_x, max_y
+
+
+def _make_connect_mode_cell_cutters(config: GenerateRequest, top_z: float):
+    """Remove all walls/lip above the base in disabled cells."""
+    import manifold3d as mf
+
+    cutters = []
+    cut_height = top_z - GF_BASE_HEIGHT + 0.2
+
+    for iy in range(config.grid_y):
+        for ix in range(config.grid_x):
+            if _cell_enabled(config, ix, iy):
+                continue
+            cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
+            cs = _cs(_sharp_rect_pts(GF_GRID, GF_GRID))
+            cutters.append(
+                mf.Manifold.extrude(cs, cut_height).translate((cx, cy, GF_BASE_HEIGHT - 0.1))
+            )
+
+    if not cutters:
+        return None
+    return mf.Manifold.batch_boolean(cutters, mf.OpType.Add)
+
+
+def _make_connect_mode_stability_plates(config: GenerateRequest):
+    """Floor plates across disabled regions, overlapping into enabled neighbors."""
+    import manifold3d as mf
+
+    plates = []
+    overlap = GF_GRID / 2.0
+    outer_w = config.grid_x * GF_GRID - 0.5
+    outer_h = config.grid_y * GF_GRID - 0.5
+    bin_hw = outer_w / 2.0
+    bin_hh = outer_h / 2.0
+
+    for cells in _find_disabled_components(config):
+        min_x, min_y, max_x, max_y = _component_world_bbox(config, cells)
+
+        for ix, iy in cells:
+            for dx, dy in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+                nx, ny = ix + dx, iy + dy
+                if not (0 <= nx < config.grid_x and 0 <= ny < config.grid_y):
+                    continue
+                if not _cell_enabled(config, nx, ny):
+                    continue
+                ncx, ncy = _cell_center(nx, ny, config.grid_x, config.grid_y)
+                if dx == 1:
+                    max_x = max(max_x, ncx + overlap)
+                elif dx == -1:
+                    min_x = min(min_x, ncx - overlap)
+                if dy == 1:
+                    max_y = max(max_y, ncy + overlap)
+                elif dy == -1:
+                    min_y = min(min_y, ncy - overlap)
+
+        min_x = max(min_x, -bin_hw)
+        max_x = min(max_x, bin_hw)
+        min_y = max(min_y, -bin_hh)
+        max_y = min(max_y, bin_hh)
+
+        w, h = max_x - min_x, max_y - min_y
+        ccx, ccy = (min_x + max_x) / 2.0, (min_y + max_y) / 2.0
+        corner_r = min(GF_CORNER_R, w / 2.0, h / 2.0)
+        plates.append(
+            mf.Manifold.extrude(
+                _cs(_rounded_rect_pts(w, h, corner_r)), PARTIAL_BIN_CONNECT_PLATE_MM
+            ).translate((ccx, ccy, GF_BASE_HEIGHT))
+        )
+
+    if not plates:
+        return None
+    return mf.Manifold.batch_boolean(plates, mf.OpType.Add)
+
+
+def _make_disabled_cell_cutters(config: GenerateRequest, top_z: float):
+    """Cutters that remove geometry for each disabled grid cell."""
+    import manifold3d as mf
+
+    cutters = []
+
+    for iy in range(config.grid_y):
+        for ix in range(config.grid_x):
+            if _cell_enabled(config, ix, iy):
+                continue
+            cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
+            cs = _cs(_sharp_rect_pts(GF_GRID, GF_GRID))
+            cutters.append(
+                mf.Manifold.extrude(cs, top_z + 0.2).translate((cx, cy, -0.1))
+            )
+
+    if not cutters:
+        return None
+    return mf.Manifold.batch_boolean(cutters, mf.OpType.Add)
+
+
+def _add_lip_features(
+    body,
+    config: GenerateRequest,
+    outer_w: float,
+    outer_h: float,
+    wall_top_z: float,
+    origin: tuple[float, float] = (0.0, 0.0),
+):
+    """Add raised rim collar and stacking lip, optionally offset to a grid cell centre."""
+    import manifold3d as mf
+
+    ox, oy = origin
+    rim_units = (getattr(config, "rim_units", 0) or 0) if config.stacking_lip else 0
+    rim_height = rim_units * GF_HEIGHT_UNIT
+    lip_base_z = wall_top_z + rim_height
+    rim_inner_w = outer_w - 2 * (LIP_D0 + LIP_D2)
+    rim_inner_h = outer_h - 2 * (LIP_D0 + LIP_D2)
+    additions = []
+
+    if rim_height > 0:
+        outer_solid = mf.Manifold.extrude(
+            _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R)), rim_height
+        )
+        inner_solid = mf.Manifold.extrude(
+            _cs(_rounded_rect_pts(rim_inner_w, rim_inner_h, GF_CORNER_R)), rim_height
+        )
+        additions.append((outer_solid - inner_solid).translate((ox, oy, wall_top_z)))
+
+    if config.stacking_lip:
+        lip_total = LIP_D0 + LIP_D1 + LIP_D2
+        notch_depth_below = LIP_D3 + LIP_D4
+        cs_wall_lip = _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R))
+        lip_solid = mf.Manifold.extrude(cs_wall_lip, lip_total).translate((ox, oy, lip_base_z))
+        notch = _build_stacking_lip_notch(outer_w, outer_h).translate(
+            (ox, oy, lip_base_z - notch_depth_below)
+        )
+        additions.append(lip_solid - notch)
+
+    if not additions:
+        return body
+
+    lip_geom = (
+        mf.Manifold.batch_boolean(additions, mf.OpType.Add)
+        if len(additions) > 1
+        else additions[0]
+    )
+    return body + lip_geom
 
 
 # ── cutter builders ───────────────────────────────────────────────────────────
@@ -334,8 +599,10 @@ def _make_magnet_holes(config: GenerateRequest):
     # outer bin corners for corners_only mode
     outer_corners = set()
     if corners_only:
-        for cx, _ in [x_full[0], x_full[-1]]:
-            for cy, _ in [y_full[0], y_full[-1]]:
+        for ix, (cx, _) in enumerate([x_full[0], x_full[-1]]):
+            for iy, (cy, _) in enumerate([y_full[0], y_full[-1]]):
+                if not _cell_enabled(config, ix if ix == 0 else math.ceil(config.grid_x) - 1, iy if iy == 0 else math.ceil(config.grid_y) - 1):
+                    continue
                 for dx, dy in [(-13.0, -13.0), (13.0, -13.0), (13.0, 13.0), (-13.0, 13.0)]:
                     # only the corner nearest the bin edge
                     if cx == x_full[0][0] and dx > 0 and len(x_full) > 1:
@@ -349,8 +616,17 @@ def _make_magnet_holes(config: GenerateRequest):
                     outer_corners.add((round(cx + dx, 4), round(cy + dy, 4)))
 
     holes = []
-    for cy, _ in y_full:
-        for cx, _ in x_full:
+    grid_ix = math.ceil(config.grid_x)
+    grid_iy = math.ceil(config.grid_y)
+    for iy in range(grid_iy):
+        for ix in range(grid_ix):
+            if not _cell_enabled(config, ix, iy):
+                continue
+            cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
+            if not any(abs(cx - fx) < 0.01 for fx, _ in x_full):
+                continue
+            if not any(abs(cy - fy) < 0.01 for fy, _ in y_full):
+                continue
             for dx, dy in [(-13.0, -13.0), (13.0, -13.0), (13.0, 13.0), (-13.0, 13.0)]:
                 pos = (round(cx + dx, 4), round(cy + dy, 4))
                 if corners_only and pos not in outer_corners:
@@ -1002,57 +1278,36 @@ class ManifoldSTLGenerator:
         offset_x = -bin_width / 2
         offset_y = -bin_depth / 2
         wall_top_z = config.height_units * GF_HEIGHT_UNIT
+        outer_w = config.grid_x * GF_GRID - 0.5
+        outer_h = config.grid_y * GF_GRID - 0.5
+        connect_bases = _partial_bins_connect_bases(config)
+        partial_shell = _uses_partial_shell(config)
 
-        # build solid shell (wall body to wall_top_z, no lip yet)
         t1 = time.monotonic()
         bin_body = _build_shell(config)
         logger.info("shell: %.2fs", time.monotonic() - t1)
 
-        outer_w = config.grid_x * GF_GRID - 0.5
-        outer_h = config.grid_y * GF_GRID - 0.5
-
-        # raised rim ("collar"): a hollow perimeter wall extending the bin wall
-        # above the floor face (wall_top_z) without filling the interior.  A
-        # protruding tool sits in the open volume inside the collar, and the
-        # stacking lip (if enabled) rides on top so a stacked bin clears the
-        # tool.  Cutouts still pocket down from wall_top_z, unaffected by the rim.
+        t1 = time.monotonic()
+        bin_body = _add_lip_features(bin_body, config, outer_w, outer_h, wall_top_z)
         rim_units = (getattr(config, "rim_units", 0) or 0) if config.stacking_lip else 0
-        rim_height = rim_units * GF_HEIGHT_UNIT
-        lip_base_z = wall_top_z + rim_height
-        # inner opening matches the stacking-lip inner opening so the collar wall
-        # is flush with the lip's inner face (no inward overhang/ledge).
-        rim_inner_w = outer_w - 2 * (LIP_D0 + LIP_D2)
-        rim_inner_h = outer_h - 2 * (LIP_D0 + LIP_D2)
+        if config.stacking_lip or rim_units > 0:
+            logger.info("lip features: %.2fs", time.monotonic() - t1)
 
-        if rim_height > 0:
-            outer_solid = mf.Manifold.extrude(
-                _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R)), rim_height
-            )
-            inner_solid = mf.Manifold.extrude(
-                _cs(_rounded_rect_pts(rim_inner_w, rim_inner_h, GF_CORNER_R)), rim_height
-            )
-            collar = (outer_solid - inner_solid).translate((0.0, 0.0, wall_top_z))
-            bin_body = bin_body + collar
-            logger.info("raised rim (%du): %.2fs", rim_units, time.monotonic() - t1)
-
-        # stacking lip: build groove into a separate lip solid (z=lip_base_z to
-        # z=lip_base_z+lip_total) and add it to the bin body.  The notch extends
-        # below lip_base_z but only cuts the lip solid (not the wall/collar), so
-        # the groove is invisible below lip_base_z — matching gf.Bin behaviour
-        # and preserving the large top-floor face at z=wall_top_z.
-        if config.stacking_lip:
-            lip_total = LIP_D0 + LIP_D1 + LIP_D2
-            notch_depth_below = LIP_D3 + LIP_D4
-            cs_wall_lip = _cs(_rounded_rect_pts(outer_w, outer_h, GF_CORNER_R))
-            lip_solid = mf.Manifold.extrude(cs_wall_lip, lip_total).translate(
-                (0.0, 0.0, lip_base_z)
-            )
-            notch = _build_stacking_lip_notch(outer_w, outer_h).translate(
-                (0.0, 0.0, lip_base_z - notch_depth_below)
-            )
-            lip_with_groove = lip_solid - notch
-            bin_body = bin_body + lip_with_groove
-            logger.info("stacking lip: %.2fs", time.monotonic() - t1)
+        if partial_shell:
+            t1 = time.monotonic()
+            top_z = _bin_top_z(config, wall_top_z)
+            if connect_bases:
+                disabled_cutters = _make_connect_mode_cell_cutters(config, top_z)
+                if disabled_cutters:
+                    bin_body = bin_body - disabled_cutters
+                plates = _make_connect_mode_stability_plates(config)
+                if plates:
+                    bin_body = bin_body + plates
+            else:
+                disabled_cutters = _make_disabled_cell_cutters(config, top_z)
+                if disabled_cutters:
+                    bin_body = bin_body - disabled_cutters
+            logger.info("partial bins: %.2fs", time.monotonic() - t1)
 
         # collect remaining cutters (pocket, magnets, finger holes, text) and
         # subtract them in one pass to avoid sequential z-plane imprecision
@@ -1237,15 +1492,16 @@ class ManifoldSTLGenerator:
         """Split completed bin into bed-sized pieces. Returns list of output paths."""
         import math
 
-        bin_width = config.grid_x * GF_GRID
-        bin_depth = config.grid_y * GF_GRID
+        span_x, span_y = _effective_grid_span(config)
+        bin_width = span_x * GF_GRID
+        bin_depth = span_y * GF_GRID
 
         fits_diagonal = (bin_width + bin_depth) / math.sqrt(2) <= bed_size
         if fits_diagonal:
             return []
 
-        x_cuts = self._compute_split_points(bin_width, config.grid_x, bed_size)
-        y_cuts = self._compute_split_points(bin_depth, config.grid_y, bed_size)
+        x_cuts = self._compute_split_points(config.grid_x * GF_GRID, config.grid_x, bed_size)
+        y_cuts = self._compute_split_points(config.grid_y * GF_GRID, config.grid_y, bed_size)
 
         if not x_cuts and not y_cuts:
             return []
@@ -1264,6 +1520,44 @@ class ManifoldSTLGenerator:
             paths.append(path)
 
         return paths
+
+    def export_separated_parts(
+        self,
+        bin_body,
+        text_body,
+        output_dir: str,
+        session_id: str,
+    ) -> list[str]:
+        """Export each disconnected manifold volume as its own STL file."""
+        part = bin_body + text_body if text_body and not text_body.is_empty() else bin_body
+        pieces = [p for p in part.decompose() if not p.is_empty()]
+        if len(pieces) < 2:
+            return []
+
+        paths = []
+        for i, piece in enumerate(pieces):
+            path = f"{output_dir}/{session_id}_part{i + 1}.stl"
+            _export_stl(piece, path)
+            paths.append(path)
+        return paths
+
+    def export_split_parts(
+        self,
+        bin_body,
+        text_body,
+        config: GenerateRequest,
+        bed_size: float,
+        output_dir: str,
+        session_id: str,
+    ) -> list[str]:
+        """Export per-piece STLs for disconnected partial bins or bed-sized splits."""
+        if _exports_separated_partial_parts(config):
+            paths = self.export_separated_parts(bin_body, text_body, output_dir, session_id)
+            if paths:
+                return paths
+        if bed_size > 0:
+            return self.split_bin(bin_body, text_body, config, bed_size, output_dir, session_id)
+        return []
 
     @staticmethod
     def _split_along_axis(part, cut_points: list[float], axis: str) -> list:

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -218,6 +218,10 @@ def _partial_bins_connect_bases(config: GenerateRequest) -> bool:
     return getattr(config, "partial_bins_connect", False) and _uses_partial_shell(config)
 
 
+def _partial_bins_retain_wall(config: GenerateRequest) -> bool:
+    return getattr(config, "partial_bins_retain_wall", False) and _partial_bins_connect_bases(config)
+
+
 def _cell_retains_base(config: GenerateRequest, ix: int, iy: int) -> bool:
     """Whether a grid cell still has base geometry (enabled, or connect-base disabled)."""
     return _cell_enabled(config, ix, iy) or _partial_bins_connect_bases(config)
@@ -299,6 +303,7 @@ def _bin_top_z(config: GenerateRequest, wall_top_z: float) -> float:
 
 PARTIAL_BIN_CONNECT_PLATE_Z_INSET = 0.2
 PARTIAL_BIN_CONNECT_PLATE_MM = 6.0 - PARTIAL_BIN_CONNECT_PLATE_Z_INSET
+PARTIAL_BIN_RETAIN_WALL_PRESERVE_MM = LIP_D0 + LIP_D2
 
 
 def _find_disabled_components(config: GenerateRequest) -> list[list[tuple[int, int]]]:
@@ -340,21 +345,46 @@ def _component_world_bbox(config: GenerateRequest, cells: list[tuple[int, int]])
 
 
 def _make_connect_mode_cell_cutters(config: GenerateRequest, top_z: float):
-    """Remove all walls/lip above the base in disabled cells."""
+    """Remove walls/lip above the base in disabled cells."""
     import manifold3d as mf
 
     cutters = []
     cut_height = top_z - GF_BASE_HEIGHT + 0.2
+    retain_wall = _partial_bins_retain_wall(config)
+    bin_hw = (config.grid_x * GF_GRID - 0.5) / 2.0
+    bin_hh = (config.grid_y * GF_GRID - 0.5) / 2.0
+    half = GF_GRID / 2.0
+    preserve = PARTIAL_BIN_RETAIN_WALL_PRESERVE_MM
 
     for iy in range(config.grid_y):
         for ix in range(config.grid_x):
             if _cell_enabled(config, ix, iy):
                 continue
             cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
-            cs = _cs(_sharp_rect_pts(GF_GRID, GF_GRID))
-            cutters.append(
-                mf.Manifold.extrude(cs, cut_height).translate((cx, cy, GF_BASE_HEIGHT - 0.1))
-            )
+            if retain_wall:
+                x0, x1 = cx - half, cx + half
+                y0, y1 = cy - half, cy + half
+                if ix == 0:
+                    x0 = max(x0, -bin_hw + preserve)
+                if ix == config.grid_x - 1:
+                    x1 = min(x1, bin_hw - preserve)
+                if iy == 0:
+                    y0 = max(y0, -bin_hh + preserve)
+                if iy == config.grid_y - 1:
+                    y1 = min(y1, bin_hh - preserve)
+                w, h = x1 - x0, y1 - y0
+                if w <= 0.1 or h <= 0.1:
+                    continue
+                ccx, ccy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+                cs = _cs(_sharp_rect_pts(w, h))
+                cutters.append(
+                    mf.Manifold.extrude(cs, cut_height).translate((ccx, ccy, GF_BASE_HEIGHT - 0.1))
+                )
+            else:
+                cs = _cs(_sharp_rect_pts(GF_GRID, GF_GRID))
+                cutters.append(
+                    mf.Manifold.extrude(cs, cut_height).translate((cx, cy, GF_BASE_HEIGHT - 0.1))
+                )
 
     if not cutters:
         return None

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -218,6 +218,11 @@ def _partial_bins_connect_bases(config: GenerateRequest) -> bool:
     return getattr(config, "partial_bins_connect", False) and _uses_partial_shell(config)
 
 
+def _cell_retains_base(config: GenerateRequest, ix: int, iy: int) -> bool:
+    """Whether a grid cell still has base geometry (enabled, or connect-base disabled)."""
+    return _cell_enabled(config, ix, iy) or _partial_bins_connect_bases(config)
+
+
 def _exports_separated_partial_parts(config: GenerateRequest) -> bool:
     return _uses_partial_shell(config) and not _partial_bins_connect_bases(config)
 
@@ -599,9 +604,11 @@ def _make_magnet_holes(config: GenerateRequest):
     # outer bin corners for corners_only mode
     outer_corners = set()
     if corners_only:
+        grid_ix_max = math.ceil(config.grid_x) - 1
+        grid_iy_max = math.ceil(config.grid_y) - 1
         for ix, (cx, _) in enumerate([x_full[0], x_full[-1]]):
             for iy, (cy, _) in enumerate([y_full[0], y_full[-1]]):
-                if not _cell_enabled(config, ix if ix == 0 else math.ceil(config.grid_x) - 1, iy if iy == 0 else math.ceil(config.grid_y) - 1):
+                if not _cell_retains_base(config, ix if ix == 0 else grid_ix_max, iy if iy == 0 else grid_iy_max):
                     continue
                 for dx, dy in [(-13.0, -13.0), (13.0, -13.0), (13.0, 13.0), (-13.0, 13.0)]:
                     # only the corner nearest the bin edge
@@ -620,7 +627,7 @@ def _make_magnet_holes(config: GenerateRequest):
     grid_iy = math.ceil(config.grid_y)
     for iy in range(grid_iy):
         for ix in range(grid_ix):
-            if not _cell_enabled(config, ix, iy):
+            if not _cell_retains_base(config, ix, iy):
                 continue
             cx, cy = _cell_center(ix, iy, config.grid_x, config.grid_y)
             if not any(abs(cx - fx) < 0.01 for fx, _ in x_full):

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -1386,7 +1386,8 @@ class ManifoldSTLGenerator:
                     cutters.append(fh_chamfers)
                 logger.info("chamfer cutouts: %.2fs", time.monotonic() - t1)
 
-        # text labels (recessed cutters + embossed body additions)
+        # text labels (recessed cutters + embossed body additions).
+        # Labels in disabled partial-bin cells are not clipped and may float in the STL.
         text_body = None
         if config.text_labels:
             t1 = time.monotonic()
@@ -1529,7 +1530,11 @@ class ManifoldSTLGenerator:
         """Split completed bin into bed-sized pieces. Returns list of output paths."""
         import math
 
-        span_x, span_y = _effective_grid_span(config)
+        span_x, span_y = (
+            (config.grid_x, config.grid_y)
+            if _partial_bins_connect_bases(config)
+            else _effective_grid_span(config)
+        )
         bin_width = span_x * GF_GRID
         bin_depth = span_y * GF_GRID
 

--- a/backend/tests/test_partial_bins.py
+++ b/backend/tests/test_partial_bins.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from app.models.schemas import GenerateRequest
 from app.services.stl_generator_manifold import (
     ManifoldSTLGenerator,
+    _cell_center,
     _cell_enabled,
     _effective_grid_span,
     _partial_cell_index,
@@ -203,3 +204,27 @@ def test_partial_bins_connect_skips_separated_export(tmp_path: Path):
     paths = generator.export_split_parts(body, None, config, 0, str(tmp_path), "partial")
 
     assert paths == []
+
+
+def test_connect_base_magnet_holes_in_disabled_cells(tmp_path: Path):
+    import manifold3d as mf
+
+    generator = ManifoldSTLGenerator()
+    values = [True, True, False, False, True, True, True, True]
+    config = _base_config(
+        grid_y=4,
+        stacking_lip=True,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=True,
+        magnets=True,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "connect.stl"))
+
+    # iy=1 is a disabled row; magnet inset is 13 mm from cell centre
+    cx, cy = _cell_center(0, 1, 2, 4)
+    mx, my = cx - 13.0, cy - 13.0
+    probe = mf.Manifold.sphere(0.4, 12).translate((mx, my, 1.0))
+    overlap = (body ^ probe).volume()
+    assert overlap < probe.volume() * 0.25

--- a/backend/tests/test_partial_bins.py
+++ b/backend/tests/test_partial_bins.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+
+from app.models.schemas import GenerateRequest
+from app.services.stl_generator_manifold import (
+    ManifoldSTLGenerator,
+    _cell_enabled,
+    _effective_grid_span,
+    _partial_cell_index,
+    _uses_partial_shell,
+)
+
+
+def _base_config(**overrides) -> GenerateRequest:
+    defaults = dict(
+        grid_x=2,
+        grid_y=2,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        bed_size=0,
+    )
+    defaults.update(overrides)
+    return GenerateRequest(**defaults)
+
+
+def test_partial_cell_index_maps_ui_top_row_to_high_iy():
+    config = _base_config(grid_y=8)
+
+    assert _partial_cell_index(config, 0, 7) == 0
+    assert _partial_cell_index(config, 1, 7) == 1
+    assert _partial_cell_index(config, 0, 0) == 14
+    assert _partial_cell_index(config, 1, 0) == 15
+
+
+def test_cell_enabled_respects_ui_row_order():
+    config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, False, True],
+    )
+
+    assert _cell_enabled(config, 0, 1) is True
+    assert _cell_enabled(config, 1, 1) is False
+    assert _cell_enabled(config, 0, 0) is False
+    assert _cell_enabled(config, 1, 0) is True
+
+
+def test_disabling_second_top_left_targets_top_not_bottom():
+    values = [True] * 16
+    values[2] = False
+    config = _base_config(
+        grid_y=8,
+        partial_bins=True,
+        partial_bins_values=values,
+    )
+
+    assert _cell_enabled(config, 0, 6) is False
+    assert _cell_enabled(config, 0, 0) is True
+
+
+def test_partial_shell_uses_effective_span():
+    config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, False, False],
+    )
+
+    assert _uses_partial_shell(config) is True
+    assert _effective_grid_span(config) == (1, 1)
+
+
+def test_partial_bin_is_smaller_than_full_bin(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    full_config = _base_config()
+    partial_config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, False, False],
+    )
+
+    full_body, _ = generator.generate_bin([], full_config, str(tmp_path / "full.stl"))
+    partial_body, _ = generator.generate_bin([], partial_config, str(tmp_path / "partial.stl"))
+
+    assert partial_body.volume() < full_body.volume()
+
+
+def test_partial_bin_with_all_cells_matches_full_bin(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    full_config = _base_config()
+    partial_config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, True, True, True],
+    )
+
+    full_body, _ = generator.generate_bin([], full_config, str(tmp_path / "full.stl"))
+    partial_body, _ = generator.generate_bin([], partial_config, str(tmp_path / "partial.stl"))
+
+    assert abs(partial_body.volume() - full_body.volume()) < 1.0
+
+
+def test_partial_bin_adjacent_cells_stay_one_piece(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, True, True],
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "l.stl"))
+
+    assert len(body.decompose()) == 1
+
+
+def test_partial_bin_many_cells_stay_connected(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    # 2x6 grid, disable one cell in the left column (UI row 1)
+    values = [True] * 12
+    values[2] = False
+    config = _base_config(
+        grid_y=6,
+        stacking_lip=True,
+        partial_bins=True,
+        partial_bins_values=values,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "grid.stl"))
+
+    assert len(body.decompose()) <= 2
+
+
+def test_partial_bins_connect_keeps_single_piece(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    values = [True, True, False, False, True, True, True, True]
+    cut_config = _base_config(
+        grid_y=4,
+        stacking_lip=True,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=False,
+    )
+    connect_config = cut_config.model_copy(update={"partial_bins_connect": True})
+
+    cut_body, _ = generator.generate_bin([], cut_config, str(tmp_path / "cut.stl"))
+    connect_body, _ = generator.generate_bin([], connect_config, str(tmp_path / "connect.stl"))
+
+    assert len(cut_body.decompose()) >= 2
+    assert generator.export_split_parts(connect_body, None, connect_config, 0, str(tmp_path), "connect") == []
+    assert connect_body.volume() > cut_body.volume()
+    assert connect_body.volume() < generator.generate_bin(
+        [],
+        _base_config(grid_y=4, stacking_lip=True),
+        str(tmp_path / "full.stl"),
+    )[0].volume()
+
+
+def test_partial_bin_split_uses_enabled_span(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, False, False],
+        bed_size=80,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "partial.stl"))
+    parts = generator.split_bin(
+        body,
+        None,
+        config,
+        config.bed_size,
+        str(tmp_path),
+        "partial",
+    )
+
+    assert parts == []
+
+
+def test_partial_bins_cut_exports_separated_stls(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    values = [True, True, False, False, True, True, True, True]
+    config = _base_config(
+        grid_y=4,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=False,
+        bed_size=0,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "full.stl"))
+    paths = generator.export_split_parts(body, None, config, 0, str(tmp_path), "partial")
+
+    assert len(paths) >= 2
+    assert all(Path(p).exists() for p in paths)
+
+
+def test_partial_bins_connect_skips_separated_export(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    values = [True, True, False, False, True, True, True, True]
+    config = _base_config(
+        grid_y=4,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=True,
+        bed_size=0,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "full.stl"))
+    paths = generator.export_split_parts(body, None, config, 0, str(tmp_path), "partial")
+
+    assert paths == []

--- a/backend/tests/test_partial_bins.py
+++ b/backend/tests/test_partial_bins.py
@@ -259,3 +259,31 @@ def test_partial_bins_retain_wall_disabled_without_connect():
         partial_bins_retain_wall=True,
     )
     assert config.partial_bins_retain_wall is False
+
+
+def test_partial_bins_rejects_all_cells_disabled():
+    import pytest
+
+    with pytest.raises(ValueError, match="at least one grid cell"):
+        _base_config(
+            partial_bins=True,
+            partial_bins_values=[False, False, False, False],
+        )
+
+
+def test_connect_mode_split_uses_full_grid_footprint(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    values = [True] + [False] * 8
+    config = _base_config(
+        grid_x=3,
+        grid_y=3,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=True,
+        bed_size=80,
+    )
+
+    body, _ = generator.generate_bin([], config, str(tmp_path / "connect.stl"))
+    parts = generator.split_bin(body, None, config, config.bed_size, str(tmp_path), "connect")
+
+    assert parts != []

--- a/backend/tests/test_partial_bins.py
+++ b/backend/tests/test_partial_bins.py
@@ -228,3 +228,34 @@ def test_connect_base_magnet_holes_in_disabled_cells(tmp_path: Path):
     probe = mf.Manifold.sphere(0.4, 12).translate((mx, my, 1.0))
     overlap = (body ^ probe).volume()
     assert overlap < probe.volume() * 0.25
+
+
+def test_partial_bins_retain_wall_adds_perimeter_material(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    values = [True, True, False, False, True, True, True, True]
+    base = _base_config(
+        grid_y=4,
+        stacking_lip=True,
+        partial_bins=True,
+        partial_bins_values=values,
+        partial_bins_connect=True,
+    )
+    connect_body, _ = generator.generate_bin([], base, str(tmp_path / "connect.stl"))
+    retain_body, _ = generator.generate_bin(
+        [],
+        base.model_copy(update={"partial_bins_retain_wall": True}),
+        str(tmp_path / "retain.stl"),
+    )
+
+    assert retain_body.volume() > connect_body.volume()
+    assert generator.export_split_parts(retain_body, None, base.model_copy(update={"partial_bins_retain_wall": True}), 0, str(tmp_path), "retain") == []
+
+
+def test_partial_bins_retain_wall_disabled_without_connect():
+    config = _base_config(
+        partial_bins=True,
+        partial_bins_values=[True, False, True, True],
+        partial_bins_connect=False,
+        partial_bins_retain_wall=True,
+    )
+    assert config.partial_bins_retain_wall is False

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -529,8 +529,6 @@ export default function BinPage() {
                                 defaultCutoutDepth={config.cutout_depth}
                                 maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
                                 halfGridBase={config.half_grid_base}
-                                partialBins={config.partial_bins}
-                                partialBinsValues={config.partial_bins_values}
                                 onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
                                 smoothedToolIds={smoothedToolIds}
                                 onToggleSmoothed={handleToggleSmoothed}

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -1,598 +1,584 @@
-"use client";
+'use client'
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter, useParams } from "next/navigation";
-import { BinEditor } from "@/components/BinEditor";
-import { BinConfigurator, calcMaxCutoutDepth } from "@/components/BinConfigurator";
-import { BinPreview3D } from "@/components/BinPreview3D";
-import { ToolBrowser } from "@/components/ToolBrowser";
-import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from "@/lib/api";
-import { buildBinConfig, createPartialBinsValues, getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from "@/lib/binDefaults";
-import type { BinConfig, BinData, PlacedTool, TextLabel } from "@/types";
-import { Download, Loader2, Package, ChevronDown, Check } from "lucide-react";
-import { Breadcrumb } from "@/components/Breadcrumb";
-import { Alert } from "@/components/Alert";
-import { useDebouncedSave } from "@/hooks/useDebouncedSave";
-import { useProjectSource } from "@/hooks/useProjectSource";
-import { GRID_UNIT } from "@/lib/constants";
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { BinEditor } from '@/components/BinEditor'
+import { BinConfigurator, calcMaxCutoutDepth } from '@/components/BinConfigurator'
+import { BinPreview3D } from '@/components/BinPreview3D'
+import { ToolBrowser } from '@/components/ToolBrowser'
+import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
+import { buildBinConfig, createPartialBinsValues, getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from '@/lib/binDefaults'
+import type { BinConfig, BinData, PlacedTool, TextLabel } from '@/types'
+import { Download, Loader2, Package, ChevronDown, Check } from 'lucide-react'
+import { Breadcrumb } from '@/components/Breadcrumb'
+import { Alert } from '@/components/Alert'
+import { useDebouncedSave } from '@/hooks/useDebouncedSave'
+import { useProjectSource } from '@/hooks/useProjectSource'
+import { GRID_UNIT } from '@/lib/constants'
 
 function InfoBanner({ children }: { children: React.ReactNode }) {
-    return <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">{children}</div>;
+  return (
+    <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
+      {children}
+    </div>
+  )
 }
 
 export default function BinPage() {
-    const router = useRouter();
-    const params = useParams();
-    const binId = params.id as string;
-    const projectSource = useProjectSource("Bins");
+  const router = useRouter()
+  const params = useParams()
+  const binId = params.id as string
+  const projectSource = useProjectSource('Bins')
 
-    const [binData, setBinData] = useState<BinData | null>(null);
-    const [placedTools, setPlacedTools] = useState<PlacedTool[]>([]);
-    const [textLabels, setTextLabels] = useState<TextLabel[]>([]);
-    const [config, setConfig] = useState<BinConfig>(() => getDefaultBinConfig());
-    const [name, setName] = useState("");
-    const [stlUrl, setStlUrl] = useState<string | null>(null);
-    const [stlUrls, setStlUrls] = useState<string[]>([]);
-    const [threemfUrl, setThreemfUrl] = useState<string | null>(null);
-    const [zipUrl, setZipUrl] = useState<string | null>(null);
-    const [insertStlUrl, setInsertStlUrl] = useState<string | null>(null);
-    const [splitCount, setSplitCount] = useState(1);
-    const [stlVersion, setStlVersion] = useState(0);
-    const [loading, setLoading] = useState(true);
-    const [generating, setGenerating] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [warning, setWarning] = useState<string | null>(null);
-    const generateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const lastGenerateRef = useRef<string>("");
-    const generatingRef = useRef(false);
-    const abortRef = useRef<AbortController | null>(null);
-    const doGenerateRef = useRef<() => void>(() => {});
-    const [smoothedToolIds, setSmoothedToolIds] = useState<Set<string>>(new Set());
-    const [smoothLevels, setSmoothLevels] = useState<Map<string, number>>(new Map());
-    const smoothLevelTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [binData, setBinData] = useState<BinData | null>(null)
+  const [placedTools, setPlacedTools] = useState<PlacedTool[]>([])
+  const [textLabels, setTextLabels] = useState<TextLabel[]>([])
+  const [config, setConfig] = useState<BinConfig>(() => getDefaultBinConfig())
+  const [name, setName] = useState('')
+  const [stlUrl, setStlUrl] = useState<string | null>(null)
+  const [stlUrls, setStlUrls] = useState<string[]>([])
+  const [threemfUrl, setThreemfUrl] = useState<string | null>(null)
+  const [zipUrl, setZipUrl] = useState<string | null>(null)
+  const [insertStlUrl, setInsertStlUrl] = useState<string | null>(null)
+  const [splitCount, setSplitCount] = useState(1)
+  const [stlVersion, setStlVersion] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [warning, setWarning] = useState<string | null>(null)
+  const generateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const lastGenerateRef = useRef<string>('')
+  const generatingRef = useRef(false)
+  const abortRef = useRef<AbortController | null>(null)
+  const doGenerateRef = useRef<() => void>(() => {})
+  const [smoothedToolIds, setSmoothedToolIds] = useState<Set<string>>(new Set())
+  const [smoothLevels, setSmoothLevels] = useState<Map<string, number>>(new Map())
+  const smoothLevelTimerRef = useRef<NodeJS.Timeout | null>(null)
 
-    const [autoSize, setAutoSize] = useState(true);
-    const [isDragging, setIsDragging] = useState(false);
-    const [exportOpen, setExportOpen] = useState(false);
-    const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null);
-    const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const exportRef = useRef<HTMLDivElement>(null);
+  const [autoSize, setAutoSize] = useState(true)
+  const [isDragging, setIsDragging] = useState(false)
+  const [exportOpen, setExportOpen] = useState(false)
+  const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null)
+  const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const exportRef = useRef<HTMLDivElement>(null)
 
-    useEffect(() => {
-        if (!exportOpen) return;
-        function handleClick(e: MouseEvent) {
-            if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
-                setExportOpen(false);
-            }
-        }
-        document.addEventListener("mousedown", handleClick);
-        return () => document.removeEventListener("mousedown", handleClick);
-    }, [exportOpen]);
+  useEffect(() => {
+    if (!exportOpen) return
+    function handleClick(e: MouseEvent) {
+      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+        setExportOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [exportOpen])
 
-    useEffect(() => {
-        async function load() {
-            try {
-                const [data, tools] = await Promise.all([getBin(binId), listTools()]);
-                setBinData(data);
+  useEffect(() => {
+    async function load() {
+      try {
+        const [data, tools] = await Promise.all([getBin(binId), listTools()])
+        setBinData(data)
 
-                const toolMap = new Map(tools.map((t) => [t.id, t]));
-                const synced = data.placed_tools.map((pt) => {
-                    const lib = toolMap.get(pt.tool_id);
-                    if (!lib) return pt;
-                    const rad = ((pt.rotation || 0) * Math.PI) / 180;
-                    const cos = Math.cos(rad);
-                    const sin = Math.sin(rad);
-                    const n = pt.points.length || 1;
-                    const cx = pt.points.reduce((s, p) => s + p.x, 0) / n;
-                    const cy = pt.points.reduce((s, p) => s + p.y, 0) / n;
-                    const newRings = (lib.interior_rings ?? []).map((ring) =>
-                        ring.map((p) => ({
-                            x: p.x * cos - p.y * sin + cx,
-                            y: p.x * sin + p.y * cos + cy,
-                        })),
-                    );
-                    return { ...pt, interior_rings: newRings };
-                });
-                setPlacedTools(synced);
-                setTextLabels(data.text_labels);
-                setName(data.name || "");
-                setConfig(buildBinConfig(data.bin_config));
-                setSmoothedToolIds(new Set(tools.filter((t) => t.smoothed).map((t) => t.id)));
-                setSmoothLevels(new Map(tools.map((t) => [t.id, t.smooth_level])));
-            } catch {
-                setError("Bin not found");
-            } finally {
-                setLoading(false);
-                setTimeout(() => doGenerateRef.current(), 100);
-            }
-        }
-        load();
-    }, [binId]);
+        const toolMap = new Map(tools.map(t => [t.id, t]))
+        const synced = data.placed_tools.map(pt => {
+          const lib = toolMap.get(pt.tool_id)
+          if (!lib) return pt
+          const rad = (pt.rotation || 0) * Math.PI / 180
+          const cos = Math.cos(rad)
+          const sin = Math.sin(rad)
+          const n = pt.points.length || 1
+          const cx = pt.points.reduce((s, p) => s + p.x, 0) / n
+          const cy = pt.points.reduce((s, p) => s + p.y, 0) / n
+          const newRings = (lib.interior_rings ?? []).map(ring =>
+            ring.map(p => ({
+              x: p.x * cos - p.y * sin + cx,
+              y: p.x * sin + p.y * cos + cy,
+            }))
+          )
+          return { ...pt, interior_rings: newRings }
+        })
+        setPlacedTools(synced)
+        setTextLabels(data.text_labels)
+        setName(data.name || '')
+        setConfig(buildBinConfig(data.bin_config));
+        setSmoothedToolIds(new Set(tools.filter(t => t.smoothed).map(t => t.id)))
+        setSmoothLevels(new Map(tools.map(t => [t.id, t.smooth_level])))
+      } catch {
+        setError('Bin not found')
+      } finally {
+        setLoading(false)
+        setTimeout(() => doGenerateRef.current(), 100)
+      }
+    }
+    load()
+  }, [binId])
 
-    const doGenerate = useCallback(async () => {
-        if (placedTools.length === 0) return;
+  const doGenerate = useCallback(async () => {
+    if (placedTools.length === 0) return
 
-        const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] });
-        if (key === lastGenerateRef.current) return;
+    const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] })
+    if (key === lastGenerateRef.current) return
 
-        if (abortRef.current) {
-            abortRef.current.abort();
-        }
+    if (abortRef.current) {
+      abortRef.current.abort()
+    }
 
-        lastGenerateRef.current = key;
-        generatingRef.current = true;
-        setGenerating(true);
-        setError(null);
-        setWarning(null);
-        setStlUrl(null);
-        setStlUrls([]);
-        setThreemfUrl(null);
-        setZipUrl(null);
-        setInsertStlUrl(null);
+    lastGenerateRef.current = key
+    generatingRef.current = true
+    setGenerating(true)
+    setError(null)
+    setWarning(null)
+    setStlUrl(null)
+    setStlUrls([])
+    setThreemfUrl(null)
+    setZipUrl(null)
+    setInsertStlUrl(null)
 
-        const controller = new AbortController();
-        abortRef.current = controller;
+    const controller = new AbortController()
+    abortRef.current = controller
 
-        try {
-            const result = await generateBinStl(binId, controller.signal);
-            setStlUrl(getImageUrl(result.stl_url));
-            setStlUrls((result.stl_urls || []).map((u) => getImageUrl(u)));
-            setThreemfUrl(result.threemf_url ? getImageUrl(result.threemf_url) : null);
-            setZipUrl(result.zip_url ? getImageUrl(result.zip_url) : null);
-            setInsertStlUrl(result.insert_stl_url ? getImageUrl(result.insert_stl_url) : null);
-            setSplitCount(result.split_count || 1);
-            setStlVersion((v) => v + 1);
-            setWarning(result.warning || null);
-        } catch (err) {
-            if (err instanceof DOMException && err.name === "AbortError") return;
-            setError(err instanceof Error ? err.message : "generation failed");
-        } finally {
-            if (abortRef.current === controller) {
-                generatingRef.current = false;
-                setGenerating(false);
-                abortRef.current = null;
-            }
-        }
-    }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels]);
+    try {
+      const result = await generateBinStl(binId, controller.signal)
+      setStlUrl(getImageUrl(result.stl_url))
+      setStlUrls((result.stl_urls || []).map(u => getImageUrl(u)))
+      setThreemfUrl(result.threemf_url ? getImageUrl(result.threemf_url) : null)
+      setZipUrl(result.zip_url ? getImageUrl(result.zip_url) : null)
+      setInsertStlUrl(result.insert_stl_url ? getImageUrl(result.insert_stl_url) : null)
+      setSplitCount(result.split_count || 1)
+      setStlVersion(v => v + 1)
+      setWarning(result.warning || null)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setError(err instanceof Error ? err.message : 'generation failed')
+    } finally {
+      if (abortRef.current === controller) {
+        generatingRef.current = false
+        setGenerating(false)
+        abortRef.current = null
+      }
+    }
+  }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels])
 
-    useEffect(() => {
-        doGenerateRef.current = doGenerate;
-    }, [doGenerate]);
+  useEffect(() => {
+    doGenerateRef.current = doGenerate
+  }, [doGenerate])
 
-    const { saving, saved } = useDebouncedSave(
-        () => {
-            if (!binData) return;
-            updateBin(binId, {
-                name: name || undefined,
-                bin_config: config,
-                placed_tools: placedTools,
-                text_labels: textLabels,
-            }).catch(() => {});
-        },
-        [binData, binId, name, config, placedTools, textLabels],
-        150,
-        { skipInitial: true },
-    );
+  const { saving, saved } = useDebouncedSave(
+    () => {
+      if (!binData) return
+      updateBin(binId, {
+        name: name || undefined,
+        bin_config: config,
+        placed_tools: placedTools,
+        text_labels: textLabels,
+      }).catch(() => {})
+    },
+    [binData, binId, name, config, placedTools, textLabels],
+    150,
+    { skipInitial: true }
+  )
 
-    useEffect(() => {
-        return () => {
-            abortRef.current?.abort();
-            if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current);
-        };
-    }, []);
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
+    }
+  }, [])
 
-    useEffect(() => {
-        if (!binData) return;
-        if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current);
-        generateTimeoutRef.current = setTimeout(() => {
-            doGenerate();
-        }, 1000);
-        return () => {
-            if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current);
-        };
-    }, [binData, placedTools, config, textLabels, smoothedToolIds, smoothLevels, doGenerate]);
+  useEffect(() => {
+    if (!binData) return
+    if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current)
+    generateTimeoutRef.current = setTimeout(() => {
+      doGenerate()
+    }, 1000)
+    return () => {
+      if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current)
+    }
+  }, [binData, placedTools, config, textLabels, smoothedToolIds, smoothLevels, doGenerate])
 
-    const handlePlacedToolsChange = useCallback((updated: PlacedTool[]) => {
-        setPlacedTools(updated);
-    }, []);
+  const handlePlacedToolsChange = useCallback((updated: PlacedTool[]) => {
+    setPlacedTools(updated)
+  }, [])
 
-    // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
-    useEffect(() => {
-        if (!autoSize || isDragging || placedTools.length === 0) return;
-        let minX = Infinity,
-            minY = Infinity,
-            maxX = -Infinity,
-            maxY = -Infinity;
-        for (const tool of placedTools) {
-            for (const p of tool.points) {
-                minX = Math.min(minX, p.x);
-                minY = Math.min(minY, p.y);
-                maxX = Math.max(maxX, p.x);
-                maxY = Math.max(maxY, p.y);
-            }
-        }
-        const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25;
-        const toolW = maxX - minX;
-        const toolH = maxY - minY;
-        const snap = config.half_grid_base ? 0.5 : 1.0;
-        const snapUnit = GRID_UNIT * snap;
-        const needX = Math.max(1, Math.ceil((toolW + 2 * halfMargin) / snapUnit) * snap);
-        const needY = Math.max(1, Math.ceil((toolH + 2 * halfMargin) / snapUnit) * snap);
+  // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
+  useEffect(() => {
+    if (!autoSize || isDragging || placedTools.length === 0) return
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const tool of placedTools) {
+      for (const p of tool.points) {
+        minX = Math.min(minX, p.x)
+        minY = Math.min(minY, p.y)
+        maxX = Math.max(maxX, p.x)
+        maxY = Math.max(maxY, p.y)
+      }
+    }
+    const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25
+    const toolW = maxX - minX
+    const toolH = maxY - minY
+    const snap = config.half_grid_base ? 0.5 : 1.0;
+    const snapUnit = GRID_UNIT * snap;
+    const needX = Math.max(1, Math.ceil((toolW + 2 * halfMargin) / snapUnit) * snap);
+    const needY = Math.max(1, Math.ceil((toolH + 2 * halfMargin) / snapUnit) * snap);
 
-        const gridChanged = config.grid_x !== needX || config.grid_y !== needY;
-        if (gridChanged) {
-            setConfig((prev) => ({
-                ...prev,
-                grid_x: needX,
-                grid_y: needY,
-                partial_bins_values: createPartialBinsValues(needX, needY),
-            }));
-        }
+    const gridChanged = config.grid_x !== needX || config.grid_y !== needY
+    if (gridChanged) {
+        setConfig((prev) => ({
+            ...prev,
+            grid_x: needX,
+            grid_y: needY,
+            partial_bins_values: createPartialBinsValues(needX, needY),
+        }));
+    }
 
-        // recentre tools if grid changed or tools are off-centre
-        const binW = (gridChanged ? needX : config.grid_x) * GRID_UNIT;
-        const binH = (gridChanged ? needY : config.grid_y) * GRID_UNIT;
-        const toolCx = (minX + maxX) / 2;
-        const toolCy = (minY + maxY) / 2;
-        const dx = binW / 2 - toolCx;
-        const dy = binH / 2 - toolCy;
-        if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
-            setPlacedTools((prev) =>
-                prev.map((tool) => ({
-                    ...tool,
-                    points: tool.points.map((p) => ({ x: p.x + dx, y: p.y + dy })),
-                    finger_holes: tool.finger_holes.map((fh) => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
-                    interior_rings: (tool.interior_rings ?? []).map((ring) => ring.map((p) => ({ x: p.x + dx, y: p.y + dy }))),
-                })),
-            );
-        }
+    // recentre tools if grid changed or tools are off-centre
+    const binW = (gridChanged ? needX : config.grid_x) * GRID_UNIT
+    const binH = (gridChanged ? needY : config.grid_y) * GRID_UNIT
+    const toolCx = (minX + maxX) / 2
+    const toolCy = (minY + maxY) / 2
+    const dx = binW / 2 - toolCx
+    const dy = binH / 2 - toolCy
+    if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
+      setPlacedTools(prev => prev.map(tool => ({
+        ...tool,
+        points: tool.points.map(p => ({ x: p.x + dx, y: p.y + dy })),
+        finger_holes: tool.finger_holes.map(fh => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
+        interior_rings: (tool.interior_rings ?? []).map(ring =>
+          ring.map(p => ({ x: p.x + dx, y: p.y + dy }))
+        ),
+      })))
+    }
     }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base]);
 
-    const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
-        try {
-            await updateTool(toolId, { smoothed });
-            setSmoothedToolIds((prev) => {
-                const next = new Set(prev);
-                if (smoothed) next.add(toolId);
-                else next.delete(toolId);
-                return next;
-            });
-        } catch {
-            /* ignore */
-        }
-    }, []);
+  const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
+    try {
+      await updateTool(toolId, { smoothed })
+      setSmoothedToolIds(prev => {
+        const next = new Set(prev)
+        if (smoothed) next.add(toolId)
+        else next.delete(toolId)
+        return next
+      })
+    } catch { /* ignore */ }
+  }, [])
 
-    const handleSmoothLevelChange = useCallback((toolId: string, level: number) => {
-        setSmoothLevels((prev) => new Map(prev).set(toolId, level));
-        if (smoothLevelTimerRef.current) clearTimeout(smoothLevelTimerRef.current);
-        smoothLevelTimerRef.current = setTimeout(() => {
-            updateTool(toolId, { smooth_level: level }).catch(() => {});
-        }, 300);
-    }, []);
+  const handleSmoothLevelChange = useCallback((toolId: string, level: number) => {
+    setSmoothLevels(prev => new Map(prev).set(toolId, level))
+    if (smoothLevelTimerRef.current) clearTimeout(smoothLevelTimerRef.current)
+    smoothLevelTimerRef.current = setTimeout(() => {
+      updateTool(toolId, { smooth_level: level }).catch(() => {})
+    }, 300)
+  }, [])
 
-    const handleAddTool = useCallback(
-        (tool: PlacedTool) => {
-            let minX = Infinity,
-                minY = Infinity,
-                maxX = -Infinity,
-                maxY = -Infinity;
-            for (const p of tool.points) {
-                minX = Math.min(minX, p.x);
-                minY = Math.min(minY, p.y);
-                maxX = Math.max(maxX, p.x);
-                maxY = Math.max(maxY, p.y);
-            }
-            const toolW = maxX - minX;
-            const toolH = maxY - minY;
+  const handleAddTool = useCallback((tool: PlacedTool) => {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const p of tool.points) {
+      minX = Math.min(minX, p.x)
+      minY = Math.min(minY, p.y)
+      maxX = Math.max(maxX, p.x)
+      maxY = Math.max(maxY, p.y)
+    }
+    const toolW = maxX - minX
+    const toolH = maxY - minY
 
-            const margin = 2 * config.wall_thickness + 2 * config.cutout_clearance + 0.5;
-            const snap = config.half_grid_base ? 0.5 : 1.0;
-            const snapUnit = GRID_UNIT * snap;
-            const needX = Math.max(config.grid_x, Math.ceil((toolW + margin) / snapUnit) * snap);
-            const needY = Math.max(config.grid_y, Math.ceil((toolH + margin) / snapUnit) * snap);
+    const margin = 2 * config.wall_thickness + 2 * config.cutout_clearance + 0.5;
+    const snap = config.half_grid_base ? 0.5 : 1.0;
+    const snapUnit = GRID_UNIT * snap;
+    const needX = Math.max(config.grid_x, Math.ceil((toolW + margin) / snapUnit) * snap);
+    const needY = Math.max(config.grid_y, Math.ceil((toolH + margin) / snapUnit) * snap);
 
-            if (needX !== config.grid_x || needY !== config.grid_y) {
-                setConfig((prev) => ({
-                    ...prev,
-                    grid_x: needX,
-                    grid_y: needY,
-                    partial_bins_values: createPartialBinsValues(needX, needY),
-                }));
-            }
-
-            // always centre the tool in the bin
-            const binW = needX * GRID_UNIT;
-            const binH = needY * GRID_UNIT;
-            const toolCx = (minX + maxX) / 2;
-            const toolCy = (minY + maxY) / 2;
-            const dx = binW / 2 - toolCx;
-            const dy = binH / 2 - toolCy;
-            const placed = {
-                ...tool,
-                points: tool.points.map((p) => ({ x: p.x + dx, y: p.y + dy })),
-                finger_holes: tool.finger_holes.map((fh) => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
-                interior_rings: (tool.interior_rings ?? []).map((ring) => ring.map((p) => ({ x: p.x + dx, y: p.y + dy }))),
-            };
-
-            setPlacedTools((prev) => [...prev, placed]);
-        },
-        [config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base],
-    );
-
-    function handleDownload() {
-        window.open(getBinStlUrl(binId), "_blank");
+    if (needX !== config.grid_x || needY !== config.grid_y) {
+        setConfig((prev) => ({
+            ...prev,
+            grid_x: needX,
+            grid_y: needY,
+            partial_bins_values: createPartialBinsValues(needX, needY),
+        }));
     }
 
-    function handleDownloadZip() {
-        window.open(getBinZipUrl(binId), "_blank");
+    // always centre the tool in the bin
+    const binW = needX * GRID_UNIT
+    const binH = needY * GRID_UNIT
+    const toolCx = (minX + maxX) / 2
+    const toolCy = (minY + maxY) / 2
+    const dx = binW / 2 - toolCx
+    const dy = binH / 2 - toolCy
+    const placed = {
+      ...tool,
+      points: tool.points.map(p => ({ x: p.x + dx, y: p.y + dy })),
+      finger_holes: tool.finger_holes.map(fh => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
+      interior_rings: (tool.interior_rings ?? []).map(ring =>
+        ring.map(p => ({ x: p.x + dx, y: p.y + dy }))
+      ),
     }
 
-    function handleDownloadThreemf() {
-        window.open(getBinThreemfUrl(binId), "_blank");
-    }
+    setPlacedTools(prev => [...prev, placed])
+  }, [config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
 
-    function handleDownloadInsert() {
-        window.open(getBinInsertUrl(binId), "_blank");
-    }
+  function handleDownload() {
+    window.open(getBinStlUrl(binId), '_blank')
+  }
 
-    function showDefaultsStatus(message: string) {
-        if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current);
-        setDefaultsStatus(message);
-        defaultsStatusTimeoutRef.current = setTimeout(() => {
-            setDefaultsStatus(null);
-            defaultsStatusTimeoutRef.current = null;
-        }, 2500);
-    }
+  function handleDownloadZip() {
+    window.open(getBinZipUrl(binId), '_blank')
+  }
 
-    function handleSaveDefaults() {
-        saveDefaultBinConfig(config);
-        showDefaultsStatus("Defaults saved");
-    }
+  function handleDownloadThreemf() {
+    window.open(getBinThreemfUrl(binId), '_blank')
+  }
 
-    function handleResetDefaults() {
-        setConfig(resetDefaultBinConfig());
-        showDefaultsStatus("Defaults reset");
-    }
+  function handleDownloadInsert() {
+    window.open(getBinInsertUrl(binId), '_blank')
+  }
 
-    if (loading) {
-        return (
-            <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
-                <Loader2 className="w-5 h-5 animate-spin" />
-                <span>Loading bin...</span>
-            </div>
-        );
-    }
+  function showDefaultsStatus(message: string) {
+    if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
+    setDefaultsStatus(message)
+    defaultsStatusTimeoutRef.current = setTimeout(() => {
+      setDefaultsStatus(null)
+      defaultsStatusTimeoutRef.current = null
+    }, 2500)
+  }
 
-    if (error && !binData) {
-        return (
-            <div className="max-w-md mx-auto py-12">
-                <Alert variant="error">{error}</Alert>
-            </div>
-        );
-    }
+  function handleSaveDefaults() {
+    saveDefaultBinConfig(config)
+    showDefaultsStatus('Defaults saved')
+  }
 
-    const stlUrlWithVersion = stlUrl ? `${stlUrl}?v=${stlVersion}` : null;
-    const splitUrlsWithVersion = stlUrls.length > 0 ? stlUrls.map((u) => `${u}?v=${stlVersion}`) : null;
-    const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null;
-    const binW = config.grid_x * GRID_UNIT;
-    const binH = config.grid_y * GRID_UNIT;
-    const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0;
-    const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl;
+  function handleResetDefaults() {
+    setConfig(resetDefaultBinConfig())
+    showDefaultsStatus('Defaults reset')
+  }
 
+  if (loading) {
     return (
-        <div className="h-[calc(100vh-44px)] flex">
-            {/* config sidebar - always open */}
-            <div className="w-[200px] flex-shrink-0 bg-surface border-r border-border flex flex-col">
-                <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-3 space-y-3">
-                    <div className="glass rounded-[10px] px-3 py-3">
-                        <div className="flex items-center gap-2 mb-3">
-                            <Breadcrumb
-                                segments={[
-                                    { label: projectSource.rootLabel, href: projectSource.rootHref },
-                                    { label: name || "Untitled", editable: true, onEdit: (v) => setName(v) },
-                                ]}
-                            />
-                            {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
-                            {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
-                        </div>
-                        <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
-                        <div className="mt-3 border-t border-border pt-3 space-y-1.5">
-                            <div className="flex gap-1.5">
-                                <button type="button" onClick={handleSaveDefaults} className="btn-secondary flex-1 px-2 py-1.5 text-[11px]">
-                                    Save as default
-                                </button>
-                                <button type="button" onClick={handleResetDefaults} className="btn-secondary px-2 py-1.5 text-[11px]" title="Reset this bin and saved defaults">
-                                    Reset
-                                </button>
-                            </div>
-                            {defaultsStatus && <p className="text-[10px] text-text-muted">{defaultsStatus}</p>}
-                        </div>
-                    </div>
+      <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
+        <Loader2 className="w-5 h-5 animate-spin" />
+        <span>Loading bin...</span>
+      </div>
+    )
+  }
 
-                    <div className="glass rounded-[10px] px-3 py-3">
-                        <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px] mb-2">Dimensions</h3>
-                        <div className="text-[11px] text-text-secondary space-y-0.5">
-                            <div className="flex justify-between">
-                                <span>Width</span>
-                                <span>{binW} mm</span>
-                            </div>
-                            <div className="flex justify-between">
-                                <span>Depth</span>
-                                <span>{binH} mm</span>
-                            </div>
-                            <div className="flex justify-between">
-                                <span>Height</span>
-                                <span>{(config.height_units * 7 + 5 + effectiveRimUnits * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+  if (error && !binData) {
+    return (
+      <div className="max-w-md mx-auto py-12">
+        <Alert variant="error">{error}</Alert>
+      </div>
+    )
+  }
 
-                {/* export buttons */}
-                <div className="p-3 flex-shrink-0 space-y-1.5">
-                    {error && <Alert variant="error">{error}</Alert>}
-                    {warning && <InfoBanner>{warning}</InfoBanner>}
-                    {splitCount > 1 && <InfoBanner>Split into {splitCount} pieces</InfoBanner>}
-                    {hasExports && (
-                        <div className="relative" ref={exportRef}>
-                            <button onClick={() => setExportOpen((p) => !p)} className="btn-primary w-full py-2 text-[11px] font-medium inline-flex items-center justify-center gap-1 cursor-pointer">
-                                <Download className="w-3.5 h-3.5" />
-                                Export
-                                <ChevronDown className="w-3 h-3" />
-                            </button>
-                            {exportOpen && (
-                                <div className="absolute bottom-full left-0 right-0 mb-1.5 bg-surface border border-border rounded-lg py-1 z-30 shadow-xl">
-                                    {stlUrl && (
-                                        <button
-                                            onClick={() => {
-                                                handleDownload();
-                                                setExportOpen(false);
-                                            }}
-                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                                        >
-                                            <Package className="w-3 h-3" />
-                                            {zipUrl ? "Full STL" : "STL"}
-                                        </button>
-                                    )}
-                                    {zipUrl && (
-                                        <button
-                                            onClick={() => {
-                                                handleDownloadZip();
-                                                setExportOpen(false);
-                                            }}
-                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                                        >
-                                            <Package className="w-3 h-3" />
-                                            ZIP ({splitCount} parts)
-                                        </button>
-                                    )}
-                                    {threemfUrl && (
-                                        <button
-                                            onClick={() => {
-                                                handleDownloadThreemf();
-                                                setExportOpen(false);
-                                            }}
-                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                                        >
-                                            <Package className="w-3 h-3" />
-                                            3MF
-                                        </button>
-                                    )}
-                                    {insertStlUrl && (
-                                        <button
-                                            onClick={() => {
-                                                handleDownloadInsert();
-                                                setExportOpen(false);
-                                            }}
-                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                                        >
-                                            <Package className="w-3 h-3" />
-                                            Insert STL
-                                        </button>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
+  const stlUrlWithVersion = stlUrl ? `${stlUrl}?v=${stlVersion}` : null
+  const splitUrlsWithVersion = stlUrls.length > 0 ? stlUrls.map(u => `${u}?v=${stlVersion}`) : null
+  const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null
+  const binW = config.grid_x * GRID_UNIT
+  const binH = config.grid_y * GRID_UNIT
+  const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0
+  const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl
+
+  return (
+    <div className="h-[calc(100vh-44px)] flex">
+      {/* config sidebar - always open */}
+      <div className="w-[200px] flex-shrink-0 bg-surface border-r border-border flex flex-col">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-3 space-y-3">
+          <div className="glass rounded-[10px] px-3 py-3">
+            <div className="flex items-center gap-2 mb-3">
+              <Breadcrumb segments={[
+                { label: projectSource.rootLabel, href: projectSource.rootHref },
+                { label: name || 'Untitled', editable: true, onEdit: (v) => setName(v) },
+              ]} />
+              {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
+              {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
             </div>
-
-            {/* right of sidebar: library on top, then canvas + 3D preview below */}
-            <div className="flex-1 min-w-0 flex flex-col">
-                {/* library strip - full width */}
-                <div className="flex-shrink-0 bg-surface border-b border-border px-3 py-2">
-                    <ToolBrowser
-                        onAddTool={handleAddTool}
-                        binWidthMm={binW}
-                        binHeightMm={binH}
-                        layout="horizontal"
-                        projectId={projectSource.projectId}
-                        currentToolIds={placedTools.map((tool) => tool.tool_id)}
-                    />
-                </div>
-
-                {/* canvas + 3D preview side by side, equal width */}
-                <div className="flex-1 min-h-0 flex">
-                    {/* canvas */}
-                    <div className="flex-1 min-w-0 relative bg-inset overflow-hidden" data-testid="bin-editor">
-                        <div className="absolute inset-0">
-                            <BinEditor
-                                placedTools={placedTools}
-                                onPlacedToolsChange={handlePlacedToolsChange}
-                                textLabels={textLabels}
-                                onTextLabelsChange={setTextLabels}
-                                gridX={config.grid_x}
-                                gridY={config.grid_y}
-                                partialBins={config.partial_bins}
-                                partialBinsValues={config.partial_bins_values}
-                                wallThickness={config.wall_thickness}
-                                defaultCutoutDepth={config.cutout_depth}
-                                maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
-                                halfGridBase={config.half_grid_base}
-                                onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
-                                smoothedToolIds={smoothedToolIds}
-                                onToggleSmoothed={handleToggleSmoothed}
-                                smoothLevels={smoothLevels}
-                                onSmoothLevelChange={handleSmoothLevelChange}
-                                onDraggingChange={setIsDragging}
-                            />
-                        </div>
-
-                        {/* floating bottom bar */}
-                        <div className="absolute bottom-3.5 left-3.5 right-3.5 z-20 glass-toolbar px-3 py-2 flex items-center justify-between">
-                            <div className="flex items-center gap-2 text-[11px] text-text-muted">
-                                {generating && <Loader2 className="w-3 h-3 animate-spin text-accent" />}
-                                <span>
-                                    {config.grid_x}x{config.grid_y} Grid ({binW} x {binH} mm)
-                                </span>
-                                {placedTools.length > 0 && (
-                                    <span>
-                                        · {placedTools.length} tool{placedTools.length !== 1 ? "s" : ""} placed
-                                    </span>
-                                )}
-                            </div>
-                        </div>
-
-                        {error && (
-                            <div className="absolute top-14 left-3.5 z-20 max-w-sm">
-                                <Alert variant="error">{error}</Alert>
-                            </div>
-                        )}
-                    </div>
-
-                    {/* 3D preview - same width as canvas */}
-                    <div className="flex-1 min-w-0 bg-surface border-l border-border flex flex-col">
-                        <div className="px-3 py-2 border-b border-border flex-shrink-0">
-                            <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">3D Preview</h3>
-                        </div>
-                        <div className="flex-1 min-h-0 relative bg-inset">
-                            {generating && (
-                                <div className="absolute inset-x-0 bottom-0 z-10">
-                                    <div className="h-1 w-full overflow-hidden bg-blue-950">
-                                        <div className="h-full w-1/3 bg-blue-500 rounded-full animate-[slide_1.2s_ease-in-out_infinite]" />
-                                    </div>
-                                </div>
-                            )}
-                            {stlUrlWithVersion ? (
-                                <BinPreview3D stlUrl={stlUrlWithVersion} splitUrls={splitUrlsWithVersion || undefined} insertUrl={insertUrlWithVersion || undefined} />
-                            ) : (
-                                <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2">
-                                    {generating ? (
-                                        <>
-                                            <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
-                                            <span>Generating...</span>
-                                        </>
-                                    ) : placedTools.length === 0 ? (
-                                        <span>Add tools to see preview</span>
-                                    ) : (
-                                        <span>Preview will appear here</span>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                </div>
+            <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
+            <div className="mt-3 border-t border-border pt-3 space-y-1.5">
+              <div className="flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={handleSaveDefaults}
+                  className="btn-secondary flex-1 px-2 py-1.5 text-[11px]"
+                >
+                  Save as default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleResetDefaults}
+                  className="btn-secondary px-2 py-1.5 text-[11px]"
+                  title="Reset this bin and saved defaults"
+                >
+                  Reset
+                </button>
+              </div>
+              {defaultsStatus && (
+                <p className="text-[10px] text-text-muted">{defaultsStatus}</p>
+              )}
             </div>
+          </div>
+
+          <div className="glass rounded-[10px] px-3 py-3">
+            <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px] mb-2">Dimensions</h3>
+            <div className="text-[11px] text-text-secondary space-y-0.5">
+              <div className="flex justify-between"><span>Width</span><span>{binW} mm</span></div>
+              <div className="flex justify-between"><span>Depth</span><span>{binH} mm</span></div>
+              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + effectiveRimUnits * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
+            </div>
+          </div>
         </div>
-    );
+
+        {/* export buttons */}
+        <div className="p-3 flex-shrink-0 space-y-1.5">
+          {error && <Alert variant="error">{error}</Alert>}
+          {warning && (
+            <InfoBanner>{warning}</InfoBanner>
+          )}
+          {splitCount > 1 && (
+            <InfoBanner>Split into {splitCount} pieces</InfoBanner>
+          )}
+          {hasExports && (
+            <div className="relative" ref={exportRef}>
+              <button
+                onClick={() => setExportOpen(p => !p)}
+                className="btn-primary w-full py-2 text-[11px] font-medium inline-flex items-center justify-center gap-1 cursor-pointer"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {exportOpen && (
+                <div className="absolute bottom-full left-0 right-0 mb-1.5 bg-surface border border-border rounded-lg py-1 z-30 shadow-xl">
+                  {stlUrl && (
+                    <button
+                      onClick={() => { handleDownload(); setExportOpen(false) }}
+                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                    >
+                      <Package className="w-3 h-3" />
+                      {zipUrl ? 'Full STL' : 'STL'}
+                    </button>
+                  )}
+                  {zipUrl && (
+                    <button
+                      onClick={() => { handleDownloadZip(); setExportOpen(false) }}
+                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                    >
+                      <Package className="w-3 h-3" />
+                      ZIP ({splitCount} parts)
+                    </button>
+                  )}
+                  {threemfUrl && (
+                    <button
+                      onClick={() => { handleDownloadThreemf(); setExportOpen(false) }}
+                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                    >
+                      <Package className="w-3 h-3" />
+                      3MF
+                    </button>
+                  )}
+                  {insertStlUrl && (
+                    <button
+                      onClick={() => { handleDownloadInsert(); setExportOpen(false) }}
+                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                    >
+                      <Package className="w-3 h-3" />
+                      Insert STL
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* right of sidebar: library on top, then canvas + 3D preview below */}
+      <div className="flex-1 min-w-0 flex flex-col">
+        {/* library strip - full width */}
+        <div className="flex-shrink-0 bg-surface border-b border-border px-3 py-2">
+          <ToolBrowser
+            onAddTool={handleAddTool}
+            binWidthMm={binW}
+            binHeightMm={binH}
+            layout="horizontal"
+            projectId={projectSource.projectId}
+            currentToolIds={placedTools.map(tool => tool.tool_id)}
+          />
+        </div>
+
+        {/* canvas + 3D preview side by side, equal width */}
+        <div className="flex-1 min-h-0 flex">
+          {/* canvas */}
+          <div className="flex-1 min-w-0 relative bg-inset overflow-hidden" data-testid="bin-editor">
+            <div className="absolute inset-0">
+              <BinEditor
+                placedTools={placedTools}
+                onPlacedToolsChange={handlePlacedToolsChange}
+                textLabels={textLabels}
+                onTextLabelsChange={setTextLabels}
+                gridX={config.grid_x}
+                gridY={config.grid_y}
+                partialBins={config.partial_bins}
+                partialBinsValues={config.partial_bins_values}
+                wallThickness={config.wall_thickness}
+                defaultCutoutDepth={config.cutout_depth}
+                maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
+                halfGridBase={config.half_grid_base}
+                onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
+                smoothedToolIds={smoothedToolIds}
+                onToggleSmoothed={handleToggleSmoothed}
+                smoothLevels={smoothLevels}
+                onSmoothLevelChange={handleSmoothLevelChange}
+                onDraggingChange={setIsDragging}
+              />
+            </div>
+
+            {/* floating bottom bar */}
+            <div className="absolute bottom-3.5 left-3.5 right-3.5 z-20 glass-toolbar px-3 py-2 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                {generating && <Loader2 className="w-3 h-3 animate-spin text-accent" />}
+                <span>{config.grid_x}x{config.grid_y} Grid ({binW} x {binH} mm)</span>
+                {placedTools.length > 0 && (
+                  <span>· {placedTools.length} tool{placedTools.length !== 1 ? 's' : ''} placed</span>
+                )}
+              </div>
+            </div>
+
+            {error && (
+              <div className="absolute top-14 left-3.5 z-20 max-w-sm">
+                <Alert variant="error">{error}</Alert>
+              </div>
+            )}
+          </div>
+
+          {/* 3D preview - same width as canvas */}
+          <div className="flex-1 min-w-0 bg-surface border-l border-border flex flex-col">
+            <div className="px-3 py-2 border-b border-border flex-shrink-0">
+              <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">3D Preview</h3>
+            </div>
+            <div className="flex-1 min-h-0 relative bg-inset">
+              {generating && (
+                <div className="absolute inset-x-0 bottom-0 z-10">
+                  <div className="h-1 w-full overflow-hidden bg-blue-950">
+                    <div className="h-full w-1/3 bg-blue-500 rounded-full animate-[slide_1.2s_ease-in-out_infinite]" />
+                  </div>
+                </div>
+              )}
+              {stlUrlWithVersion ? (
+                <BinPreview3D stlUrl={stlUrlWithVersion} splitUrls={splitUrlsWithVersion || undefined} insertUrl={insertUrlWithVersion || undefined} />
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2">
+                  {generating ? (
+                    <>
+                      <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
+                      <span>Generating...</span>
+                    </>
+                  ) : placedTools.length === 0 ? (
+                    <span>Add tools to see preview</span>
+                  ) : (
+                    <span>Preview will appear here</span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -523,6 +523,8 @@ export default function BinPage() {
                                 onTextLabelsChange={setTextLabels}
                                 gridX={config.grid_x}
                                 gridY={config.grid_y}
+                                partialBins={config.partial_bins}
+                                partialBinsValues={config.partial_bins_values}
                                 wallThickness={config.wall_thickness}
                                 defaultCutoutDepth={config.cutout_depth}
                                 maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -1,572 +1,598 @@
-'use client'
+"use client";
 
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { useRouter, useParams } from 'next/navigation'
-import { BinEditor } from '@/components/BinEditor'
-import { BinConfigurator, calcMaxCutoutDepth } from '@/components/BinConfigurator'
-import { BinPreview3D } from '@/components/BinPreview3D'
-import { ToolBrowser } from '@/components/ToolBrowser'
-import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
-import { getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from '@/lib/binDefaults'
-import type { BinConfig, BinData, PlacedTool, TextLabel } from '@/types'
-import { Download, Loader2, Package, ChevronDown, Check } from 'lucide-react'
-import { Breadcrumb } from '@/components/Breadcrumb'
-import { Alert } from '@/components/Alert'
-import { useDebouncedSave } from '@/hooks/useDebouncedSave'
-import { useProjectSource } from '@/hooks/useProjectSource'
-import { GRID_UNIT } from '@/lib/constants'
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { BinEditor } from "@/components/BinEditor";
+import { BinConfigurator, calcMaxCutoutDepth } from "@/components/BinConfigurator";
+import { BinPreview3D } from "@/components/BinPreview3D";
+import { ToolBrowser } from "@/components/ToolBrowser";
+import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from "@/lib/api";
+import { buildBinConfig, createPartialBinsValues, getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from "@/lib/binDefaults";
+import type { BinConfig, BinData, PlacedTool, TextLabel } from "@/types";
+import { Download, Loader2, Package, ChevronDown, Check } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Alert } from "@/components/Alert";
+import { useDebouncedSave } from "@/hooks/useDebouncedSave";
+import { useProjectSource } from "@/hooks/useProjectSource";
+import { GRID_UNIT } from "@/lib/constants";
 
 function InfoBanner({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
-      {children}
-    </div>
-  )
+    return <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">{children}</div>;
 }
 
 export default function BinPage() {
-  const router = useRouter()
-  const params = useParams()
-  const binId = params.id as string
-  const projectSource = useProjectSource('Bins')
+    const router = useRouter();
+    const params = useParams();
+    const binId = params.id as string;
+    const projectSource = useProjectSource("Bins");
 
-  const [binData, setBinData] = useState<BinData | null>(null)
-  const [placedTools, setPlacedTools] = useState<PlacedTool[]>([])
-  const [textLabels, setTextLabels] = useState<TextLabel[]>([])
-  const [config, setConfig] = useState<BinConfig>(() => getDefaultBinConfig())
-  const [name, setName] = useState('')
-  const [stlUrl, setStlUrl] = useState<string | null>(null)
-  const [stlUrls, setStlUrls] = useState<string[]>([])
-  const [threemfUrl, setThreemfUrl] = useState<string | null>(null)
-  const [zipUrl, setZipUrl] = useState<string | null>(null)
-  const [insertStlUrl, setInsertStlUrl] = useState<string | null>(null)
-  const [splitCount, setSplitCount] = useState(1)
-  const [stlVersion, setStlVersion] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [generating, setGenerating] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [warning, setWarning] = useState<string | null>(null)
-  const generateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const lastGenerateRef = useRef<string>('')
-  const generatingRef = useRef(false)
-  const abortRef = useRef<AbortController | null>(null)
-  const doGenerateRef = useRef<() => void>(() => {})
-  const [smoothedToolIds, setSmoothedToolIds] = useState<Set<string>>(new Set())
-  const [smoothLevels, setSmoothLevels] = useState<Map<string, number>>(new Map())
-  const smoothLevelTimerRef = useRef<NodeJS.Timeout | null>(null)
+    const [binData, setBinData] = useState<BinData | null>(null);
+    const [placedTools, setPlacedTools] = useState<PlacedTool[]>([]);
+    const [textLabels, setTextLabels] = useState<TextLabel[]>([]);
+    const [config, setConfig] = useState<BinConfig>(() => getDefaultBinConfig());
+    const [name, setName] = useState("");
+    const [stlUrl, setStlUrl] = useState<string | null>(null);
+    const [stlUrls, setStlUrls] = useState<string[]>([]);
+    const [threemfUrl, setThreemfUrl] = useState<string | null>(null);
+    const [zipUrl, setZipUrl] = useState<string | null>(null);
+    const [insertStlUrl, setInsertStlUrl] = useState<string | null>(null);
+    const [splitCount, setSplitCount] = useState(1);
+    const [stlVersion, setStlVersion] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [generating, setGenerating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [warning, setWarning] = useState<string | null>(null);
+    const generateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const lastGenerateRef = useRef<string>("");
+    const generatingRef = useRef(false);
+    const abortRef = useRef<AbortController | null>(null);
+    const doGenerateRef = useRef<() => void>(() => {});
+    const [smoothedToolIds, setSmoothedToolIds] = useState<Set<string>>(new Set());
+    const [smoothLevels, setSmoothLevels] = useState<Map<string, number>>(new Map());
+    const smoothLevelTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const [autoSize, setAutoSize] = useState(true)
-  const [isDragging, setIsDragging] = useState(false)
-  const [exportOpen, setExportOpen] = useState(false)
-  const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null)
-  const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const exportRef = useRef<HTMLDivElement>(null)
+    const [autoSize, setAutoSize] = useState(true);
+    const [isDragging, setIsDragging] = useState(false);
+    const [exportOpen, setExportOpen] = useState(false);
+    const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null);
+    const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const exportRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!exportOpen) return
-    function handleClick(e: MouseEvent) {
-      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
-        setExportOpen(false)
-      }
+    useEffect(() => {
+        if (!exportOpen) return;
+        function handleClick(e: MouseEvent) {
+            if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+                setExportOpen(false);
+            }
+        }
+        document.addEventListener("mousedown", handleClick);
+        return () => document.removeEventListener("mousedown", handleClick);
+    }, [exportOpen]);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const [data, tools] = await Promise.all([getBin(binId), listTools()]);
+                setBinData(data);
+
+                const toolMap = new Map(tools.map((t) => [t.id, t]));
+                const synced = data.placed_tools.map((pt) => {
+                    const lib = toolMap.get(pt.tool_id);
+                    if (!lib) return pt;
+                    const rad = ((pt.rotation || 0) * Math.PI) / 180;
+                    const cos = Math.cos(rad);
+                    const sin = Math.sin(rad);
+                    const n = pt.points.length || 1;
+                    const cx = pt.points.reduce((s, p) => s + p.x, 0) / n;
+                    const cy = pt.points.reduce((s, p) => s + p.y, 0) / n;
+                    const newRings = (lib.interior_rings ?? []).map((ring) =>
+                        ring.map((p) => ({
+                            x: p.x * cos - p.y * sin + cx,
+                            y: p.x * sin + p.y * cos + cy,
+                        })),
+                    );
+                    return { ...pt, interior_rings: newRings };
+                });
+                setPlacedTools(synced);
+                setTextLabels(data.text_labels);
+                setName(data.name || "");
+                setConfig(buildBinConfig(data.bin_config));
+                setSmoothedToolIds(new Set(tools.filter((t) => t.smoothed).map((t) => t.id)));
+                setSmoothLevels(new Map(tools.map((t) => [t.id, t.smooth_level])));
+            } catch {
+                setError("Bin not found");
+            } finally {
+                setLoading(false);
+                setTimeout(() => doGenerateRef.current(), 100);
+            }
+        }
+        load();
+    }, [binId]);
+
+    const doGenerate = useCallback(async () => {
+        if (placedTools.length === 0) return;
+
+        const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] });
+        if (key === lastGenerateRef.current) return;
+
+        if (abortRef.current) {
+            abortRef.current.abort();
+        }
+
+        lastGenerateRef.current = key;
+        generatingRef.current = true;
+        setGenerating(true);
+        setError(null);
+        setWarning(null);
+        setStlUrl(null);
+        setStlUrls([]);
+        setThreemfUrl(null);
+        setZipUrl(null);
+        setInsertStlUrl(null);
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        try {
+            const result = await generateBinStl(binId, controller.signal);
+            setStlUrl(getImageUrl(result.stl_url));
+            setStlUrls((result.stl_urls || []).map((u) => getImageUrl(u)));
+            setThreemfUrl(result.threemf_url ? getImageUrl(result.threemf_url) : null);
+            setZipUrl(result.zip_url ? getImageUrl(result.zip_url) : null);
+            setInsertStlUrl(result.insert_stl_url ? getImageUrl(result.insert_stl_url) : null);
+            setSplitCount(result.split_count || 1);
+            setStlVersion((v) => v + 1);
+            setWarning(result.warning || null);
+        } catch (err) {
+            if (err instanceof DOMException && err.name === "AbortError") return;
+            setError(err instanceof Error ? err.message : "generation failed");
+        } finally {
+            if (abortRef.current === controller) {
+                generatingRef.current = false;
+                setGenerating(false);
+                abortRef.current = null;
+            }
+        }
+    }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels]);
+
+    useEffect(() => {
+        doGenerateRef.current = doGenerate;
+    }, [doGenerate]);
+
+    const { saving, saved } = useDebouncedSave(
+        () => {
+            if (!binData) return;
+            updateBin(binId, {
+                name: name || undefined,
+                bin_config: config,
+                placed_tools: placedTools,
+                text_labels: textLabels,
+            }).catch(() => {});
+        },
+        [binData, binId, name, config, placedTools, textLabels],
+        150,
+        { skipInitial: true },
+    );
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+            if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!binData) return;
+        if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current);
+        generateTimeoutRef.current = setTimeout(() => {
+            doGenerate();
+        }, 1000);
+        return () => {
+            if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current);
+        };
+    }, [binData, placedTools, config, textLabels, smoothedToolIds, smoothLevels, doGenerate]);
+
+    const handlePlacedToolsChange = useCallback((updated: PlacedTool[]) => {
+        setPlacedTools(updated);
+    }, []);
+
+    // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
+    useEffect(() => {
+        if (!autoSize || isDragging || placedTools.length === 0) return;
+        let minX = Infinity,
+            minY = Infinity,
+            maxX = -Infinity,
+            maxY = -Infinity;
+        for (const tool of placedTools) {
+            for (const p of tool.points) {
+                minX = Math.min(minX, p.x);
+                minY = Math.min(minY, p.y);
+                maxX = Math.max(maxX, p.x);
+                maxY = Math.max(maxY, p.y);
+            }
+        }
+        const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25;
+        const toolW = maxX - minX;
+        const toolH = maxY - minY;
+        const snap = config.half_grid_base ? 0.5 : 1.0;
+        const snapUnit = GRID_UNIT * snap;
+        const needX = Math.max(1, Math.ceil((toolW + 2 * halfMargin) / snapUnit) * snap);
+        const needY = Math.max(1, Math.ceil((toolH + 2 * halfMargin) / snapUnit) * snap);
+
+        const gridChanged = config.grid_x !== needX || config.grid_y !== needY;
+        if (gridChanged) {
+            setConfig((prev) => ({
+                ...prev,
+                grid_x: needX,
+                grid_y: needY,
+                partial_bins_values: createPartialBinsValues(needX, needY),
+            }));
+        }
+
+        // recentre tools if grid changed or tools are off-centre
+        const binW = (gridChanged ? needX : config.grid_x) * GRID_UNIT;
+        const binH = (gridChanged ? needY : config.grid_y) * GRID_UNIT;
+        const toolCx = (minX + maxX) / 2;
+        const toolCy = (minY + maxY) / 2;
+        const dx = binW / 2 - toolCx;
+        const dy = binH / 2 - toolCy;
+        if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
+            setPlacedTools((prev) =>
+                prev.map((tool) => ({
+                    ...tool,
+                    points: tool.points.map((p) => ({ x: p.x + dx, y: p.y + dy })),
+                    finger_holes: tool.finger_holes.map((fh) => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
+                    interior_rings: (tool.interior_rings ?? []).map((ring) => ring.map((p) => ({ x: p.x + dx, y: p.y + dy }))),
+                })),
+            );
+        }
+    }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base]);
+
+    const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
+        try {
+            await updateTool(toolId, { smoothed });
+            setSmoothedToolIds((prev) => {
+                const next = new Set(prev);
+                if (smoothed) next.add(toolId);
+                else next.delete(toolId);
+                return next;
+            });
+        } catch {
+            /* ignore */
+        }
+    }, []);
+
+    const handleSmoothLevelChange = useCallback((toolId: string, level: number) => {
+        setSmoothLevels((prev) => new Map(prev).set(toolId, level));
+        if (smoothLevelTimerRef.current) clearTimeout(smoothLevelTimerRef.current);
+        smoothLevelTimerRef.current = setTimeout(() => {
+            updateTool(toolId, { smooth_level: level }).catch(() => {});
+        }, 300);
+    }, []);
+
+    const handleAddTool = useCallback(
+        (tool: PlacedTool) => {
+            let minX = Infinity,
+                minY = Infinity,
+                maxX = -Infinity,
+                maxY = -Infinity;
+            for (const p of tool.points) {
+                minX = Math.min(minX, p.x);
+                minY = Math.min(minY, p.y);
+                maxX = Math.max(maxX, p.x);
+                maxY = Math.max(maxY, p.y);
+            }
+            const toolW = maxX - minX;
+            const toolH = maxY - minY;
+
+            const margin = 2 * config.wall_thickness + 2 * config.cutout_clearance + 0.5;
+            const snap = config.half_grid_base ? 0.5 : 1.0;
+            const snapUnit = GRID_UNIT * snap;
+            const needX = Math.max(config.grid_x, Math.ceil((toolW + margin) / snapUnit) * snap);
+            const needY = Math.max(config.grid_y, Math.ceil((toolH + margin) / snapUnit) * snap);
+
+            if (needX !== config.grid_x || needY !== config.grid_y) {
+                setConfig((prev) => ({
+                    ...prev,
+                    grid_x: needX,
+                    grid_y: needY,
+                    partial_bins_values: createPartialBinsValues(needX, needY),
+                }));
+            }
+
+            // always centre the tool in the bin
+            const binW = needX * GRID_UNIT;
+            const binH = needY * GRID_UNIT;
+            const toolCx = (minX + maxX) / 2;
+            const toolCy = (minY + maxY) / 2;
+            const dx = binW / 2 - toolCx;
+            const dy = binH / 2 - toolCy;
+            const placed = {
+                ...tool,
+                points: tool.points.map((p) => ({ x: p.x + dx, y: p.y + dy })),
+                finger_holes: tool.finger_holes.map((fh) => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
+                interior_rings: (tool.interior_rings ?? []).map((ring) => ring.map((p) => ({ x: p.x + dx, y: p.y + dy }))),
+            };
+
+            setPlacedTools((prev) => [...prev, placed]);
+        },
+        [config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base],
+    );
+
+    function handleDownload() {
+        window.open(getBinStlUrl(binId), "_blank");
     }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [exportOpen])
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const [data, tools] = await Promise.all([getBin(binId), listTools()])
-        setBinData(data)
-
-        const toolMap = new Map(tools.map(t => [t.id, t]))
-        const synced = data.placed_tools.map(pt => {
-          const lib = toolMap.get(pt.tool_id)
-          if (!lib) return pt
-          const rad = (pt.rotation || 0) * Math.PI / 180
-          const cos = Math.cos(rad)
-          const sin = Math.sin(rad)
-          const n = pt.points.length || 1
-          const cx = pt.points.reduce((s, p) => s + p.x, 0) / n
-          const cy = pt.points.reduce((s, p) => s + p.y, 0) / n
-          const newRings = (lib.interior_rings ?? []).map(ring =>
-            ring.map(p => ({
-              x: p.x * cos - p.y * sin + cx,
-              y: p.x * sin + p.y * cos + cy,
-            }))
-          )
-          return { ...pt, interior_rings: newRings }
-        })
-        setPlacedTools(synced)
-        setTextLabels(data.text_labels)
-        setName(data.name || '')
-        setConfig(data.bin_config)
-        setSmoothedToolIds(new Set(tools.filter(t => t.smoothed).map(t => t.id)))
-        setSmoothLevels(new Map(tools.map(t => [t.id, t.smooth_level])))
-      } catch {
-        setError('Bin not found')
-      } finally {
-        setLoading(false)
-        setTimeout(() => doGenerateRef.current(), 100)
-      }
-    }
-    load()
-  }, [binId])
-
-  const doGenerate = useCallback(async () => {
-    if (placedTools.length === 0) return
-
-    const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] })
-    if (key === lastGenerateRef.current) return
-
-    if (abortRef.current) {
-      abortRef.current.abort()
+    function handleDownloadZip() {
+        window.open(getBinZipUrl(binId), "_blank");
     }
 
-    lastGenerateRef.current = key
-    generatingRef.current = true
-    setGenerating(true)
-    setError(null)
-    setWarning(null)
-    setStlUrl(null)
-    setStlUrls([])
-    setThreemfUrl(null)
-    setZipUrl(null)
-    setInsertStlUrl(null)
-
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    try {
-      const result = await generateBinStl(binId, controller.signal)
-      setStlUrl(getImageUrl(result.stl_url))
-      setStlUrls((result.stl_urls || []).map(u => getImageUrl(u)))
-      setThreemfUrl(result.threemf_url ? getImageUrl(result.threemf_url) : null)
-      setZipUrl(result.zip_url ? getImageUrl(result.zip_url) : null)
-      setInsertStlUrl(result.insert_stl_url ? getImageUrl(result.insert_stl_url) : null)
-      setSplitCount(result.split_count || 1)
-      setStlVersion(v => v + 1)
-      setWarning(result.warning || null)
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return
-      setError(err instanceof Error ? err.message : 'generation failed')
-    } finally {
-      if (abortRef.current === controller) {
-        generatingRef.current = false
-        setGenerating(false)
-        abortRef.current = null
-      }
-    }
-  }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels])
-
-  useEffect(() => {
-    doGenerateRef.current = doGenerate
-  }, [doGenerate])
-
-  const { saving, saved } = useDebouncedSave(
-    () => {
-      if (!binData) return
-      updateBin(binId, {
-        name: name || undefined,
-        bin_config: config,
-        placed_tools: placedTools,
-        text_labels: textLabels,
-      }).catch(() => {})
-    },
-    [binData, binId, name, config, placedTools, textLabels],
-    150,
-    { skipInitial: true }
-  )
-
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort()
-      if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!binData) return
-    if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current)
-    generateTimeoutRef.current = setTimeout(() => {
-      doGenerate()
-    }, 1000)
-    return () => {
-      if (generateTimeoutRef.current) clearTimeout(generateTimeoutRef.current)
-    }
-  }, [binData, placedTools, config, textLabels, smoothedToolIds, smoothLevels, doGenerate])
-
-  const handlePlacedToolsChange = useCallback((updated: PlacedTool[]) => {
-    setPlacedTools(updated)
-  }, [])
-
-  // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
-  useEffect(() => {
-    if (!autoSize || isDragging || placedTools.length === 0) return
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    for (const tool of placedTools) {
-      for (const p of tool.points) {
-        minX = Math.min(minX, p.x)
-        minY = Math.min(minY, p.y)
-        maxX = Math.max(maxX, p.x)
-        maxY = Math.max(maxY, p.y)
-      }
-    }
-    const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25
-    const toolW = maxX - minX
-    const toolH = maxY - minY
-    const snap = config.half_grid_base ? 0.5 : 1.0
-    const snapUnit = GRID_UNIT * snap
-    const needX = Math.max(1, Math.ceil((toolW + 2 * halfMargin) / snapUnit) * snap)
-    const needY = Math.max(1, Math.ceil((toolH + 2 * halfMargin) / snapUnit) * snap)
-
-    const gridChanged = config.grid_x !== needX || config.grid_y !== needY
-    if (gridChanged) {
-      setConfig(prev => ({ ...prev, grid_x: needX, grid_y: needY }))
+    function handleDownloadThreemf() {
+        window.open(getBinThreemfUrl(binId), "_blank");
     }
 
-    // recentre tools if grid changed or tools are off-centre
-    const binW = (gridChanged ? needX : config.grid_x) * GRID_UNIT
-    const binH = (gridChanged ? needY : config.grid_y) * GRID_UNIT
-    const toolCx = (minX + maxX) / 2
-    const toolCy = (minY + maxY) / 2
-    const dx = binW / 2 - toolCx
-    const dy = binH / 2 - toolCy
-    if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
-      setPlacedTools(prev => prev.map(tool => ({
-        ...tool,
-        points: tool.points.map(p => ({ x: p.x + dx, y: p.y + dy })),
-        finger_holes: tool.finger_holes.map(fh => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
-        interior_rings: (tool.interior_rings ?? []).map(ring =>
-          ring.map(p => ({ x: p.x + dx, y: p.y + dy }))
-        ),
-      })))
-    }
-  }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
-
-  const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
-    try {
-      await updateTool(toolId, { smoothed })
-      setSmoothedToolIds(prev => {
-        const next = new Set(prev)
-        if (smoothed) next.add(toolId)
-        else next.delete(toolId)
-        return next
-      })
-    } catch { /* ignore */ }
-  }, [])
-
-  const handleSmoothLevelChange = useCallback((toolId: string, level: number) => {
-    setSmoothLevels(prev => new Map(prev).set(toolId, level))
-    if (smoothLevelTimerRef.current) clearTimeout(smoothLevelTimerRef.current)
-    smoothLevelTimerRef.current = setTimeout(() => {
-      updateTool(toolId, { smooth_level: level }).catch(() => {})
-    }, 300)
-  }, [])
-
-  const handleAddTool = useCallback((tool: PlacedTool) => {
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    for (const p of tool.points) {
-      minX = Math.min(minX, p.x)
-      minY = Math.min(minY, p.y)
-      maxX = Math.max(maxX, p.x)
-      maxY = Math.max(maxY, p.y)
-    }
-    const toolW = maxX - minX
-    const toolH = maxY - minY
-
-    const margin = 2 * config.wall_thickness + 2 * config.cutout_clearance + 0.5
-    const snap = config.half_grid_base ? 0.5 : 1.0
-    const snapUnit = GRID_UNIT * snap
-    const needX = Math.max(config.grid_x, Math.ceil((toolW + margin) / snapUnit) * snap)
-    const needY = Math.max(config.grid_y, Math.ceil((toolH + margin) / snapUnit) * snap)
-
-    if (needX !== config.grid_x || needY !== config.grid_y) {
-      setConfig(prev => ({ ...prev, grid_x: needX, grid_y: needY }))
+    function handleDownloadInsert() {
+        window.open(getBinInsertUrl(binId), "_blank");
     }
 
-    // always centre the tool in the bin
-    const binW = needX * GRID_UNIT
-    const binH = needY * GRID_UNIT
-    const toolCx = (minX + maxX) / 2
-    const toolCy = (minY + maxY) / 2
-    const dx = binW / 2 - toolCx
-    const dy = binH / 2 - toolCy
-    const placed = {
-      ...tool,
-      points: tool.points.map(p => ({ x: p.x + dx, y: p.y + dy })),
-      finger_holes: tool.finger_holes.map(fh => ({ ...fh, x: fh.x + dx, y: fh.y + dy })),
-      interior_rings: (tool.interior_rings ?? []).map(ring =>
-        ring.map(p => ({ x: p.x + dx, y: p.y + dy }))
-      ),
+    function showDefaultsStatus(message: string) {
+        if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current);
+        setDefaultsStatus(message);
+        defaultsStatusTimeoutRef.current = setTimeout(() => {
+            setDefaultsStatus(null);
+            defaultsStatusTimeoutRef.current = null;
+        }, 2500);
     }
 
-    setPlacedTools(prev => [...prev, placed])
-  }, [config.grid_x, config.grid_y])
+    function handleSaveDefaults() {
+        saveDefaultBinConfig(config);
+        showDefaultsStatus("Defaults saved");
+    }
 
-  function handleDownload() {
-    window.open(getBinStlUrl(binId), '_blank')
-  }
+    function handleResetDefaults() {
+        setConfig(resetDefaultBinConfig());
+        showDefaultsStatus("Defaults reset");
+    }
 
-  function handleDownloadZip() {
-    window.open(getBinZipUrl(binId), '_blank')
-  }
-
-  function handleDownloadThreemf() {
-    window.open(getBinThreemfUrl(binId), '_blank')
-  }
-
-  function handleDownloadInsert() {
-    window.open(getBinInsertUrl(binId), '_blank')
-  }
-
-  function showDefaultsStatus(message: string) {
-    if (defaultsStatusTimeoutRef.current) clearTimeout(defaultsStatusTimeoutRef.current)
-    setDefaultsStatus(message)
-    defaultsStatusTimeoutRef.current = setTimeout(() => {
-      setDefaultsStatus(null)
-      defaultsStatusTimeoutRef.current = null
-    }, 2500)
-  }
-
-  function handleSaveDefaults() {
-    saveDefaultBinConfig(config)
-    showDefaultsStatus('Defaults saved')
-  }
-
-  function handleResetDefaults() {
-    setConfig(resetDefaultBinConfig())
-    showDefaultsStatus('Defaults reset')
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
-        <Loader2 className="w-5 h-5 animate-spin" />
-        <span>Loading bin...</span>
-      </div>
-    )
-  }
-
-  if (error && !binData) {
-    return (
-      <div className="max-w-md mx-auto py-12">
-        <Alert variant="error">{error}</Alert>
-      </div>
-    )
-  }
-
-  const stlUrlWithVersion = stlUrl ? `${stlUrl}?v=${stlVersion}` : null
-  const splitUrlsWithVersion = stlUrls.length > 0 ? stlUrls.map(u => `${u}?v=${stlVersion}`) : null
-  const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null
-  const binW = config.grid_x * GRID_UNIT
-  const binH = config.grid_y * GRID_UNIT
-  const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0
-  const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl
-
-  return (
-    <div className="h-[calc(100vh-44px)] flex">
-      {/* config sidebar - always open */}
-      <div className="w-[200px] flex-shrink-0 bg-surface border-r border-border flex flex-col">
-        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-3 space-y-3">
-          <div className="glass rounded-[10px] px-3 py-3">
-            <div className="flex items-center gap-2 mb-3">
-              <Breadcrumb segments={[
-                { label: projectSource.rootLabel, href: projectSource.rootHref },
-                { label: name || 'Untitled', editable: true, onEdit: (v) => setName(v) },
-              ]} />
-              {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
-              {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-12 gap-2 text-text-muted">
+                <Loader2 className="w-5 h-5 animate-spin" />
+                <span>Loading bin...</span>
             </div>
-            <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
-            <div className="mt-3 border-t border-border pt-3 space-y-1.5">
-              <div className="flex gap-1.5">
-                <button
-                  type="button"
-                  onClick={handleSaveDefaults}
-                  className="btn-secondary flex-1 px-2 py-1.5 text-[11px]"
-                >
-                  Save as default
-                </button>
-                <button
-                  type="button"
-                  onClick={handleResetDefaults}
-                  className="btn-secondary px-2 py-1.5 text-[11px]"
-                  title="Reset this bin and saved defaults"
-                >
-                  Reset
-                </button>
-              </div>
-              {defaultsStatus && (
-                <p className="text-[10px] text-text-muted">{defaultsStatus}</p>
-              )}
-            </div>
-          </div>
+        );
+    }
 
-          <div className="glass rounded-[10px] px-3 py-3">
-            <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px] mb-2">Dimensions</h3>
-            <div className="text-[11px] text-text-secondary space-y-0.5">
-              <div className="flex justify-between"><span>Width</span><span>{binW} mm</span></div>
-              <div className="flex justify-between"><span>Depth</span><span>{binH} mm</span></div>
-              <div className="flex justify-between"><span>Height</span><span>{(config.height_units * 7 + 5 + effectiveRimUnits * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span></div>
-            </div>
-          </div>
-        </div>
-
-        {/* export buttons */}
-        <div className="p-3 flex-shrink-0 space-y-1.5">
-          {error && <Alert variant="error">{error}</Alert>}
-          {warning && (
-            <InfoBanner>{warning}</InfoBanner>
-          )}
-          {splitCount > 1 && (
-            <InfoBanner>Split into {splitCount} pieces</InfoBanner>
-          )}
-          {hasExports && (
-            <div className="relative" ref={exportRef}>
-              <button
-                onClick={() => setExportOpen(p => !p)}
-                className="btn-primary w-full py-2 text-[11px] font-medium inline-flex items-center justify-center gap-1 cursor-pointer"
-              >
-                <Download className="w-3.5 h-3.5" />
-                Export
-                <ChevronDown className="w-3 h-3" />
-              </button>
-              {exportOpen && (
-                <div className="absolute bottom-full left-0 right-0 mb-1.5 bg-surface border border-border rounded-lg py-1 z-30 shadow-xl">
-                  {stlUrl && (
-                    <button
-                      onClick={() => { handleDownload(); setExportOpen(false) }}
-                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                    >
-                      <Package className="w-3 h-3" />
-                      {zipUrl ? 'Full STL' : 'STL'}
-                    </button>
-                  )}
-                  {zipUrl && (
-                    <button
-                      onClick={() => { handleDownloadZip(); setExportOpen(false) }}
-                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                    >
-                      <Package className="w-3 h-3" />
-                      ZIP ({splitCount} parts)
-                    </button>
-                  )}
-                  {threemfUrl && (
-                    <button
-                      onClick={() => { handleDownloadThreemf(); setExportOpen(false) }}
-                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                    >
-                      <Package className="w-3 h-3" />
-                      3MF
-                    </button>
-                  )}
-                  {insertStlUrl && (
-                    <button
-                      onClick={() => { handleDownloadInsert(); setExportOpen(false) }}
-                      className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
-                    >
-                      <Package className="w-3 h-3" />
-                      Insert STL
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* right of sidebar: library on top, then canvas + 3D preview below */}
-      <div className="flex-1 min-w-0 flex flex-col">
-        {/* library strip - full width */}
-        <div className="flex-shrink-0 bg-surface border-b border-border px-3 py-2">
-          <ToolBrowser
-            onAddTool={handleAddTool}
-            binWidthMm={binW}
-            binHeightMm={binH}
-            layout="horizontal"
-            projectId={projectSource.projectId}
-            currentToolIds={placedTools.map(tool => tool.tool_id)}
-          />
-        </div>
-
-        {/* canvas + 3D preview side by side, equal width */}
-        <div className="flex-1 min-h-0 flex">
-          {/* canvas */}
-          <div className="flex-1 min-w-0 relative bg-inset overflow-hidden" data-testid="bin-editor">
-            <div className="absolute inset-0">
-              <BinEditor
-                placedTools={placedTools}
-                onPlacedToolsChange={handlePlacedToolsChange}
-                textLabels={textLabels}
-                onTextLabelsChange={setTextLabels}
-                gridX={config.grid_x}
-                gridY={config.grid_y}
-                wallThickness={config.wall_thickness}
-                defaultCutoutDepth={config.cutout_depth}
-                maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
-                halfGridBase={config.half_grid_base}
-                onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
-                smoothedToolIds={smoothedToolIds}
-                onToggleSmoothed={handleToggleSmoothed}
-                smoothLevels={smoothLevels}
-                onSmoothLevelChange={handleSmoothLevelChange}
-                onDraggingChange={setIsDragging}
-              />
-            </div>
-
-            {/* floating bottom bar */}
-            <div className="absolute bottom-3.5 left-3.5 right-3.5 z-20 glass-toolbar px-3 py-2 flex items-center justify-between">
-              <div className="flex items-center gap-2 text-[11px] text-text-muted">
-                {generating && <Loader2 className="w-3 h-3 animate-spin text-accent" />}
-                <span>{config.grid_x}x{config.grid_y} Grid ({binW} x {binH} mm)</span>
-                {placedTools.length > 0 && (
-                  <span>· {placedTools.length} tool{placedTools.length !== 1 ? 's' : ''} placed</span>
-                )}
-              </div>
-            </div>
-
-            {error && (
-              <div className="absolute top-14 left-3.5 z-20 max-w-sm">
+    if (error && !binData) {
+        return (
+            <div className="max-w-md mx-auto py-12">
                 <Alert variant="error">{error}</Alert>
-              </div>
-            )}
-          </div>
+            </div>
+        );
+    }
 
-          {/* 3D preview - same width as canvas */}
-          <div className="flex-1 min-w-0 bg-surface border-l border-border flex flex-col">
-            <div className="px-3 py-2 border-b border-border flex-shrink-0">
-              <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">3D Preview</h3>
-            </div>
-            <div className="flex-1 min-h-0 relative bg-inset">
-              {generating && (
-                <div className="absolute inset-x-0 bottom-0 z-10">
-                  <div className="h-1 w-full overflow-hidden bg-blue-950">
-                    <div className="h-full w-1/3 bg-blue-500 rounded-full animate-[slide_1.2s_ease-in-out_infinite]" />
-                  </div>
+    const stlUrlWithVersion = stlUrl ? `${stlUrl}?v=${stlVersion}` : null;
+    const splitUrlsWithVersion = stlUrls.length > 0 ? stlUrls.map((u) => `${u}?v=${stlVersion}`) : null;
+    const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null;
+    const binW = config.grid_x * GRID_UNIT;
+    const binH = config.grid_y * GRID_UNIT;
+    const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0;
+    const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl;
+
+    return (
+        <div className="h-[calc(100vh-44px)] flex">
+            {/* config sidebar - always open */}
+            <div className="w-[200px] flex-shrink-0 bg-surface border-r border-border flex flex-col">
+                <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-3 space-y-3">
+                    <div className="glass rounded-[10px] px-3 py-3">
+                        <div className="flex items-center gap-2 mb-3">
+                            <Breadcrumb
+                                segments={[
+                                    { label: projectSource.rootLabel, href: projectSource.rootHref },
+                                    { label: name || "Untitled", editable: true, onEdit: (v) => setName(v) },
+                                ]}
+                            />
+                            {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
+                            {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
+                        </div>
+                        <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
+                        <div className="mt-3 border-t border-border pt-3 space-y-1.5">
+                            <div className="flex gap-1.5">
+                                <button type="button" onClick={handleSaveDefaults} className="btn-secondary flex-1 px-2 py-1.5 text-[11px]">
+                                    Save as default
+                                </button>
+                                <button type="button" onClick={handleResetDefaults} className="btn-secondary px-2 py-1.5 text-[11px]" title="Reset this bin and saved defaults">
+                                    Reset
+                                </button>
+                            </div>
+                            {defaultsStatus && <p className="text-[10px] text-text-muted">{defaultsStatus}</p>}
+                        </div>
+                    </div>
+
+                    <div className="glass rounded-[10px] px-3 py-3">
+                        <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px] mb-2">Dimensions</h3>
+                        <div className="text-[11px] text-text-secondary space-y-0.5">
+                            <div className="flex justify-between">
+                                <span>Width</span>
+                                <span>{binW} mm</span>
+                            </div>
+                            <div className="flex justify-between">
+                                <span>Depth</span>
+                                <span>{binH} mm</span>
+                            </div>
+                            <div className="flex justify-between">
+                                <span>Height</span>
+                                <span>{(config.height_units * 7 + 5 + effectiveRimUnits * 7 + (config.stacking_lip ? 4.4 : 0)).toFixed(1)} mm</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-              )}
-              {stlUrlWithVersion ? (
-                <BinPreview3D stlUrl={stlUrlWithVersion} splitUrls={splitUrlsWithVersion || undefined} insertUrl={insertUrlWithVersion || undefined} />
-              ) : (
-                <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2">
-                  {generating ? (
-                    <>
-                      <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
-                      <span>Generating...</span>
-                    </>
-                  ) : placedTools.length === 0 ? (
-                    <span>Add tools to see preview</span>
-                  ) : (
-                    <span>Preview will appear here</span>
-                  )}
+
+                {/* export buttons */}
+                <div className="p-3 flex-shrink-0 space-y-1.5">
+                    {error && <Alert variant="error">{error}</Alert>}
+                    {warning && <InfoBanner>{warning}</InfoBanner>}
+                    {splitCount > 1 && <InfoBanner>Split into {splitCount} pieces</InfoBanner>}
+                    {hasExports && (
+                        <div className="relative" ref={exportRef}>
+                            <button onClick={() => setExportOpen((p) => !p)} className="btn-primary w-full py-2 text-[11px] font-medium inline-flex items-center justify-center gap-1 cursor-pointer">
+                                <Download className="w-3.5 h-3.5" />
+                                Export
+                                <ChevronDown className="w-3 h-3" />
+                            </button>
+                            {exportOpen && (
+                                <div className="absolute bottom-full left-0 right-0 mb-1.5 bg-surface border border-border rounded-lg py-1 z-30 shadow-xl">
+                                    {stlUrl && (
+                                        <button
+                                            onClick={() => {
+                                                handleDownload();
+                                                setExportOpen(false);
+                                            }}
+                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                                        >
+                                            <Package className="w-3 h-3" />
+                                            {zipUrl ? "Full STL" : "STL"}
+                                        </button>
+                                    )}
+                                    {zipUrl && (
+                                        <button
+                                            onClick={() => {
+                                                handleDownloadZip();
+                                                setExportOpen(false);
+                                            }}
+                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                                        >
+                                            <Package className="w-3 h-3" />
+                                            ZIP ({splitCount} parts)
+                                        </button>
+                                    )}
+                                    {threemfUrl && (
+                                        <button
+                                            onClick={() => {
+                                                handleDownloadThreemf();
+                                                setExportOpen(false);
+                                            }}
+                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                                        >
+                                            <Package className="w-3 h-3" />
+                                            3MF
+                                        </button>
+                                    )}
+                                    {insertStlUrl && (
+                                        <button
+                                            onClick={() => {
+                                                handleDownloadInsert();
+                                                setExportOpen(false);
+                                            }}
+                                            className="w-full text-left px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-hover hover:text-text-primary transition-colors cursor-pointer flex items-center gap-2"
+                                        >
+                                            <Package className="w-3 h-3" />
+                                            Insert STL
+                                        </button>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </div>
-              )}
             </div>
-          </div>
+
+            {/* right of sidebar: library on top, then canvas + 3D preview below */}
+            <div className="flex-1 min-w-0 flex flex-col">
+                {/* library strip - full width */}
+                <div className="flex-shrink-0 bg-surface border-b border-border px-3 py-2">
+                    <ToolBrowser
+                        onAddTool={handleAddTool}
+                        binWidthMm={binW}
+                        binHeightMm={binH}
+                        layout="horizontal"
+                        projectId={projectSource.projectId}
+                        currentToolIds={placedTools.map((tool) => tool.tool_id)}
+                    />
+                </div>
+
+                {/* canvas + 3D preview side by side, equal width */}
+                <div className="flex-1 min-h-0 flex">
+                    {/* canvas */}
+                    <div className="flex-1 min-w-0 relative bg-inset overflow-hidden" data-testid="bin-editor">
+                        <div className="absolute inset-0">
+                            <BinEditor
+                                placedTools={placedTools}
+                                onPlacedToolsChange={handlePlacedToolsChange}
+                                textLabels={textLabels}
+                                onTextLabelsChange={setTextLabels}
+                                gridX={config.grid_x}
+                                gridY={config.grid_y}
+                                wallThickness={config.wall_thickness}
+                                defaultCutoutDepth={config.cutout_depth}
+                                maxCutoutDepth={calcMaxCutoutDepth(config.height_units, config.stacking_lip)}
+                                halfGridBase={config.half_grid_base}
+                                partialBins={config.partial_bins}
+                                partialBinsValues={config.partial_bins_values}
+                                onEditTool={(toolId) => router.push(projectSource.scopedHref(`/tools/${toolId}`))}
+                                smoothedToolIds={smoothedToolIds}
+                                onToggleSmoothed={handleToggleSmoothed}
+                                smoothLevels={smoothLevels}
+                                onSmoothLevelChange={handleSmoothLevelChange}
+                                onDraggingChange={setIsDragging}
+                            />
+                        </div>
+
+                        {/* floating bottom bar */}
+                        <div className="absolute bottom-3.5 left-3.5 right-3.5 z-20 glass-toolbar px-3 py-2 flex items-center justify-between">
+                            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                                {generating && <Loader2 className="w-3 h-3 animate-spin text-accent" />}
+                                <span>
+                                    {config.grid_x}x{config.grid_y} Grid ({binW} x {binH} mm)
+                                </span>
+                                {placedTools.length > 0 && (
+                                    <span>
+                                        · {placedTools.length} tool{placedTools.length !== 1 ? "s" : ""} placed
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+
+                        {error && (
+                            <div className="absolute top-14 left-3.5 z-20 max-w-sm">
+                                <Alert variant="error">{error}</Alert>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* 3D preview - same width as canvas */}
+                    <div className="flex-1 min-w-0 bg-surface border-l border-border flex flex-col">
+                        <div className="px-3 py-2 border-b border-border flex-shrink-0">
+                            <h3 className="text-[10px] font-semibold text-text-muted uppercase tracking-[1.5px]">3D Preview</h3>
+                        </div>
+                        <div className="flex-1 min-h-0 relative bg-inset">
+                            {generating && (
+                                <div className="absolute inset-x-0 bottom-0 z-10">
+                                    <div className="h-1 w-full overflow-hidden bg-blue-950">
+                                        <div className="h-full w-1/3 bg-blue-500 rounded-full animate-[slide_1.2s_ease-in-out_infinite]" />
+                                    </div>
+                                </div>
+                            )}
+                            {stlUrlWithVersion ? (
+                                <BinPreview3D stlUrl={stlUrlWithVersion} splitUrls={splitUrlsWithVersion || undefined} insertUrl={insertUrlWithVersion || undefined} />
+                            ) : (
+                                <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2">
+                                    {generating ? (
+                                        <>
+                                            <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
+                                            <span>Generating...</span>
+                                        </>
+                                    ) : placedTools.length === 0 ? (
+                                        <span>Add tools to see preview</span>
+                                    ) : (
+                                        <span>Preview will appear here</span>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  )
+    );
 }

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -247,7 +247,7 @@ export default function BinPage() {
         ),
       })))
     }
-    }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base]);
+  }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
 
   const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
     try {

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -49,7 +49,7 @@ function Toggle({ checked, onChange, label, help, disabled }: { checked: boolean
         disabled={disabled}
         onClick={() => onChange(!checked)}
         className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${
-          checked ? "bg-accent" : "bg-elevated"
+          checked ? 'bg-accent' : 'bg-elevated'
         }`}
       >
         <span
@@ -268,7 +268,7 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
           help="Holes in the base for magnets. Keeps bins locked to the baseplate."
           disabled={config.half_grid_base}
         />
-        {config.half_grid_base && ( 
+        {config.half_grid_base && (
           <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">
             Magnet holes are not compatible with half-grid base cells
           </p>

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -1,348 +1,392 @@
-'use client'
+"use client";
 
-import { Info } from 'lucide-react'
-import type { BinConfig } from '@/types'
-import { NumericInput } from '@/components/NumericInput'
-import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from '@/lib/settings'
+import { Info } from "lucide-react";
+import type { BinConfig } from "@/types";
+import { NumericInput } from "@/components/NumericInput";
+import { createPartialBinsValues } from "@/lib/binDefaults";
+import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from "@/lib/settings";
+import { cn } from "@/lib/utils";
+import { ClassValue } from "clsx";
 
-const GF_HEIGHT_UNIT = 7.0
-const GF_BASE_HEIGHT = 4.75
+const GF_HEIGHT_UNIT = 7.0;
+const GF_BASE_HEIGHT = 4.75;
 // lip_d3 (1.2) + lip_d4 (2.6)
-const LIP_NOTCH_DEPTH = 3.8
+const LIP_NOTCH_DEPTH = 3.8;
 
 export function calcMaxCutoutDepth(heightUnits: number, stackingLip: boolean): number {
-  const wallTopZ = heightUnits * GF_HEIGHT_UNIT
-  const lipDeduction = stackingLip ? LIP_NOTCH_DEPTH : 0
-  return Math.max(5, wallTopZ - GF_BASE_HEIGHT - 2 - lipDeduction)
+    const wallTopZ = heightUnits * GF_HEIGHT_UNIT;
+    const lipDeduction = stackingLip ? LIP_NOTCH_DEPTH : 0;
+    return Math.max(5, wallTopZ - GF_BASE_HEIGHT - 2 - lipDeduction);
 }
 
 interface Props {
-  config: BinConfig
-  onChange: (config: BinConfig) => void
-  autoSize?: boolean
-  onAutoSizeChange?: (v: boolean) => void
+    config: BinConfig;
+    onChange: (config: BinConfig) => void;
+    autoSize?: boolean;
+    onAutoSizeChange?: (v: boolean) => void;
 }
 
 function HelpTip({ text }: { text: string }) {
-  return (
-    <span className="group ml-1">
-      <Info className="w-3 h-3 text-text-muted cursor-help inline-block" />
-      <span className="absolute left-0 right-0 bottom-full mb-1.5 px-2 py-1.5 text-[11px] leading-tight text-text-primary bg-elevated border border-border-subtle rounded whitespace-normal opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-30 shadow-lg">
-        {text}
-      </span>
-    </span>
-  )
+    return (
+        <span className="group ml-1">
+            <Info className="w-3 h-3 text-text-muted cursor-help inline-block" />
+            <span className="absolute left-0 right-0 bottom-full mb-1.5 px-2 py-1.5 text-[11px] leading-tight text-text-primary bg-elevated border border-border-subtle rounded whitespace-normal opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-30 shadow-lg">
+                {text}
+            </span>
+        </span>
+    );
 }
 
 function Toggle({ checked, onChange, label, help, disabled }: { checked: boolean; onChange: (v: boolean) => void; label: string; help?: string; disabled?: boolean }) {
-  return (
-    <div className={`relative flex items-center justify-between py-2 ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
-      <span className="text-xs text-text-primary tracking-[0.3px]">
-        {label}
-        {help && <HelpTip text={help} />}
-      </span>
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${
-          checked ? 'bg-accent' : 'bg-elevated'
-        }`}
-      >
-        <span
-          className={`inline-block h-3.5 w-3.5 rounded-sm transition-transform ${
-            checked ? 'translate-x-[18px]' : 'translate-x-[3px]'
-          }`}
-          style={{
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: checked ? '#3096bc' : '#334155',
-            backgroundColor: checked ? '#fff' : 'rgba(235,236,236,0.3)',
-            boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
-          }}
-        />
-      </button>
-    </div>
-  )
+    return (
+        <div className={`relative flex items-center justify-between py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
+            <span className="text-xs text-text-primary tracking-[0.3px]">
+                {label}
+                {help && <HelpTip text={help} />}
+            </span>
+            <button
+                type="button"
+                disabled={disabled}
+                onClick={() => onChange(!checked)}
+                className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${checked ? "bg-accent" : "bg-elevated"}`}
+            >
+                <span
+                    className={`inline-block h-3.5 w-3.5 rounded-sm transition-transform ${checked ? "translate-x-[18px]" : "translate-x-[3px]"}`}
+                    style={{
+                        borderWidth: "1px",
+                        borderStyle: "solid",
+                        borderColor: checked ? "#3096bc" : "#334155",
+                        backgroundColor: checked ? "#fff" : "rgba(235,236,236,0.3)",
+                        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+                    }}
+                />
+            </button>
+        </div>
+    );
 }
 
 function SliderRow({
-  label,
-  value,
-  min,
-  max,
-  step = 1,
-  unit,
-  help,
-  onChange,
-  disabled,
+    label,
+    value,
+    min,
+    max,
+    step = 1,
+    unit,
+    help,
+    onChange,
+    disabled,
 }: {
-  label: string
-  value: number
-  min: number
-  max: number
-  step?: number
-  unit?: string
-  help?: string
-  onChange: (v: number) => void
-  disabled?: boolean
+    label: string;
+    value: number;
+    min: number;
+    max: number;
+    step?: number;
+    unit?: string;
+    help?: string;
+    onChange: (v: number) => void;
+    disabled?: boolean;
 }) {
-  const pct = ((value - min) / (max - min)) * 100
+    const pct = ((value - min) / (max - min)) * 100;
 
-  return (
-    <div className={`relative space-y-1.5 py-2 ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
-      <span className="text-xs text-text-primary tracking-[0.3px]">
-        {label}
-        {help && <HelpTip text={help} />}
-      </span>
-      <div className="flex items-center gap-2">
-        <input
-          type="range"
-          min={min}
-          max={max}
-          step={step}
-          value={value}
-          disabled={disabled}
-          onChange={(e) => {
-            const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value)
-            onChange(v)
-          }}
-          className="flex-1 min-w-0"
-          style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
-        />
-        <div className="flex items-center gap-1">
-          <NumericInput
-            min={min}
-            max={max}
-            step={step}
-            value={value}
-            disabled={disabled}
-            onChange={onChange}
-            className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
-          />
-          {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}
+    return (
+        <div className={`relative space-y-1.5 py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
+            <span className="text-xs text-text-primary tracking-[0.3px]">
+                {label}
+                {help && <HelpTip text={help} />}
+            </span>
+            <div className="flex items-center gap-2">
+                <input
+                    type="range"
+                    min={min}
+                    max={max}
+                    step={step}
+                    value={value}
+                    disabled={disabled}
+                    onChange={(e) => {
+                        const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value);
+                        onChange(v);
+                    }}
+                    className="flex-1 min-w-0"
+                    style={{ "--slider-pct": `${pct}%` } as React.CSSProperties}
+                />
+                <div className="flex items-center gap-1">
+                    <NumericInput
+                        min={min}
+                        max={max}
+                        step={step}
+                        value={value}
+                        disabled={disabled}
+                        onChange={onChange}
+                        className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
+                    />
+                    {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  )
+    );
+}
+
+function RadioMatrix({ sizeX, sizeY, values, onChange }: { sizeX: number; sizeY: number; values: boolean[]; onChange: (v: boolean[]) => void }) {
+    let containerClasses: ClassValue = "gap-1 p-1 mx-1 rounded-md w-1/3";
+    if (sizeX > 1) containerClasses = "gap-1 p-1 mx-1 rounded-sm w-1/2";
+    if (sizeX > 2) containerClasses = "gap-1 p-1 mx-1 rounded-sm";
+    if (sizeX > 4) containerClasses = "gap-px p-0 mx-0 rounded-sm";
+
+    return (
+        <div className={cn("grid bg-base p-2 mx-2 rounded-md", containerClasses)} style={{ gridTemplateColumns: `repeat(${sizeX}, 1fr)`, gridTemplateRows: `repeat(${sizeY}, 1fr)` }}>
+            {values.map((value, index) => (
+                <button
+                    key={index}
+                    onClick={() => onChange(values.map((v, i) => (i === index ? !v : v)))}
+                    className={cn("w-full border-2 aspect-square border-muted min-w-3", value ? "bg-accent border-accent" : "bg-elevated border-muted", sizeX > 4 ? "rounded-[2px]" : "rounded-sm")}
+                ></button>
+            ))}
+        </div>
+    );
 }
 
 export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }: Props) {
-  function update(partial: Partial<BinConfig>) {
-    onChange({ ...config, ...partial })
-  }
+    function update(partial: Partial<BinConfig>) {
+        onChange({ ...config, ...partial });
+    }
 
-  const maxCutoutDepth = calcMaxCutoutDepth(config.height_units, config.stacking_lip)
-  const binWidth = config.grid_x * 42
-  const binDepth = config.grid_y * 42
-  const needsSplit = config.bed_size > 0 && (binWidth > config.bed_size || binDepth > config.bed_size)
+    const maxCutoutDepth = calcMaxCutoutDepth(config.height_units, config.stacking_lip);
+    const binWidth = config.grid_x * 42;
+    const binDepth = config.grid_y * 42;
+    const needsSplit = config.bed_size > 0 && (binWidth > config.bed_size || binDepth > config.bed_size);
+    const exportsSeparateParts =
+        config.partial_bins &&
+        !config.partial_bins_connect &&
+        config.partial_bins_values.some((enabled) => !enabled);
 
-  return (
-    <div className="space-y-0">
-      {onAutoSizeChange && (
-        <Toggle
-          label="Auto-size grid"
-          help="Automatically fit grid to placed tools. Turn off to set grid size manually."
-          checked={!!autoSize}
-          onChange={onAutoSizeChange}
-        />
-      )}
+    return (
+        <div className="space-y-0">
+            {onAutoSizeChange && <Toggle label="Auto-size grid" help="Automatically fit grid to placed tools. Turn off to set grid size manually." checked={!!autoSize} onChange={onAutoSizeChange} />}
 
-      <SliderRow
-        label="Grid Width"
-        help="Bin width in gridfinity units (42mm each). Half-unit increments (21mm) supported."
-        value={config.grid_x}
-        min={1}
-        max={10}
-        step={0.5}
-        unit="u"
-        onChange={(v) => update({ grid_x: v })}
-        disabled={autoSize}
-      />
-
-      <SliderRow
-        label="Grid Depth"
-        help="Bin depth in gridfinity units (42mm each). Half-unit increments (21mm) supported."
-        value={config.grid_y}
-        min={1}
-        max={10}
-        step={0.5}
-        unit="u"
-        onChange={(v) => update({ grid_y: v })}
-        disabled={autoSize}
-      />
-
-      <SliderRow
-        label="Height"
-        help="Bin height in gridfinity units. Each unit is 7mm, plus a 4.75mm base."
-        value={config.height_units}
-        min={1}
-        max={20}
-        unit="u"
-        onChange={(v) => {
-          const newMax = calcMaxCutoutDepth(v, config.stacking_lip)
-          update({ height_units: v, cutout_depth: Math.min(config.cutout_depth, newMax) })
-        }}
-      />
-
-      <SliderRow
-        label="Cutout Depth"
-        help={`How deep the tool pocket is cut into the bin. Max ${maxCutoutDepth.toFixed(1)}mm at ${config.height_units}u height.`}
-        value={Math.min(config.cutout_depth, maxCutoutDepth)}
-        min={5}
-        max={maxCutoutDepth}
-        step={0.5}
-        unit="mm"
-        onChange={(v) => update({ cutout_depth: v })}
-      />
-
-      <SliderRow
-        label="Clearance"
-        help="Extra space around tool outlines. Increase if tools fit too tightly."
-        value={config.cutout_clearance}
-        min={0}
-        max={5}
-        step={0.1}
-        unit="mm"
-        onChange={(v) => update({ cutout_clearance: v })}
-      />
-
-      <SliderRow
-        label="Cutout Chamfer"
-        help="Bevel distance on the top edge of each tool pocket, in mm. 0 = sharp edge."
-        value={config.cutout_chamfer}
-        min={0}
-        max={3}
-        step={0.1}
-        unit="mm"
-        onChange={(v) => update({ cutout_chamfer: v })}
-      />
-
-      <div className="border-t border-border mt-2 pt-1">
-        <Toggle
-          checked={config.half_grid_base}
-          onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
-          label="Half-grid base"
-          help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
-        />
-        <Toggle
-          checked={config.magnets && !config.half_grid_base}
-          onChange={(v) => update({ magnets: v })}
-          label="Magnet holes"
-          help="Holes in the base for magnets. Keeps bins locked to the baseplate."
-          disabled={config.half_grid_base}
-        />
-        {config.half_grid_base && (
-          <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">
-            Magnet holes are not compatible with half-grid base cells
-          </p>
-        )}
-        {config.magnets && !config.half_grid_base && (
-          <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
             <SliderRow
-              label="Diameter"
-              value={config.magnet_diameter}
-              min={3}
-              max={10}
-              step={0.5}
-              unit="mm"
-              onChange={(v) => update({ magnet_diameter: v })}
+                label="Grid Width"
+                help="Bin width in gridfinity units (42mm each). Half-unit increments (21mm) supported."
+                value={config.grid_x}
+                min={1}
+                max={10}
+                step={0.5}
+                unit="u"
+                onChange={(v) =>
+                    update({
+                        grid_x: v,
+                        partial_bins_values: createPartialBinsValues(v, config.grid_y),
+                    })
+                }
+                disabled={autoSize}
             />
-            <SliderRow
-              label="Depth"
-              value={config.magnet_depth}
-              min={1}
-              max={5}
-              step={0.1}
-              unit="mm"
-              onChange={(v) => update({ magnet_depth: v })}
-            />
-            <Toggle
-              checked={config.magnet_corners_only}
-              onChange={(v) => update({ magnet_corners_only: v })}
-              label="Corners only"
-              help="Only place magnet holes at the 4 outer corners of the bin."
-            />
-          </div>
-        )}
-        <Toggle
-          checked={config.stacking_lip}
-          onChange={(v) => {
-            const newMax = calcMaxCutoutDepth(config.height_units, v)
-            update({
-              stacking_lip: v,
-              rim_units: v ? config.rim_units : 0,
-              cutout_depth: Math.min(config.cutout_depth, newMax),
-            })
-          }}
-          label="Stacking lip"
-          help="Raised rim at the top so bins can stack securely on top of each other."
-        />
-        {config.stacking_lip && (
-          <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
-            <SliderRow
-              label="Raise Lip"
-              help="Extends the wall and lip this many units (7mm each) above the floor face, leaving the interior open. Lets a tool protrude above the floor while a stacked bin still clears it. 0 = standard."
-              value={config.rim_units}
-              min={0}
-              max={10}
-              unit="u"
-              onChange={(v) => update({ rim_units: v })}
-            />
-          </div>
-        )}
-        <Toggle
-          checked={config.insert_enabled}
-          onChange={(v) => update({ insert_enabled: v })}
-          label="Contrast Insert"
-          help="Generates a separate insert STL to print in a contrasting colour. The pocket is deepened to accommodate it."
-        />
-        {config.insert_enabled && (
-          <>
-            <SliderRow
-              label="Insert Height"
-              help="Thickness of the insert in mm."
-              value={config.insert_height}
-              min={0.5}
-              max={10}
-              step={0.1}
-              unit="mm"
-              onChange={(v) => update({ insert_height: v })}
-            />
-            <SliderRow
-              label="Insert Fit"
-              help="Clearance shaved off the insert edges so it drops into the pocket."
-              value={config.insert_clearance}
-              min={0}
-              max={1}
-              step={0.05}
-              unit="mm"
-              onChange={(v) => update({ insert_clearance: v })}
-            />
-          </>
-        )}
-      </div>
 
-      <div className="border-t border-border mt-2 pt-1">
-        <SliderRow
-          label="Bed Size"
-          help="Print bed size. Bins wider than this are automatically split into pieces."
-          value={config.bed_size}
-          min={BED_SIZE_MIN_MM}
-          max={BED_SIZE_MAX_MM}
-          step={1}
-          unit="mm"
-          onChange={(v) => update({ bed_size: v })}
-        />
-        {needsSplit && (
-          <div className="text-[11px] text-amber-400 mt-1 leading-tight">
-            {binWidth > config.bed_size && `Width ${binWidth}mm exceeds bed`}
-            {binWidth > config.bed_size && binDepth > config.bed_size && ' & '}
-            {binDepth > config.bed_size && `Depth ${binDepth}mm exceeds bed`}
-            {' \u2014 will be split'}
-          </div>
-        )}
-      </div>
-    </div>
-  )
+            <SliderRow
+                label="Grid Depth"
+                help="Bin depth in gridfinity units (42mm each). Half-unit increments (21mm) supported."
+                value={config.grid_y}
+                min={1}
+                max={10}
+                step={0.5}
+                unit="u"
+                onChange={(v) =>
+                    update({
+                        grid_y: v,
+                        partial_bins_values: createPartialBinsValues(config.grid_x, v),
+                    })
+                }
+                disabled={autoSize}
+            />
+
+            <SliderRow
+                label="Height"
+                help="Bin height in gridfinity units. Each unit is 7mm, plus a 4.75mm base."
+                value={config.height_units}
+                min={1}
+                max={20}
+                unit="u"
+                onChange={(v) => {
+                    const newMax = calcMaxCutoutDepth(v, config.stacking_lip);
+                    update({ height_units: v, cutout_depth: Math.min(config.cutout_depth, newMax) });
+                }}
+            />
+
+            <SliderRow
+                label="Cutout Depth"
+                help={`How deep the tool pocket is cut into the bin. Max ${maxCutoutDepth.toFixed(1)}mm at ${config.height_units}u height.`}
+                value={Math.min(config.cutout_depth, maxCutoutDepth)}
+                min={5}
+                max={maxCutoutDepth}
+                step={0.5}
+                unit="mm"
+                onChange={(v) => update({ cutout_depth: v })}
+            />
+
+            <SliderRow
+                label="Clearance"
+                help="Extra space around tool outlines. Increase if tools fit too tightly."
+                value={config.cutout_clearance}
+                min={0}
+                max={5}
+                step={0.1}
+                unit="mm"
+                onChange={(v) => update({ cutout_clearance: v })}
+            />
+
+            <SliderRow
+                label="Cutout Chamfer"
+                help="Bevel distance on the top edge of each tool pocket, in mm. 0 = sharp edge."
+                value={config.cutout_chamfer}
+                min={0}
+                max={3}
+                step={0.1}
+                unit="mm"
+                onChange={(v) => update({ cutout_chamfer: v })}
+            />
+
+            <div className="border-t border-border mt-2 pt-1">
+                <Toggle
+                    checked={config.half_grid_base}
+                    onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
+                    label="Half-grid base"
+                    help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
+                />
+                <Toggle
+                    checked={config.magnets && !config.half_grid_base}
+                    onChange={(v) => update({ magnets: v })}
+                    label="Magnet holes"
+                    help="Holes in the base for magnets. Keeps bins locked to the baseplate."
+                    disabled={config.half_grid_base}
+                />
+                {config.half_grid_base && (
+                    <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">
+                        Magnet holes are not compatible with half-grid base cells
+                    </p>
+                )}
+                {config.magnets && !config.half_grid_base && (
+                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+                        <SliderRow label="Diameter" value={config.magnet_diameter} min={3} max={10} step={0.5} unit="mm" onChange={(v) => update({ magnet_diameter: v })} />
+                        <SliderRow label="Depth" value={config.magnet_depth} min={1} max={5} step={0.1} unit="mm" onChange={(v) => update({ magnet_depth: v })} />
+                        <Toggle
+                            checked={config.magnet_corners_only}
+                            onChange={(v) => update({ magnet_corners_only: v })}
+                            label="Corners only"
+                            help="Only place magnet holes at the 4 outer corners of the bin."
+                        />
+                    </div>
+                )}
+                <Toggle
+                    checked={config.stacking_lip}
+                    onChange={(v) => {
+                        const newMax = calcMaxCutoutDepth(config.height_units, v);
+                        update({
+                            stacking_lip: v,
+                            rim_units: v ? config.rim_units : 0,
+                            cutout_depth: Math.min(config.cutout_depth, newMax),
+                        });
+                    }}
+                    label="Stacking lip"
+                    help="Raised rim at the top so bins can stack securely on top of each other."
+                />
+                {config.stacking_lip && (
+                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+                        <SliderRow
+                            label="Raise Lip"
+                            help="Extends the wall and lip this many units (7mm each) above the floor face, leaving the interior open. Lets a tool protrude above the floor while a stacked bin still clears it. 0 = standard."
+                            value={config.rim_units}
+                            min={0}
+                            max={10}
+                            unit="u"
+                            onChange={(v) => update({ rim_units: v })}
+                        />
+                    </div>
+                )}
+                <Toggle
+                    checked={config.insert_enabled}
+                    onChange={(v) => update({ insert_enabled: v })}
+                    label="Contrast Insert"
+                    help="Generates a separate insert STL to print in a contrasting colour. The pocket is deepened to accommodate it."
+                />
+                {config.insert_enabled && (
+                    <>
+                        <SliderRow
+                            label="Insert Height"
+                            help="Thickness of the insert in mm."
+                            value={config.insert_height}
+                            min={0.5}
+                            max={10}
+                            step={0.1}
+                            unit="mm"
+                            onChange={(v) => update({ insert_height: v })}
+                        />
+                        <SliderRow
+                            label="Insert Fit"
+                            help="Clearance shaved off the insert edges so it drops into the pocket."
+                            value={config.insert_clearance}
+                            min={0}
+                            max={1}
+                            step={0.05}
+                            unit="mm"
+                            onChange={(v) => update({ insert_clearance: v })}
+                        />
+                    </>
+                )}
+            </div>
+
+            <div className="border-t border-border mt-2 pt-1">
+                <SliderRow
+                    label="Bed Size"
+                    help="Print bed size. Bins wider than this are automatically split into pieces."
+                    value={config.bed_size}
+                    min={BED_SIZE_MIN_MM}
+                    max={BED_SIZE_MAX_MM}
+                    step={1}
+                    unit="mm"
+                    onChange={(v) => update({ bed_size: v })}
+                />
+                {needsSplit && (
+                    <div className="text-[11px] text-amber-400 mt-1 leading-tight">
+                        {binWidth > config.bed_size && `Width ${binWidth}mm exceeds bed`}
+                        {binWidth > config.bed_size && binDepth > config.bed_size && " & "}
+                        {binDepth > config.bed_size && `Depth ${binDepth}mm exceeds bed`}
+                        {" \u2014 will be split"}
+                    </div>
+                )}
+            </div>
+
+            <div className="border-t border-border mt-2 pt-1">
+                <Toggle
+                    checked={config.partial_bins}
+                    onChange={(v) =>
+                        update({
+                            partial_bins: v,
+                            ...(!v ? { partial_bins_connect: false } : {}),
+                        })
+                    }
+                    label="Partial Bins"
+                    help="Print only parts of the bin that are needed to hold the tools."
+                />
+                {config.partial_bins && (
+                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+                        <RadioMatrix
+                            sizeX={Math.ceil(config.grid_x)}
+                            sizeY={Math.ceil(config.grid_y)}
+                            values={config.partial_bins_values}
+                            onChange={(v) => update({ partial_bins_values: v })}
+                        />
+                        <Toggle
+                            checked={config.partial_bins_connect}
+                            onChange={(v) => update({ partial_bins_connect: v })}
+                            label="Connect base"
+                            help="Remove walls in disabled cells, bridge them with a thin base plate, and keep one connected print."
+                        />
+                        {exportsSeparateParts && (
+                            <div className="text-[11px] text-amber-400 mt-1 leading-tight">
+                                Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
 }

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -359,7 +359,7 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
                     onChange={(v) =>
                         update({
                             partial_bins: v,
-                            ...(!v ? { partial_bins_connect: false } : {}),
+                            ...(!v ? { partial_bins_connect: false, partial_bins_retain_wall: false } : {}),
                         })
                     }
                     label="Partial Bins"
@@ -375,10 +375,23 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
                         />
                         <Toggle
                             checked={config.partial_bins_connect}
-                            onChange={(v) => update({ partial_bins_connect: v })}
+                            onChange={(v) =>
+                                update({
+                                    partial_bins_connect: v,
+                                    ...(!v ? { partial_bins_retain_wall: false } : {}),
+                                })
+                            }
                             label="Connect base"
                             help="Remove walls in disabled cells, bridge them with a thin base plate, and keep one connected print."
                         />
+                        {config.partial_bins_connect && (
+                            <Toggle
+                                checked={config.partial_bins_retain_wall}
+                                onChange={(v) => update({ partial_bins_retain_wall: v })}
+                                label="Retain outer wall"
+                                help="Keep the bin perimeter wall through disabled cells while still connecting them on the base."
+                            />
+                        )}
                         {exportsSeparateParts && (
                             <div className="text-[11px] text-amber-400 mt-1 leading-tight">
                                 Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -39,16 +39,18 @@ function HelpTip({ text }: { text: string }) {
 
 function Toggle({ checked, onChange, label, help, disabled }: { checked: boolean; onChange: (v: boolean) => void; label: string; help?: string; disabled?: boolean }) {
   return (
-    <div className={`relative flex items-center justify-between py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
+    <div className={`relative flex items-center justify-between py-2 ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
       <span className="text-xs text-text-primary tracking-[0.3px]">
         {label}
         {help && <HelpTip text={help} />}
       </span>
       <button
-          type="button"
-          disabled={disabled}
-          onClick={() => onChange(!checked)}
-          className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${checked ? "bg-accent" : "bg-elevated"}`}
+        type="button"
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${
+          checked ? "bg-accent" : "bg-elevated"
+        }`}
       >
         <span
           className={`inline-block h-3.5 w-3.5 rounded-sm transition-transform ${
@@ -253,47 +255,51 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
       />
 
       <div className="border-t border-border mt-2 pt-1">
-          <Toggle
-              checked={config.half_grid_base}
-              onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
-              label="Half-grid base"
-              help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
-          />
-          <Toggle
-              checked={config.magnets && !config.half_grid_base}
-              onChange={(v) => update({ magnets: v })}
-              label="Magnet holes"
-              help="Holes in the base for magnets. Keeps bins locked to the baseplate."
-              disabled={config.half_grid_base}
-          />
-          {config.half_grid_base && <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">Magnet holes are not compatible with half-grid base cells</p>}
-          {config.magnets && !config.half_grid_base && (
-              <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
-                <SliderRow
-                  label="Diameter"
-                  value={config.magnet_diameter}
-                  min={3}
-                  max={10}
-                  step={0.5}
-                  unit="mm"
-                  onChange={(v) => update({ magnet_diameter: v })}
-                />
-                <SliderRow
-                  label="Depth"
-                  value={config.magnet_depth}
-                  min={1}
-                  max={5}
-                  step={0.1}
-                  unit="mm"
-                  onChange={(v) => update({ magnet_depth: v })}
-                />
-                <Toggle
-                  checked={config.magnet_corners_only}
-                  onChange={(v) => update({ magnet_corners_only: v })}
-                  label="Corners only"
-                  help="Only place magnet holes at the 4 outer corners of the bin."
-                />
-              </div>
+        <Toggle
+          checked={config.half_grid_base}
+          onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
+          label="Half-grid base"
+          help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
+        />
+        <Toggle
+          checked={config.magnets && !config.half_grid_base}
+          onChange={(v) => update({ magnets: v })}
+          label="Magnet holes"
+          help="Holes in the base for magnets. Keeps bins locked to the baseplate."
+          disabled={config.half_grid_base}
+        />
+        {config.half_grid_base && ( 
+          <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">
+            Magnet holes are not compatible with half-grid base cells
+          </p>
+        )}
+        {config.magnets && !config.half_grid_base && (
+          <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+            <SliderRow
+              label="Diameter"
+              value={config.magnet_diameter}
+              min={3}
+              max={10}
+              step={0.5}
+              unit="mm"
+              onChange={(v) => update({ magnet_diameter: v })}
+            />
+            <SliderRow
+              label="Depth"
+              value={config.magnet_depth}
+              min={1}
+              max={5}
+              step={0.1}
+              unit="mm"
+              onChange={(v) => update({ magnet_depth: v })}
+            />
+            <Toggle
+              checked={config.magnet_corners_only}
+              onChange={(v) => update({ magnet_corners_only: v })}
+              label="Corners only"
+              help="Only place magnet holes at the 4 outer corners of the bin."
+            />
+          </div>
         )}
         <Toggle
           checked={config.stacking_lip}

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -1,408 +1,417 @@
-"use client";
+'use client'
 
-import { Info } from "lucide-react";
-import type { BinConfig } from "@/types";
-import { NumericInput } from "@/components/NumericInput";
-import { createPartialBinsValues } from "@/lib/binDefaults";
-import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from "@/lib/settings";
-import { cn } from "@/lib/utils";
-import { ClassValue } from "clsx";
+import { Info } from 'lucide-react'
+import type { BinConfig } from '@/types'
+import { NumericInput } from '@/components/NumericInput'
+import { createPartialBinsValues } from '@/lib/binDefaults'
+import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from '@/lib/settings'
+import { cn } from '@/lib/utils'
+import { ClassValue } from 'clsx'
 
-const GF_HEIGHT_UNIT = 7.0;
-const GF_BASE_HEIGHT = 4.75;
+const GF_HEIGHT_UNIT = 7.0
+const GF_BASE_HEIGHT = 4.75
 // lip_d3 (1.2) + lip_d4 (2.6)
-const LIP_NOTCH_DEPTH = 3.8;
+const LIP_NOTCH_DEPTH = 3.8
 
 export function calcMaxCutoutDepth(heightUnits: number, stackingLip: boolean): number {
-    const wallTopZ = heightUnits * GF_HEIGHT_UNIT;
-    const lipDeduction = stackingLip ? LIP_NOTCH_DEPTH : 0;
-    return Math.max(5, wallTopZ - GF_BASE_HEIGHT - 2 - lipDeduction);
+  const wallTopZ = heightUnits * GF_HEIGHT_UNIT
+  const lipDeduction = stackingLip ? LIP_NOTCH_DEPTH : 0
+  return Math.max(5, wallTopZ - GF_BASE_HEIGHT - 2 - lipDeduction)
 }
 
 interface Props {
-    config: BinConfig;
-    onChange: (config: BinConfig) => void;
-    autoSize?: boolean;
-    onAutoSizeChange?: (v: boolean) => void;
+  config: BinConfig
+  onChange: (config: BinConfig) => void
+  autoSize?: boolean
+  onAutoSizeChange?: (v: boolean) => void
 }
 
 function HelpTip({ text }: { text: string }) {
-    return (
-        <span className="group ml-1">
-            <Info className="w-3 h-3 text-text-muted cursor-help inline-block" />
-            <span className="absolute left-0 right-0 bottom-full mb-1.5 px-2 py-1.5 text-[11px] leading-tight text-text-primary bg-elevated border border-border-subtle rounded whitespace-normal opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-30 shadow-lg">
-                {text}
-            </span>
-        </span>
-    );
+  return (
+    <span className="group ml-1">
+      <Info className="w-3 h-3 text-text-muted cursor-help inline-block" />
+      <span className="absolute left-0 right-0 bottom-full mb-1.5 px-2 py-1.5 text-[11px] leading-tight text-text-primary bg-elevated border border-border-subtle rounded whitespace-normal opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-30 shadow-lg">
+        {text}
+      </span>
+    </span>
+  )
 }
 
 function Toggle({ checked, onChange, label, help, disabled }: { checked: boolean; onChange: (v: boolean) => void; label: string; help?: string; disabled?: boolean }) {
-    return (
-        <div className={`relative flex items-center justify-between py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
-            <span className="text-xs text-text-primary tracking-[0.3px]">
-                {label}
-                {help && <HelpTip text={help} />}
-            </span>
-            <button
-                type="button"
-                disabled={disabled}
-                onClick={() => onChange(!checked)}
-                className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${checked ? "bg-accent" : "bg-elevated"}`}
-            >
-                <span
-                    className={`inline-block h-3.5 w-3.5 rounded-sm transition-transform ${checked ? "translate-x-[18px]" : "translate-x-[3px]"}`}
-                    style={{
-                        borderWidth: "1px",
-                        borderStyle: "solid",
-                        borderColor: checked ? "#3096bc" : "#334155",
-                        backgroundColor: checked ? "#fff" : "rgba(235,236,236,0.3)",
-                        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
-                    }}
-                />
-            </button>
-        </div>
-    );
+  return (
+    <div className={`relative flex items-center justify-between py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
+      <span className="text-xs text-text-primary tracking-[0.3px]">
+        {label}
+        {help && <HelpTip text={help} />}
+      </span>
+      <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onChange(!checked)}
+          className={`relative inline-flex h-5 w-9 items-center rounded transition-colors ${checked ? "bg-accent" : "bg-elevated"}`}
+      >
+        <span
+          className={`inline-block h-3.5 w-3.5 rounded-sm transition-transform ${
+            checked ? 'translate-x-[18px]' : 'translate-x-[3px]'
+          }`}
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderColor: checked ? '#3096bc' : '#334155',
+            backgroundColor: checked ? '#fff' : 'rgba(235,236,236,0.3)',
+            boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+          }}
+        />
+      </button>
+    </div>
+  )
 }
 
 function SliderRow({
-    label,
-    value,
-    min,
-    max,
-    step = 1,
-    unit,
-    help,
-    onChange,
-    disabled,
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  unit,
+  help,
+  onChange,
+  disabled,
 }: {
-    label: string;
-    value: number;
-    min: number;
-    max: number;
-    step?: number;
-    unit?: string;
-    help?: string;
-    onChange: (v: number) => void;
-    disabled?: boolean;
+  label: string
+  value: number
+  min: number
+  max: number
+  step?: number
+  unit?: string
+  help?: string
+  onChange: (v: number) => void
+  disabled?: boolean
 }) {
-    const pct = ((value - min) / (max - min)) * 100;
+  const pct = ((value - min) / (max - min)) * 100
 
-    return (
-        <div className={`relative space-y-1.5 py-2 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
-            <span className="text-xs text-text-primary tracking-[0.3px]">
-                {label}
-                {help && <HelpTip text={help} />}
-            </span>
-            <div className="flex items-center gap-2">
-                <input
-                    type="range"
-                    min={min}
-                    max={max}
-                    step={step}
-                    value={value}
-                    disabled={disabled}
-                    onChange={(e) => {
-                        const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value);
-                        onChange(v);
-                    }}
-                    className="flex-1 min-w-0"
-                    style={{ "--slider-pct": `${pct}%` } as React.CSSProperties}
-                />
-                <div className="flex items-center gap-1">
-                    <NumericInput
-                        min={min}
-                        max={max}
-                        step={step}
-                        value={value}
-                        disabled={disabled}
-                        onChange={onChange}
-                        className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
-                    />
-                    {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}
-                </div>
-            </div>
+  return (
+    <div className={`relative space-y-1.5 py-2 ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
+      <span className="text-xs text-text-primary tracking-[0.3px]">
+        {label}
+        {help && <HelpTip text={help} />}
+      </span>
+      <div className="flex items-center gap-2">
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          disabled={disabled}
+          onChange={(e) => {
+            const v = step >= 1 ? parseInt(e.target.value) : parseFloat(e.target.value)
+            onChange(v)
+          }}
+          className="flex-1 min-w-0"
+          style={{ '--slider-pct': `${pct}%` } as React.CSSProperties}
+        />
+        <div className="flex items-center gap-1">
+          <NumericInput
+            min={min}
+            max={max}
+            step={step}
+            value={value}
+            disabled={disabled}
+            onChange={onChange}
+            className="w-14 h-7 bg-elevated text-right text-xs font-semibold text-text-primary rounded pr-2 focus:outline-none"
+          />
+          {unit && <span className="text-[10px] text-text-muted w-5">{unit}</span>}
         </div>
-    );
+      </div>
+    </div>
+  )
 }
 
 function RadioMatrix({ sizeX, sizeY, values, onChange }: { sizeX: number; sizeY: number; values: boolean[]; onChange: (v: boolean[]) => void }) {
-    let containerClasses: ClassValue = "gap-1 p-1 mx-1 rounded-md w-1/3";
-    if (sizeX > 1) containerClasses = "gap-1 p-1 mx-1 rounded-sm w-1/2";
-    if (sizeX > 2) containerClasses = "gap-1 p-1 mx-1 rounded-sm";
-    if (sizeX > 4) containerClasses = "gap-px p-0 mx-0 rounded-sm";
+  let containerClasses: ClassValue = "gap-1 p-1 mx-1 rounded-md w-1/3";
+  if (sizeX > 1) containerClasses = "gap-1 p-1 mx-1 rounded-sm w-1/2";
+  if (sizeX > 2) containerClasses = "gap-1 p-1 mx-1 rounded-sm";
+  if (sizeX > 4) containerClasses = "gap-px p-0 mx-0 rounded-sm";
 
-    return (
-        <div className={cn("grid bg-base p-2 mx-2 rounded-md", containerClasses)} style={{ gridTemplateColumns: `repeat(${sizeX}, 1fr)`, gridTemplateRows: `repeat(${sizeY}, 1fr)` }}>
-            {values.map((value, index) => (
-                <button
-                    key={index}
-                    onClick={() => {
-                        if (value && values.filter(Boolean).length <= 1) return;
-                        onChange(values.map((v, i) => (i === index ? !v : v)));
-                    }}
-                    className={cn("w-full border-2 aspect-square border-muted min-w-3", value ? "bg-accent border-accent" : "bg-elevated border-muted", sizeX > 4 ? "rounded-[2px]" : "rounded-sm")}
-                ></button>
-            ))}
-        </div>
-    );
+  return (
+      <div className={cn("grid bg-base p-2 mx-2 rounded-md", containerClasses)} style={{ gridTemplateColumns: `repeat(${sizeX}, 1fr)`, gridTemplateRows: `repeat(${sizeY}, 1fr)` }}>
+          {values.map((value, index) => (
+              <button
+                  key={index}
+                  onClick={() => {
+                      if (value && values.filter(Boolean).length <= 1) return;
+                      onChange(values.map((v, i) => (i === index ? !v : v)));
+                  }}
+                  className={cn("w-full border-2 aspect-square border-muted min-w-3", value ? "bg-accent border-accent" : "bg-elevated border-muted", sizeX > 4 ? "rounded-[2px]" : "rounded-sm")}
+              ></button>
+          ))}
+      </div>
+  );
 }
 
 export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }: Props) {
-    function update(partial: Partial<BinConfig>) {
-        onChange({ ...config, ...partial });
-    }
+  function update(partial: Partial<BinConfig>) {
+    onChange({ ...config, ...partial })
+  }
 
-    const maxCutoutDepth = calcMaxCutoutDepth(config.height_units, config.stacking_lip);
-    const binWidth = config.grid_x * 42;
-    const binDepth = config.grid_y * 42;
-    const needsSplit = config.bed_size > 0 && (binWidth > config.bed_size || binDepth > config.bed_size);
-    const exportsSeparateParts =
-        config.partial_bins &&
-        !config.partial_bins_connect &&
-        config.partial_bins_values.some((enabled) => !enabled);
+  const maxCutoutDepth = calcMaxCutoutDepth(config.height_units, config.stacking_lip)
+  const binWidth = config.grid_x * 42
+  const binDepth = config.grid_y * 42
+  const needsSplit = config.bed_size > 0 && (binWidth > config.bed_size || binDepth > config.bed_size)
+  const exportsSeparateParts = config.partial_bins && !config.partial_bins_connect && config.partial_bins_values.some((enabled) => !enabled);
 
-    return (
-        <div className="space-y-0">
-            {onAutoSizeChange && <Toggle label="Auto-size grid" help="Automatically fit grid to placed tools. Turn off to set grid size manually." checked={!!autoSize} onChange={onAutoSizeChange} />}
+  return (
+    <div className="space-y-0">
+      {onAutoSizeChange && (
+        <Toggle
+          label="Auto-size grid"
+          help="Automatically fit grid to placed tools. Turn off to set grid size manually."
+          checked={!!autoSize}
+          onChange={onAutoSizeChange}
+        />
+      )}
 
-            <SliderRow
-                label="Grid Width"
-                help="Bin width in gridfinity units (42mm each). Half-unit increments (21mm) supported."
-                value={config.grid_x}
-                min={1}
-                max={10}
-                step={0.5}
-                unit="u"
-                onChange={(v) =>
-                    update({
-                        grid_x: v,
-                        partial_bins_values: createPartialBinsValues(v, config.grid_y),
-                    })
-                }
-                disabled={autoSize}
-            />
+      <SliderRow
+        label="Grid Width"
+        help="Bin width in gridfinity units (42mm each). Half-unit increments (21mm) supported."
+        value={config.grid_x}
+        min={1}
+        max={10}
+        step={0.5}
+        unit="u"
+        onChange={(v) =>
+          update({
+              grid_x: v,
+              partial_bins_values: createPartialBinsValues(v, config.grid_y),
+          })
+        }
+        disabled={autoSize}
+      />
 
-            <SliderRow
-                label="Grid Depth"
-                help="Bin depth in gridfinity units (42mm each). Half-unit increments (21mm) supported."
-                value={config.grid_y}
-                min={1}
-                max={10}
-                step={0.5}
-                unit="u"
-                onChange={(v) =>
-                    update({
-                        grid_y: v,
-                        partial_bins_values: createPartialBinsValues(config.grid_x, v),
-                    })
-                }
-                disabled={autoSize}
-            />
+      <SliderRow
+        label="Grid Depth"
+        help="Bin depth in gridfinity units (42mm each). Half-unit increments (21mm) supported."
+        value={config.grid_y}
+        min={1}
+        max={10}
+        step={0.5}
+        unit="u"
+        onChange={(v) =>
+          update({
+              grid_y: v,
+              partial_bins_values: createPartialBinsValues(config.grid_x, v),
+          })
+        }
+        disabled={autoSize}
+      />
 
-            <SliderRow
-                label="Height"
-                help="Bin height in gridfinity units. Each unit is 7mm, plus a 4.75mm base."
-                value={config.height_units}
-                min={1}
-                max={20}
-                unit="u"
-                onChange={(v) => {
-                    const newMax = calcMaxCutoutDepth(v, config.stacking_lip);
-                    update({ height_units: v, cutout_depth: Math.min(config.cutout_depth, newMax) });
-                }}
-            />
+      <SliderRow
+        label="Height"
+        help="Bin height in gridfinity units. Each unit is 7mm, plus a 4.75mm base."
+        value={config.height_units}
+        min={1}
+        max={20}
+        unit="u"
+        onChange={(v) => {
+          const newMax = calcMaxCutoutDepth(v, config.stacking_lip)
+          update({ height_units: v, cutout_depth: Math.min(config.cutout_depth, newMax) })
+        }}
+      />
 
-            <SliderRow
-                label="Cutout Depth"
-                help={`How deep the tool pocket is cut into the bin. Max ${maxCutoutDepth.toFixed(1)}mm at ${config.height_units}u height.`}
-                value={Math.min(config.cutout_depth, maxCutoutDepth)}
-                min={5}
-                max={maxCutoutDepth}
-                step={0.5}
-                unit="mm"
-                onChange={(v) => update({ cutout_depth: v })}
-            />
+      <SliderRow
+        label="Cutout Depth"
+        help={`How deep the tool pocket is cut into the bin. Max ${maxCutoutDepth.toFixed(1)}mm at ${config.height_units}u height.`}
+        value={Math.min(config.cutout_depth, maxCutoutDepth)}
+        min={5}
+        max={maxCutoutDepth}
+        step={0.5}
+        unit="mm"
+        onChange={(v) => update({ cutout_depth: v })}
+      />
 
-            <SliderRow
-                label="Clearance"
-                help="Extra space around tool outlines. Increase if tools fit too tightly."
-                value={config.cutout_clearance}
-                min={0}
-                max={5}
-                step={0.1}
-                unit="mm"
-                onChange={(v) => update({ cutout_clearance: v })}
-            />
+      <SliderRow
+        label="Clearance"
+        help="Extra space around tool outlines. Increase if tools fit too tightly."
+        value={config.cutout_clearance}
+        min={0}
+        max={5}
+        step={0.1}
+        unit="mm"
+        onChange={(v) => update({ cutout_clearance: v })}
+      />
 
-            <SliderRow
-                label="Cutout Chamfer"
-                help="Bevel distance on the top edge of each tool pocket, in mm. 0 = sharp edge."
-                value={config.cutout_chamfer}
-                min={0}
-                max={3}
-                step={0.1}
-                unit="mm"
-                onChange={(v) => update({ cutout_chamfer: v })}
-            />
+      <SliderRow
+        label="Cutout Chamfer"
+        help="Bevel distance on the top edge of each tool pocket, in mm. 0 = sharp edge."
+        value={config.cutout_chamfer}
+        min={0}
+        max={3}
+        step={0.1}
+        unit="mm"
+        onChange={(v) => update({ cutout_chamfer: v })}
+      />
 
-            <div className="border-t border-border mt-2 pt-1">
-                <Toggle
-                    checked={config.half_grid_base}
-                    onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
-                    label="Half-grid base"
-                    help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
-                />
-                <Toggle
-                    checked={config.magnets && !config.half_grid_base}
-                    onChange={(v) => update({ magnets: v })}
-                    label="Magnet holes"
-                    help="Holes in the base for magnets. Keeps bins locked to the baseplate."
-                    disabled={config.half_grid_base}
-                />
-                {config.half_grid_base && (
-                    <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">
-                        Magnet holes are not compatible with half-grid base cells
-                    </p>
-                )}
-                {config.magnets && !config.half_grid_base && (
-                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
-                        <SliderRow label="Diameter" value={config.magnet_diameter} min={3} max={10} step={0.5} unit="mm" onChange={(v) => update({ magnet_diameter: v })} />
-                        <SliderRow label="Depth" value={config.magnet_depth} min={1} max={5} step={0.1} unit="mm" onChange={(v) => update({ magnet_depth: v })} />
-                        <Toggle
-                            checked={config.magnet_corners_only}
-                            onChange={(v) => update({ magnet_corners_only: v })}
-                            label="Corners only"
-                            help="Only place magnet holes at the 4 outer corners of the bin."
-                        />
-                    </div>
-                )}
-                <Toggle
-                    checked={config.stacking_lip}
-                    onChange={(v) => {
-                        const newMax = calcMaxCutoutDepth(config.height_units, v);
-                        update({
-                            stacking_lip: v,
-                            rim_units: v ? config.rim_units : 0,
-                            cutout_depth: Math.min(config.cutout_depth, newMax),
-                        });
-                    }}
-                    label="Stacking lip"
-                    help="Raised rim at the top so bins can stack securely on top of each other."
-                />
-                {config.stacking_lip && (
-                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
-                        <SliderRow
-                            label="Raise Lip"
-                            help="Extends the wall and lip this many units (7mm each) above the floor face, leaving the interior open. Lets a tool protrude above the floor while a stacked bin still clears it. 0 = standard."
-                            value={config.rim_units}
-                            min={0}
-                            max={10}
-                            unit="u"
-                            onChange={(v) => update({ rim_units: v })}
-                        />
-                    </div>
-                )}
-                <Toggle
-                    checked={config.insert_enabled}
-                    onChange={(v) => update({ insert_enabled: v })}
-                    label="Contrast Insert"
-                    help="Generates a separate insert STL to print in a contrasting colour. The pocket is deepened to accommodate it."
-                />
-                {config.insert_enabled && (
-                    <>
-                        <SliderRow
-                            label="Insert Height"
-                            help="Thickness of the insert in mm."
-                            value={config.insert_height}
-                            min={0.5}
-                            max={10}
-                            step={0.1}
-                            unit="mm"
-                            onChange={(v) => update({ insert_height: v })}
-                        />
-                        <SliderRow
-                            label="Insert Fit"
-                            help="Clearance shaved off the insert edges so it drops into the pocket."
-                            value={config.insert_clearance}
-                            min={0}
-                            max={1}
-                            step={0.05}
-                            unit="mm"
-                            onChange={(v) => update({ insert_clearance: v })}
-                        />
-                    </>
-                )}
-            </div>
-
-            <div className="border-t border-border mt-2 pt-1">
+      <div className="border-t border-border mt-2 pt-1">
+          <Toggle
+              checked={config.half_grid_base}
+              onChange={(v) => update({ half_grid_base: v, ...(v ? { magnets: false } : {}) })}
+              label="Half-grid base"
+              help="Use 21mm half-grid cells on the baseplate instead of standard 42mm. Gives finer positioning on the baseplate."
+          />
+          <Toggle
+              checked={config.magnets && !config.half_grid_base}
+              onChange={(v) => update({ magnets: v })}
+              label="Magnet holes"
+              help="Holes in the base for magnets. Keeps bins locked to the baseplate."
+              disabled={config.half_grid_base}
+          />
+          {config.half_grid_base && <p className="text-[11px] text-text-muted mt-0.5 leading-tight pl-0.5">Magnet holes are not compatible with half-grid base cells</p>}
+          {config.magnets && !config.half_grid_base && (
+              <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
                 <SliderRow
-                    label="Bed Size"
-                    help="Print bed size. Bins wider than this are automatically split into pieces."
-                    value={config.bed_size}
-                    min={BED_SIZE_MIN_MM}
-                    max={BED_SIZE_MAX_MM}
-                    step={1}
-                    unit="mm"
-                    onChange={(v) => update({ bed_size: v })}
+                  label="Diameter"
+                  value={config.magnet_diameter}
+                  min={3}
+                  max={10}
+                  step={0.5}
+                  unit="mm"
+                  onChange={(v) => update({ magnet_diameter: v })}
                 />
-                {needsSplit && (
-                    <div className="text-[11px] text-amber-400 mt-1 leading-tight">
-                        {binWidth > config.bed_size && `Width ${binWidth}mm exceeds bed`}
-                        {binWidth > config.bed_size && binDepth > config.bed_size && " & "}
-                        {binDepth > config.bed_size && `Depth ${binDepth}mm exceeds bed`}
-                        {" \u2014 will be split"}
-                    </div>
-                )}
-            </div>
-
-            <div className="border-t border-border mt-2 pt-1">
+                <SliderRow
+                  label="Depth"
+                  value={config.magnet_depth}
+                  min={1}
+                  max={5}
+                  step={0.1}
+                  unit="mm"
+                  onChange={(v) => update({ magnet_depth: v })}
+                />
                 <Toggle
-                    checked={config.partial_bins}
-                    onChange={(v) =>
-                        update({
-                            partial_bins: v,
-                            ...(!v ? { partial_bins_connect: false, partial_bins_retain_wall: false } : {}),
-                        })
-                    }
-                    label="Partial Bins"
-                    help="Print only parts of the bin that are needed to hold the tools."
+                  checked={config.magnet_corners_only}
+                  onChange={(v) => update({ magnet_corners_only: v })}
+                  label="Corners only"
+                  help="Only place magnet holes at the 4 outer corners of the bin."
                 />
-                {config.partial_bins && (
-                    <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
-                        <RadioMatrix
-                            sizeX={Math.ceil(config.grid_x)}
-                            sizeY={Math.ceil(config.grid_y)}
-                            values={config.partial_bins_values}
-                            onChange={(v) => update({ partial_bins_values: v })}
-                        />
-                        <Toggle
-                            checked={config.partial_bins_connect}
-                            onChange={(v) =>
-                                update({
-                                    partial_bins_connect: v,
-                                    ...(!v ? { partial_bins_retain_wall: false } : {}),
-                                })
-                            }
-                            label="Connect base"
-                            help="Remove walls in disabled cells, bridge them with a thin base plate, and keep one connected print."
-                        />
-                        {config.partial_bins_connect && (
-                            <Toggle
-                                checked={config.partial_bins_retain_wall}
-                                onChange={(v) => update({ partial_bins_retain_wall: v })}
-                                label="Retain outer wall"
-                                help="Keep the bin perimeter wall through disabled cells while still connecting them on the base."
-                            />
-                        )}
-                        {exportsSeparateParts && (
-                            <div className="text-[11px] text-amber-400 mt-1 leading-tight">
-                                Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-        </div>
-    );
+              </div>
+        )}
+        <Toggle
+          checked={config.stacking_lip}
+          onChange={(v) => {
+            const newMax = calcMaxCutoutDepth(config.height_units, v)
+            update({
+              stacking_lip: v,
+              rim_units: v ? config.rim_units : 0,
+              cutout_depth: Math.min(config.cutout_depth, newMax),
+            })
+          }}
+          label="Stacking lip"
+          help="Raised rim at the top so bins can stack securely on top of each other."
+        />
+        {config.stacking_lip && (
+          <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+            <SliderRow
+              label="Raise Lip"
+              help="Extends the wall and lip this many units (7mm each) above the floor face, leaving the interior open. Lets a tool protrude above the floor while a stacked bin still clears it. 0 = standard."
+              value={config.rim_units}
+              min={0}
+              max={10}
+              unit="u"
+              onChange={(v) => update({ rim_units: v })}
+            />
+          </div>
+        )}
+        <Toggle
+          checked={config.insert_enabled}
+          onChange={(v) => update({ insert_enabled: v })}
+          label="Contrast Insert"
+          help="Generates a separate insert STL to print in a contrasting colour. The pocket is deepened to accommodate it."
+        />
+        {config.insert_enabled && (
+          <>
+            <SliderRow
+              label="Insert Height"
+              help="Thickness of the insert in mm."
+              value={config.insert_height}
+              min={0.5}
+              max={10}
+              step={0.1}
+              unit="mm"
+              onChange={(v) => update({ insert_height: v })}
+            />
+            <SliderRow
+              label="Insert Fit"
+              help="Clearance shaved off the insert edges so it drops into the pocket."
+              value={config.insert_clearance}
+              min={0}
+              max={1}
+              step={0.05}
+              unit="mm"
+              onChange={(v) => update({ insert_clearance: v })}
+            />
+          </>
+        )}
+      </div>
+
+      <div className="border-t border-border mt-2 pt-1">
+        <SliderRow
+          label="Bed Size"
+          help="Print bed size. Bins wider than this are automatically split into pieces."
+          value={config.bed_size}
+          min={BED_SIZE_MIN_MM}
+          max={BED_SIZE_MAX_MM}
+          step={1}
+          unit="mm"
+          onChange={(v) => update({ bed_size: v })}
+        />
+        {needsSplit && (
+          <div className="text-[11px] text-amber-400 mt-1 leading-tight">
+            {binWidth > config.bed_size && `Width ${binWidth}mm exceeds bed`}
+            {binWidth > config.bed_size && binDepth > config.bed_size && ' & '}
+            {binDepth > config.bed_size && `Depth ${binDepth}mm exceeds bed`}
+            {' \u2014 will be split'}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-border mt-2 pt-1">
+          <Toggle
+              checked={config.partial_bins}
+              onChange={(v) =>
+                  update({
+                      partial_bins: v,
+                      ...(!v ? { partial_bins_connect: false, partial_bins_retain_wall: false } : {}),
+                  })
+              }
+              label="Partial Bins"
+              help="Print only parts of the bin that are needed to hold the tools."
+          />
+          {config.partial_bins && (
+              <div className="pl-3 border-l border-border-subtle ml-1 space-y-0">
+                  <RadioMatrix sizeX={Math.ceil(config.grid_x)} sizeY={Math.ceil(config.grid_y)} values={config.partial_bins_values} onChange={(v) => update({ partial_bins_values: v })} />
+                  <Toggle
+                      checked={config.partial_bins_connect}
+                      onChange={(v) =>
+                          update({
+                              partial_bins_connect: v,
+                              ...(!v ? { partial_bins_retain_wall: false } : {}),
+                          })
+                      }
+                      label="Connect base"
+                      help="Remove walls in disabled cells, bridge them with a thin base plate, and keep one connected print."
+                  />
+                  {config.partial_bins_connect && (
+                      <Toggle
+                          checked={config.partial_bins_retain_wall}
+                          onChange={(v) => update({ partial_bins_retain_wall: v })}
+                          label="Retain outer wall"
+                          help="Keep the bin perimeter wall through disabled cells while still connecting them on the base."
+                      />
+                  )}
+                  {exportsSeparateParts && <div className="text-[11px] text-amber-400 mt-1 leading-tight">Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part</div>}
+              </div>
+          )}
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -137,7 +137,10 @@ function RadioMatrix({ sizeX, sizeY, values, onChange }: { sizeX: number; sizeY:
             {values.map((value, index) => (
                 <button
                     key={index}
-                    onClick={() => onChange(values.map((v, i) => (i === index ? !v : v)))}
+                    onClick={() => {
+                        if (value && values.filter(Boolean).length <= 1) return;
+                        onChange(values.map((v, i) => (i === index ? !v : v)));
+                    }}
                     className={cn("w-full border-2 aspect-square border-muted min-w-3", value ? "bg-accent border-accent" : "bg-elevated border-muted", sizeX > 4 ? "rounded-[2px]" : "rounded-sm")}
                 ></button>
             ))}

--- a/frontend/src/components/BinEditor.tsx
+++ b/frontend/src/components/BinEditor.tsx
@@ -14,6 +14,8 @@ interface Props {
   onTextLabelsChange: (labels: TextLabel[]) => void
   gridX: number
   gridY: number
+  partialBins: boolean
+  partialBinsValues: boolean[]
   wallThickness: number
   defaultCutoutDepth: number
   maxCutoutDepth: number
@@ -48,6 +50,8 @@ export function BinEditor({
   onTextLabelsChange,
   gridX,
   gridY,
+  partialBins,
+  partialBinsValues,
   wallThickness,
   defaultCutoutDepth,
   maxCutoutDepth,
@@ -541,6 +545,8 @@ export function BinEditor({
         displayHeight={displayHeight}
         gridX={gridX}
         gridY={gridY}
+        partialBins={partialBins}
+        partialBinsValues={partialBinsValues}
         wallThickness={wallThickness}
         placedTools={placedTools}
         selection={selection}

--- a/frontend/src/components/BinEditorCanvas.tsx
+++ b/frontend/src/components/BinEditorCanvas.tsx
@@ -20,6 +20,8 @@ interface Props {
   displayHeight: number
   gridX: number
   gridY: number
+  partialBins: boolean
+  partialBinsValues: boolean[]
   wallThickness: number
   placedTools: PlacedTool[]
   selection: Selection
@@ -66,6 +68,8 @@ export function BinEditorCanvas({
   displayHeight,
   gridX,
   gridY,
+  partialBins,
+  partialBinsValues,
   wallThickness,
   placedTools,
   selection,
@@ -149,6 +153,28 @@ export function BinEditorCanvas({
               />
             )
           })}
+
+          {/* disabled partial-bin cells */}
+          {partialBins && Array.from({ length: gridY }).map((_, iy) =>
+              Array.from({ length: gridX }).map((_, ix) => {
+                  const enabled = partialBinsValues[iy * gridX + ix] ?? true;
+                  if (enabled) return null;
+                  const cell = GRID_UNIT * DISPLAY_SCALE;
+                  return (
+                      <rect
+                          key={`partial-off-${ix}-${iy}`}
+                          x={ix * cell}
+                          y={iy * cell}
+                          width={cell}
+                          height={cell}
+                          fill="rgba(239, 68, 68, 0.22)"
+                          stroke="rgba(239, 68, 68, 0.1)"
+                          strokeWidth={1}
+                          className="pointer-events-none"
+                      />
+                  );
+              }),
+          )}
 
           {/* wall inset boundary */}
           {(() => {

--- a/frontend/src/lib/binDefaults.test.ts
+++ b/frontend/src/lib/binDefaults.test.ts
@@ -39,6 +39,23 @@ describe('bin defaults', () => {
     vi.unstubAllGlobals()
   })
 
+  it('normalizes partial_bins_values to match grid size', () => {
+    const config = buildBinConfig({ grid_x: 3, grid_y: 4 })
+
+    expect(config.partial_bins).toBe(false)
+    expect(config.partial_bins_values).toEqual(Array(12).fill(true))
+  })
+
+  it('resets partial_bins_values when grid overrides change size', () => {
+    const config = buildBinConfig({
+      grid_x: 3,
+      grid_y: 2,
+      partial_bins_values: [true, true],
+    })
+
+    expect(config.partial_bins_values).toEqual(Array(6).fill(true))
+  })
+
   it('uses legacy bedSize when no full bin defaults are saved', () => {
     storage.setItem(SETTINGS_KEY, JSON.stringify({ bedSize: 220 }))
 

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -1,8 +1,8 @@
-import type { BinConfig, BinDefaults } from "@/types";
-import { getSettings, saveSettings } from "./settings";
+import type { BinConfig, BinDefaults } from '@/types'
+import { getSettings, saveSettings } from './settings'
 
 export function createPartialBinsValues(gridX: number, gridY: number): boolean[] {
-  return Array(Math.ceil(gridX) * Math.ceil(gridY)).fill(true)
+  return Array(Math.ceil(gridX) * Math.ceil(gridY)).fill(true);
 }
 
 export const FACTORY_BIN_CONFIG: BinConfig = {
@@ -32,42 +32,42 @@ export const FACTORY_BIN_CONFIG: BinConfig = {
 }
 
 export function buildBinConfig(overrides: Partial<BinDefaults> | null = null): BinConfig {
-    const merged = {
-        ...FACTORY_BIN_CONFIG,
-        ...(overrides || {}),
-        text_labels: [] as BinConfig["text_labels"],
-    };
-    const expectedLength = Math.ceil(merged.grid_x) * Math.ceil(merged.grid_y);
-    if (!merged.partial_bins_values || merged.partial_bins_values.length !== expectedLength) {
-        merged.partial_bins_values = createPartialBinsValues(merged.grid_x, merged.grid_y);
-    }
-    return merged;
+  const merged = {
+      ...FACTORY_BIN_CONFIG,
+      ...(overrides || {}),
+      text_labels: [] as BinConfig["text_labels"],
+  };
+  const expectedLength = Math.ceil(merged.grid_x) * Math.ceil(merged.grid_y);
+  if (!merged.partial_bins_values || merged.partial_bins_values.length !== expectedLength) {
+      merged.partial_bins_values = createPartialBinsValues(merged.grid_x, merged.grid_y);
+  }
+  return merged;
 }
 
 export function binDefaultsFromConfig(config: Partial<BinConfig>): BinDefaults {
-    const { text_labels: _textLabels, ...defaults } = buildBinConfig(config);
-    return defaults;
+  const { text_labels: _textLabels, ...defaults } = buildBinConfig(config)
+  return defaults
 }
 
 export function getDefaultBinConfig(): BinConfig {
-    const settings = getSettings();
-    return buildBinConfig({
-        ...(settings.binDefaults || {}),
-        bed_size: settings.bedSize,
-    });
+  const settings = getSettings()
+  return buildBinConfig({
+    ...(settings.binDefaults || {}),
+    bed_size: settings.bedSize,
+  })
 }
 
 export function getDefaultBinDefaults(): BinDefaults {
-    return binDefaultsFromConfig(getDefaultBinConfig());
+  return binDefaultsFromConfig(getDefaultBinConfig())
 }
 
 export function saveDefaultBinConfig(config: BinConfig): BinDefaults {
-    const defaults = binDefaultsFromConfig(config);
-    saveSettings({ bedSize: defaults.bed_size, binDefaults: defaults });
-    return defaults;
+  const defaults = binDefaultsFromConfig(config)
+  saveSettings({ bedSize: defaults.bed_size, binDefaults: defaults })
+  return defaults
 }
 
 export function resetDefaultBinConfig(): BinConfig {
-    saveSettings({ bedSize: FACTORY_BIN_CONFIG.bed_size, binDefaults: undefined });
-    return buildBinConfig();
+  saveSettings({ bedSize: FACTORY_BIN_CONFIG.bed_size, binDefaults: undefined })
+  return buildBinConfig()
 }

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -1,5 +1,9 @@
-import type { BinConfig, BinDefaults } from '@/types'
-import { getSettings, saveSettings } from './settings'
+import type { BinConfig, BinDefaults } from "@/types";
+import { getSettings, saveSettings } from "./settings";
+
+export function createPartialBinsValues(gridX: number, gridY: number): boolean[] {
+  return Array(Math.ceil(gridX) * Math.ceil(gridY)).fill(true)
+}
 
 export const FACTORY_BIN_CONFIG: BinConfig = {
   grid_x: 2,
@@ -18,43 +22,51 @@ export const FACTORY_BIN_CONFIG: BinConfig = {
   insert_enabled: false,
   insert_height: 1.0,
   insert_clearance: 0.2,
-  bed_size: 256,
   half_grid_base: false,
+  partial_bins: false,
+  partial_bins_values: createPartialBinsValues(2, 2),
+  partial_bins_connect: false,
+  bed_size: 256,
   text_labels: [],
 }
 
 export function buildBinConfig(overrides: Partial<BinDefaults> | null = null): BinConfig {
-  return {
-    ...FACTORY_BIN_CONFIG,
-    ...(overrides || {}),
-    text_labels: [],
-  }
+    const merged = {
+        ...FACTORY_BIN_CONFIG,
+        ...(overrides || {}),
+        text_labels: [] as BinConfig["text_labels"],
+    };
+    const expectedLength = Math.ceil(merged.grid_x) * Math.ceil(merged.grid_y);
+    if (!merged.partial_bins_values || merged.partial_bins_values.length !== expectedLength) {
+        merged.partial_bins_values = createPartialBinsValues(merged.grid_x, merged.grid_y);
+    }
+    return merged;
 }
 
 export function binDefaultsFromConfig(config: Partial<BinConfig>): BinDefaults {
-  const { text_labels: _textLabels, ...defaults } = buildBinConfig(config)
-  return defaults
+    const { text_labels: _textLabels, ...defaults } = buildBinConfig(config);
+    return defaults;
 }
 
 export function getDefaultBinConfig(): BinConfig {
-  const settings = getSettings()
-  return buildBinConfig({
-    ...(settings.binDefaults || {}),
-    bed_size: settings.bedSize,
-  })
+    const settings = getSettings();
+    return buildBinConfig({
+        ...(settings.binDefaults || {}),
+        bed_size: settings.bedSize,
+    });
 }
 
 export function getDefaultBinDefaults(): BinDefaults {
-  return binDefaultsFromConfig(getDefaultBinConfig())
+    return binDefaultsFromConfig(getDefaultBinConfig());
 }
 
 export function saveDefaultBinConfig(config: BinConfig): BinDefaults {
-  const defaults = binDefaultsFromConfig(config)
-  saveSettings({ bedSize: defaults.bed_size, binDefaults: defaults })
-  return defaults
+    const defaults = binDefaultsFromConfig(config);
+    saveSettings({ bedSize: defaults.bed_size, binDefaults: defaults });
+    return defaults;
 }
 
 export function resetDefaultBinConfig(): BinConfig {
-  saveSettings({ bedSize: FACTORY_BIN_CONFIG.bed_size, binDefaults: undefined })
-  return buildBinConfig()
+    saveSettings({ bedSize: FACTORY_BIN_CONFIG.bed_size, binDefaults: undefined });
+    return buildBinConfig();
 }

--- a/frontend/src/lib/binDefaults.ts
+++ b/frontend/src/lib/binDefaults.ts
@@ -26,6 +26,7 @@ export const FACTORY_BIN_CONFIG: BinConfig = {
   partial_bins: false,
   partial_bins_values: createPartialBinsValues(2, 2),
   partial_bins_connect: false,
+  partial_bins_retain_wall: false,
   bed_size: 256,
   text_labels: [],
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,285 +1,284 @@
 export interface Point {
-    x: number
-    y: number
-  }
-  
-  export type PaperSize = 'a4' | 'letter' | 'a3' | 'tabloid'
-  
-  export interface FingerHole {
-    id: string
-    x: number
-    y: number
-    radius: number
-    rotation?: number
-    shape?: CutoutShape
-    width?: number
-    height?: number
-    depth_override?: number | null
-  }
-  
-  export type CutoutShape = 'circle' | 'cylinder' | 'square' | 'rectangle' | 'filleted_rectangle'
-  
-  export interface Polygon {
-    id: string
-    points: Point[]
-    label: string
-    finger_holes: FingerHole[]
-    interior_rings: Point[][]
-  }
-  
-  export interface TextLabel {
-    id: string
-    text: string
-    x: number
-    y: number
-    font_size: number
-    rotation: number
-    emboss: boolean
-    depth: number
-  }
-  
-  export interface Layout {
-    bin_config: BinConfig
-    polygons: Polygon[]
-    text_labels: TextLabel[]
-  }
-  
-  export interface Session {
-    id: string
-    name: string | null
-    description: string | null
-    tags: string[]
-    created_at: string | null
-    original_image_path: string | null
-    corrected_image_path: string | null
-    mask_image_path: string | null
-    corners: Point[] | null
-    paper_size: PaperSize | null
-    scale_factor: number | null
-    polygons: Polygon[] | null
-    stl_path: string | null
-    layout: Layout | null
-  }
-  
-  export interface SessionSummary {
-    id: string
-    name: string | null
-    description: string | null
-    tags: string[]
-    created_at: string | null
-    thumbnail_url: string | null
-    tool_count: number
-    has_stl: boolean
-  }
-  
-  export interface UploadResponse {
-    session_id: string
-    image_url: string
-    detected_corners: Point[] | null
-  }
-  
-  export interface CornersResponse {
-    corrected_image_url: string
-    scale_factor: number
-  }
-  
-  export interface TraceResponse {
-    polygons: Polygon[]
-    mask_url: string | null
-  }
-  
-  export interface GenerateResponse {
-    stl_url: string
-    stl_urls?: string[]
-    threemf_url?: string
-    split_count?: number
-    zip_url?: string | null
-    insert_stl_url?: string | null
-    warning?: string | null
-  }
-  
-  export interface BinDefaults {
-    grid_x: number
-    grid_y: number
-    height_units: number
-    magnets: boolean
-    magnet_diameter: number
-    magnet_depth: number
-    magnet_corners_only: boolean
-    stacking_lip: boolean
-    rim_units: number
-    wall_thickness: number
-    cutout_depth: number
-    cutout_clearance: number
-    cutout_chamfer: number
-    insert_enabled: boolean
-    insert_height: number
-    insert_clearance: number
-    half_grid_base: boolean
-    partial_bins: boolean
-    partial_bins_values: boolean[]
-    partial_bins_connect: boolean
-    partial_bins_retain_wall: boolean
-    bed_size: number
-  }
-  
-  export interface BinConfig extends BinDefaults {
-    text_labels: TextLabel[]
-  }
-  
-  // --- tool library ---
-  
-  export interface Tool {
-    id: string
-    name: string
-    points: Point[]
-    finger_holes: FingerHole[]
-    interior_rings: Point[][]
-    smoothed: boolean
-    smooth_level: number
-    source_session_id: string | null
-    image_context: ToolImageContext | null
-    category: string | null
-    drawer: string | null
-    tags: string[]
-    project_ids: string[]
-    review_status: string | null
-    needs_cleanup: boolean
-    created_at: string | null
-  }
-  
-  export type AffineMatrix = [number, number, number, number, number, number]
-  
-  export interface ToolImageContext {
-    image_url: string
-    image_width: number
-    image_height: number
-    origin_x_mm: number
-    origin_y_mm: number
-    scale_factor: number
-    transform: AffineMatrix
-  }
-  
-  export interface ToolSummary {
-    id: string
-    name: string
-    created_at: string | null
-    point_count: number
-    points: Point[]
-    interior_rings: Point[][]
-    smoothed: boolean
-    smooth_level: number
-    thumbnail_url: string | null
-    image_transform: AffineMatrix | null
-    image_context: ToolImageContext | null
-    category: string | null
-    drawer: string | null
-    tags: string[]
-    project_ids: string[]
-    review_status: string | null
-    needs_cleanup: boolean
-  }
-  
-  // --- projects ---
-  
-  export type ProjectStatus = 'active' | 'ready_to_print' | 'printed' | 'archived'
-  export type ProjectHealthSeverity = 'warning' | 'error'
-  export type ProjectHealthCode =
-    | 'missing_tool'
-    | 'missing_bin'
-    | 'bin_missing_project_id'
-    | 'bin_project_mismatch'
-    | 'outside_tool'
-    | 'tool_missing_project_id'
-    | 'tool_extra_project_id'
-  
-  export interface BinProject {
-    id: string
-    name: string
-    description: string | null
-    status: ProjectStatus
-    tool_ids: string[]
-    bin_ids: string[]
-    placed_tool_ids: string[]
-    unplaced_tool_ids: string[]
-    target_grid_x: number | null
-    target_grid_y: number | null
-    default_bin_config: BinDefaults | null
-    notes: string | null
-    created_at: string | null
-    updated_at: string | null
-  }
-  
-  export interface BinProjectSummary {
-    id: string
-    name: string
-    description: string | null
-    status: ProjectStatus
-    tool_count: number
-    bin_count: number
-    placed_count: number
-    unplaced_count: number
-    target_grid_x: number | null
-    target_grid_y: number | null
-    created_at: string | null
-    updated_at: string | null
-  }
-  
-  export interface ProjectHealthIssue {
-    code: ProjectHealthCode
-    severity: ProjectHealthSeverity
-    message: string
-    tool_id: string | null
-    bin_id: string | null
-    other_project_id: string | null
-    repairable: boolean
-  }
-  
-  export interface ProjectHealthResponse {
-    issues: ProjectHealthIssue[]
-    repairable_count: number
-    manual_count: number
-  }
-  
-  // --- bins ---
-  
-  export interface PlacedTool {
-    id: string
-    tool_id: string
-    name: string
-    points: Point[]
-    finger_holes: FingerHole[]
-    interior_rings: Point[][]
-    rotation: number
-    depth_override?: number | null
-  }
-  
-  export interface BinData {
-    id: string
-    name: string | null
-    project_id: string | null
-    bin_config: BinConfig
-    placed_tools: PlacedTool[]
-    text_labels: TextLabel[]
-    stl_path: string | null
-    created_at: string | null
-  }
-  
-  export interface BinPreviewTool {
-    points: Point[]
-    interior_rings: Point[][]
-  }
-  
-  export interface BinSummary {
-    id: string
-    name: string | null
-    project_id: string | null
-    created_at: string | null
-    tool_ids: string[]
-    tool_count: number
-    has_stl: boolean
-    grid_x: number
-    grid_y: number
-    preview_tools: BinPreviewTool[]
-  }
-  
+  x: number
+  y: number
+}
+
+export type PaperSize = 'a4' | 'letter' | 'a3' | 'tabloid'
+
+export interface FingerHole {
+  id: string
+  x: number
+  y: number
+  radius: number
+  rotation?: number
+  shape?: CutoutShape
+  width?: number
+  height?: number
+  depth_override?: number | null
+}
+
+export type CutoutShape = 'circle' | 'cylinder' | 'square' | 'rectangle' | 'filleted_rectangle'
+
+export interface Polygon {
+  id: string
+  points: Point[]
+  label: string
+  finger_holes: FingerHole[]
+  interior_rings: Point[][]
+}
+
+export interface TextLabel {
+  id: string
+  text: string
+  x: number
+  y: number
+  font_size: number
+  rotation: number
+  emboss: boolean
+  depth: number
+}
+
+export interface Layout {
+  bin_config: BinConfig
+  polygons: Polygon[]
+  text_labels: TextLabel[]
+}
+
+export interface Session {
+  id: string
+  name: string | null
+  description: string | null
+  tags: string[]
+  created_at: string | null
+  original_image_path: string | null
+  corrected_image_path: string | null
+  mask_image_path: string | null
+  corners: Point[] | null
+  paper_size: PaperSize | null
+  scale_factor: number | null
+  polygons: Polygon[] | null
+  stl_path: string | null
+  layout: Layout | null
+}
+
+export interface SessionSummary {
+  id: string
+  name: string | null
+  description: string | null
+  tags: string[]
+  created_at: string | null
+  thumbnail_url: string | null
+  tool_count: number
+  has_stl: boolean
+}
+
+export interface UploadResponse {
+  session_id: string
+  image_url: string
+  detected_corners: Point[] | null
+}
+
+export interface CornersResponse {
+  corrected_image_url: string
+  scale_factor: number
+}
+
+export interface TraceResponse {
+  polygons: Polygon[]
+  mask_url: string | null
+}
+
+export interface GenerateResponse {
+  stl_url: string
+  stl_urls?: string[]
+  threemf_url?: string
+  split_count?: number
+  zip_url?: string | null
+  insert_stl_url?: string | null
+  warning?: string | null
+}
+
+export interface BinDefaults {
+  grid_x: number
+  grid_y: number
+  height_units: number
+  magnets: boolean
+  magnet_diameter: number
+  magnet_depth: number
+  magnet_corners_only: boolean
+  stacking_lip: boolean
+  rim_units: number
+  wall_thickness: number
+  cutout_depth: number
+  cutout_clearance: number
+  cutout_chamfer: number
+  insert_enabled: boolean
+  insert_height: number
+  insert_clearance: number
+  half_grid_base: boolean
+  partial_bins: boolean
+  partial_bins_values: boolean[]
+  partial_bins_connect: boolean
+  partial_bins_retain_wall: boolean
+  bed_size: number
+}
+
+export interface BinConfig extends BinDefaults {
+  text_labels: TextLabel[]
+}
+
+// --- tool library ---
+
+export interface Tool {
+  id: string
+  name: string
+  points: Point[]
+  finger_holes: FingerHole[]
+  interior_rings: Point[][]
+  smoothed: boolean
+  smooth_level: number
+  source_session_id: string | null
+  image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
+  created_at: string | null
+}
+
+export type AffineMatrix = [number, number, number, number, number, number]
+
+export interface ToolImageContext {
+  image_url: string
+  image_width: number
+  image_height: number
+  origin_x_mm: number
+  origin_y_mm: number
+  scale_factor: number
+  transform: AffineMatrix
+}
+
+export interface ToolSummary {
+  id: string
+  name: string
+  created_at: string | null
+  point_count: number
+  points: Point[]
+  interior_rings: Point[][]
+  smoothed: boolean
+  smooth_level: number
+  thumbnail_url: string | null
+  image_transform: AffineMatrix | null
+  image_context: ToolImageContext | null
+  category: string | null
+  drawer: string | null
+  tags: string[]
+  project_ids: string[]
+  review_status: string | null
+  needs_cleanup: boolean
+}
+
+// --- projects ---
+
+export type ProjectStatus = 'active' | 'ready_to_print' | 'printed' | 'archived'
+export type ProjectHealthSeverity = 'warning' | 'error'
+export type ProjectHealthCode =
+  | 'missing_tool'
+  | 'missing_bin'
+  | 'bin_missing_project_id'
+  | 'bin_project_mismatch'
+  | 'outside_tool'
+  | 'tool_missing_project_id'
+  | 'tool_extra_project_id'
+
+export interface BinProject {
+  id: string
+  name: string
+  description: string | null
+  status: ProjectStatus
+  tool_ids: string[]
+  bin_ids: string[]
+  placed_tool_ids: string[]
+  unplaced_tool_ids: string[]
+  target_grid_x: number | null
+  target_grid_y: number | null
+  default_bin_config: BinDefaults | null
+  notes: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface BinProjectSummary {
+  id: string
+  name: string
+  description: string | null
+  status: ProjectStatus
+  tool_count: number
+  bin_count: number
+  placed_count: number
+  unplaced_count: number
+  target_grid_x: number | null
+  target_grid_y: number | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface ProjectHealthIssue {
+  code: ProjectHealthCode
+  severity: ProjectHealthSeverity
+  message: string
+  tool_id: string | null
+  bin_id: string | null
+  other_project_id: string | null
+  repairable: boolean
+}
+
+export interface ProjectHealthResponse {
+  issues: ProjectHealthIssue[]
+  repairable_count: number
+  manual_count: number
+}
+
+// --- bins ---
+
+export interface PlacedTool {
+  id: string
+  tool_id: string
+  name: string
+  points: Point[]
+  finger_holes: FingerHole[]
+  interior_rings: Point[][]
+  rotation: number
+  depth_override?: number | null
+}
+
+export interface BinData {
+  id: string
+  name: string | null
+  project_id: string | null
+  bin_config: BinConfig
+  placed_tools: PlacedTool[]
+  text_labels: TextLabel[]
+  stl_path: string | null
+  created_at: string | null
+}
+
+export interface BinPreviewTool {
+  points: Point[]
+  interior_rings: Point[][]
+}
+
+export interface BinSummary {
+  id: string
+  name: string | null
+  project_id: string | null
+  created_at: string | null
+  tool_ids: string[]
+  tool_count: number
+  has_stl: boolean
+  grid_x: number
+  grid_y: number
+  preview_tools: BinPreviewTool[]
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,101 +1,101 @@
 export interface Point {
-  x: number
-  y: number
+    x: number;
+    y: number;
 }
 
-export type PaperSize = 'a4' | 'letter' | 'a3' | 'tabloid'
+export type PaperSize = "a4" | "letter" | "a3" | "tabloid";
 
 export interface FingerHole {
-  id: string
-  x: number
-  y: number
-  radius: number
-  rotation?: number
-  shape?: CutoutShape
-  width?: number
-  height?: number
-  depth_override?: number | null
+    id: string;
+    x: number;
+    y: number;
+    radius: number;
+    rotation?: number;
+    shape?: CutoutShape;
+    width?: number;
+    height?: number;
+    depth_override?: number | null;
 }
 
-export type CutoutShape = 'circle' | 'cylinder' | 'square' | 'rectangle' | 'filleted_rectangle'
+export type CutoutShape = "circle" | "cylinder" | "square" | "rectangle" | "filleted_rectangle";
 
 export interface Polygon {
-  id: string
-  points: Point[]
-  label: string
-  finger_holes: FingerHole[]
-  interior_rings: Point[][]
+    id: string;
+    points: Point[];
+    label: string;
+    finger_holes: FingerHole[];
+    interior_rings: Point[][];
 }
 
 export interface TextLabel {
-  id: string
-  text: string
-  x: number
-  y: number
-  font_size: number
-  rotation: number
-  emboss: boolean
-  depth: number
+    id: string;
+    text: string;
+    x: number;
+    y: number;
+    font_size: number;
+    rotation: number;
+    emboss: boolean;
+    depth: number;
 }
 
 export interface Layout {
-  bin_config: BinConfig
-  polygons: Polygon[]
-  text_labels: TextLabel[]
+    bin_config: BinConfig;
+    polygons: Polygon[];
+    text_labels: TextLabel[];
 }
 
 export interface Session {
-  id: string
-  name: string | null
-  description: string | null
-  tags: string[]
-  created_at: string | null
-  original_image_path: string | null
-  corrected_image_path: string | null
-  mask_image_path: string | null
-  corners: Point[] | null
-  paper_size: PaperSize | null
-  scale_factor: number | null
-  polygons: Polygon[] | null
-  stl_path: string | null
-  layout: Layout | null
+    id: string;
+    name: string | null;
+    description: string | null;
+    tags: string[];
+    created_at: string | null;
+    original_image_path: string | null;
+    corrected_image_path: string | null;
+    mask_image_path: string | null;
+    corners: Point[] | null;
+    paper_size: PaperSize | null;
+    scale_factor: number | null;
+    polygons: Polygon[] | null;
+    stl_path: string | null;
+    layout: Layout | null;
 }
 
 export interface SessionSummary {
-  id: string
-  name: string | null
-  description: string | null
-  tags: string[]
-  created_at: string | null
-  thumbnail_url: string | null
-  tool_count: number
-  has_stl: boolean
+    id: string;
+    name: string | null;
+    description: string | null;
+    tags: string[];
+    created_at: string | null;
+    thumbnail_url: string | null;
+    tool_count: number;
+    has_stl: boolean;
 }
 
 export interface UploadResponse {
-  session_id: string
-  image_url: string
-  detected_corners: Point[] | null
+    session_id: string;
+    image_url: string;
+    detected_corners: Point[] | null;
 }
 
 export interface CornersResponse {
-  corrected_image_url: string
-  scale_factor: number
+    corrected_image_url: string;
+    scale_factor: number;
 }
 
 export interface TraceResponse {
-  polygons: Polygon[]
-  mask_url: string | null
+    polygons: Polygon[];
+    mask_url: string | null;
 }
 
 export interface GenerateResponse {
-  stl_url: string
-  stl_urls?: string[]
-  threemf_url?: string
-  split_count?: number
-  zip_url?: string | null
-  insert_stl_url?: string | null
-  warning?: string | null
+    stl_url: string;
+    stl_urls?: string[];
+    threemf_url?: string;
+    split_count?: number;
+    zip_url?: string | null;
+    insert_stl_url?: string | null;
+    warning?: string | null;
 }
 
 export interface BinDefaults {
@@ -115,166 +115,162 @@ export interface BinDefaults {
   insert_enabled: boolean
   insert_height: number
   insert_clearance: number
-  bed_size: number
   half_grid_base: boolean
+  partial_bins: boolean
+  partial_bins_values: boolean[]
+  partial_bins_connect: boolean
+  bed_size: number
 }
 
 export interface BinConfig extends BinDefaults {
-  text_labels: TextLabel[]
+    text_labels: TextLabel[];
 }
 
 // --- tool library ---
 
 export interface Tool {
-  id: string
-  name: string
-  points: Point[]
-  finger_holes: FingerHole[]
-  interior_rings: Point[][]
-  smoothed: boolean
-  smooth_level: number
-  source_session_id: string | null
-  image_context: ToolImageContext | null
-  category: string | null
-  drawer: string | null
-  tags: string[]
-  project_ids: string[]
-  review_status: string | null
-  needs_cleanup: boolean
-  created_at: string | null
+    id: string;
+    name: string;
+    points: Point[];
+    finger_holes: FingerHole[];
+    interior_rings: Point[][];
+    smoothed: boolean;
+    smooth_level: number;
+    source_session_id: string | null;
+    image_context: ToolImageContext | null;
+    category: string | null;
+    drawer: string | null;
+    tags: string[];
+    project_ids: string[];
+    review_status: string | null;
+    needs_cleanup: boolean;
+    created_at: string | null;
 }
 
-export type AffineMatrix = [number, number, number, number, number, number]
+export type AffineMatrix = [number, number, number, number, number, number];
 
 export interface ToolImageContext {
-  image_url: string
-  image_width: number
-  image_height: number
-  origin_x_mm: number
-  origin_y_mm: number
-  scale_factor: number
-  transform: AffineMatrix
+    image_url: string;
+    image_width: number;
+    image_height: number;
+    origin_x_mm: number;
+    origin_y_mm: number;
+    scale_factor: number;
+    transform: AffineMatrix;
 }
 
 export interface ToolSummary {
-  id: string
-  name: string
-  created_at: string | null
-  point_count: number
-  points: Point[]
-  interior_rings: Point[][]
-  smoothed: boolean
-  smooth_level: number
-  thumbnail_url: string | null
-  image_transform: AffineMatrix | null
-  image_context: ToolImageContext | null
-  category: string | null
-  drawer: string | null
-  tags: string[]
-  project_ids: string[]
-  review_status: string | null
-  needs_cleanup: boolean
+    id: string;
+    name: string;
+    created_at: string | null;
+    point_count: number;
+    points: Point[];
+    interior_rings: Point[][];
+    smoothed: boolean;
+    smooth_level: number;
+    thumbnail_url: string | null;
+    image_transform: AffineMatrix | null;
+    image_context: ToolImageContext | null;
+    category: string | null;
+    drawer: string | null;
+    tags: string[];
+    project_ids: string[];
+    review_status: string | null;
+    needs_cleanup: boolean;
 }
 
 // --- projects ---
 
-export type ProjectStatus = 'active' | 'ready_to_print' | 'printed' | 'archived'
-export type ProjectHealthSeverity = 'warning' | 'error'
-export type ProjectHealthCode =
-  | 'missing_tool'
-  | 'missing_bin'
-  | 'bin_missing_project_id'
-  | 'bin_project_mismatch'
-  | 'outside_tool'
-  | 'tool_missing_project_id'
-  | 'tool_extra_project_id'
+export type ProjectStatus = "active" | "ready_to_print" | "printed" | "archived";
+export type ProjectHealthSeverity = "warning" | "error";
+export type ProjectHealthCode = "missing_tool" | "missing_bin" | "bin_missing_project_id" | "bin_project_mismatch" | "outside_tool" | "tool_missing_project_id" | "tool_extra_project_id";
 
 export interface BinProject {
-  id: string
-  name: string
-  description: string | null
-  status: ProjectStatus
-  tool_ids: string[]
-  bin_ids: string[]
-  placed_tool_ids: string[]
-  unplaced_tool_ids: string[]
-  target_grid_x: number | null
-  target_grid_y: number | null
-  default_bin_config: BinDefaults | null
-  notes: string | null
-  created_at: string | null
-  updated_at: string | null
+    id: string;
+    name: string;
+    description: string | null;
+    status: ProjectStatus;
+    tool_ids: string[];
+    bin_ids: string[];
+    placed_tool_ids: string[];
+    unplaced_tool_ids: string[];
+    target_grid_x: number | null;
+    target_grid_y: number | null;
+    default_bin_config: BinDefaults | null;
+    notes: string | null;
+    created_at: string | null;
+    updated_at: string | null;
 }
 
 export interface BinProjectSummary {
-  id: string
-  name: string
-  description: string | null
-  status: ProjectStatus
-  tool_count: number
-  bin_count: number
-  placed_count: number
-  unplaced_count: number
-  target_grid_x: number | null
-  target_grid_y: number | null
-  created_at: string | null
-  updated_at: string | null
+    id: string;
+    name: string;
+    description: string | null;
+    status: ProjectStatus;
+    tool_count: number;
+    bin_count: number;
+    placed_count: number;
+    unplaced_count: number;
+    target_grid_x: number | null;
+    target_grid_y: number | null;
+    created_at: string | null;
+    updated_at: string | null;
 }
 
 export interface ProjectHealthIssue {
-  code: ProjectHealthCode
-  severity: ProjectHealthSeverity
-  message: string
-  tool_id: string | null
-  bin_id: string | null
-  other_project_id: string | null
-  repairable: boolean
+    code: ProjectHealthCode;
+    severity: ProjectHealthSeverity;
+    message: string;
+    tool_id: string | null;
+    bin_id: string | null;
+    other_project_id: string | null;
+    repairable: boolean;
 }
 
 export interface ProjectHealthResponse {
-  issues: ProjectHealthIssue[]
-  repairable_count: number
-  manual_count: number
+    issues: ProjectHealthIssue[];
+    repairable_count: number;
+    manual_count: number;
 }
 
 // --- bins ---
 
 export interface PlacedTool {
-  id: string
-  tool_id: string
-  name: string
-  points: Point[]
-  finger_holes: FingerHole[]
-  interior_rings: Point[][]
-  rotation: number
-  depth_override?: number | null
+    id: string;
+    tool_id: string;
+    name: string;
+    points: Point[];
+    finger_holes: FingerHole[];
+    interior_rings: Point[][];
+    rotation: number;
+    depth_override?: number | null;
 }
 
 export interface BinData {
-  id: string
-  name: string | null
-  project_id: string | null
-  bin_config: BinConfig
-  placed_tools: PlacedTool[]
-  text_labels: TextLabel[]
-  stl_path: string | null
-  created_at: string | null
+    id: string;
+    name: string | null;
+    project_id: string | null;
+    bin_config: BinConfig;
+    placed_tools: PlacedTool[];
+    text_labels: TextLabel[];
+    stl_path: string | null;
+    created_at: string | null;
 }
 
 export interface BinPreviewTool {
-  points: Point[]
-  interior_rings: Point[][]
+    points: Point[];
+    interior_rings: Point[][];
 }
 
 export interface BinSummary {
-  id: string
-  name: string | null
-  project_id: string | null
-  created_at: string | null
-  tool_ids: string[]
-  tool_count: number
-  has_stl: boolean
-  grid_x: number
-  grid_y: number
-  preview_tools: BinPreviewTool[]
+    id: string;
+    name: string | null;
+    project_id: string | null;
+    created_at: string | null;
+    tool_ids: string[];
+    tool_count: number;
+    has_stl: boolean;
+    grid_x: number;
+    grid_y: number;
+    preview_tools: BinPreviewTool[];
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -119,6 +119,7 @@ export interface BinDefaults {
   partial_bins: boolean
   partial_bins_values: boolean[]
   partial_bins_connect: boolean
+  partial_bins_retain_wall: boolean
   bed_size: number
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,277 +1,285 @@
 export interface Point {
-    x: number;
-    y: number;
-}
-
-export type PaperSize = "a4" | "letter" | "a3" | "tabloid";
-
-export interface FingerHole {
-    id: string;
-    x: number;
-    y: number;
-    radius: number;
-    rotation?: number;
-    shape?: CutoutShape;
-    width?: number;
-    height?: number;
-    depth_override?: number | null;
-}
-
-export type CutoutShape = "circle" | "cylinder" | "square" | "rectangle" | "filleted_rectangle";
-
-export interface Polygon {
-    id: string;
-    points: Point[];
-    label: string;
-    finger_holes: FingerHole[];
-    interior_rings: Point[][];
-}
-
-export interface TextLabel {
-    id: string;
-    text: string;
-    x: number;
-    y: number;
-    font_size: number;
-    rotation: number;
-    emboss: boolean;
-    depth: number;
-}
-
-export interface Layout {
-    bin_config: BinConfig;
-    polygons: Polygon[];
-    text_labels: TextLabel[];
-}
-
-export interface Session {
-    id: string;
-    name: string | null;
-    description: string | null;
-    tags: string[];
-    created_at: string | null;
-    original_image_path: string | null;
-    corrected_image_path: string | null;
-    mask_image_path: string | null;
-    corners: Point[] | null;
-    paper_size: PaperSize | null;
-    scale_factor: number | null;
-    polygons: Polygon[] | null;
-    stl_path: string | null;
-    layout: Layout | null;
-}
-
-export interface SessionSummary {
-    id: string;
-    name: string | null;
-    description: string | null;
-    tags: string[];
-    created_at: string | null;
-    thumbnail_url: string | null;
-    tool_count: number;
-    has_stl: boolean;
-}
-
-export interface UploadResponse {
-    session_id: string;
-    image_url: string;
-    detected_corners: Point[] | null;
-}
-
-export interface CornersResponse {
-    corrected_image_url: string;
-    scale_factor: number;
-}
-
-export interface TraceResponse {
-    polygons: Polygon[];
-    mask_url: string | null;
-}
-
-export interface GenerateResponse {
-    stl_url: string;
-    stl_urls?: string[];
-    threemf_url?: string;
-    split_count?: number;
-    zip_url?: string | null;
-    insert_stl_url?: string | null;
-    warning?: string | null;
-}
-
-export interface BinDefaults {
-  grid_x: number
-  grid_y: number
-  height_units: number
-  magnets: boolean
-  magnet_diameter: number
-  magnet_depth: number
-  magnet_corners_only: boolean
-  stacking_lip: boolean
-  rim_units: number
-  wall_thickness: number
-  cutout_depth: number
-  cutout_clearance: number
-  cutout_chamfer: number
-  insert_enabled: boolean
-  insert_height: number
-  insert_clearance: number
-  half_grid_base: boolean
-  partial_bins: boolean
-  partial_bins_values: boolean[]
-  partial_bins_connect: boolean
-  partial_bins_retain_wall: boolean
-  bed_size: number
-}
-
-export interface BinConfig extends BinDefaults {
-    text_labels: TextLabel[];
-}
-
-// --- tool library ---
-
-export interface Tool {
-    id: string;
-    name: string;
-    points: Point[];
-    finger_holes: FingerHole[];
-    interior_rings: Point[][];
-    smoothed: boolean;
-    smooth_level: number;
-    source_session_id: string | null;
-    image_context: ToolImageContext | null;
-    category: string | null;
-    drawer: string | null;
-    tags: string[];
-    project_ids: string[];
-    review_status: string | null;
-    needs_cleanup: boolean;
-    created_at: string | null;
-}
-
-export type AffineMatrix = [number, number, number, number, number, number];
-
-export interface ToolImageContext {
-    image_url: string;
-    image_width: number;
-    image_height: number;
-    origin_x_mm: number;
-    origin_y_mm: number;
-    scale_factor: number;
-    transform: AffineMatrix;
-}
-
-export interface ToolSummary {
-    id: string;
-    name: string;
-    created_at: string | null;
-    point_count: number;
-    points: Point[];
-    interior_rings: Point[][];
-    smoothed: boolean;
-    smooth_level: number;
-    thumbnail_url: string | null;
-    image_transform: AffineMatrix | null;
-    image_context: ToolImageContext | null;
-    category: string | null;
-    drawer: string | null;
-    tags: string[];
-    project_ids: string[];
-    review_status: string | null;
-    needs_cleanup: boolean;
-}
-
-// --- projects ---
-
-export type ProjectStatus = "active" | "ready_to_print" | "printed" | "archived";
-export type ProjectHealthSeverity = "warning" | "error";
-export type ProjectHealthCode = "missing_tool" | "missing_bin" | "bin_missing_project_id" | "bin_project_mismatch" | "outside_tool" | "tool_missing_project_id" | "tool_extra_project_id";
-
-export interface BinProject {
-    id: string;
-    name: string;
-    description: string | null;
-    status: ProjectStatus;
-    tool_ids: string[];
-    bin_ids: string[];
-    placed_tool_ids: string[];
-    unplaced_tool_ids: string[];
-    target_grid_x: number | null;
-    target_grid_y: number | null;
-    default_bin_config: BinDefaults | null;
-    notes: string | null;
-    created_at: string | null;
-    updated_at: string | null;
-}
-
-export interface BinProjectSummary {
-    id: string;
-    name: string;
-    description: string | null;
-    status: ProjectStatus;
-    tool_count: number;
-    bin_count: number;
-    placed_count: number;
-    unplaced_count: number;
-    target_grid_x: number | null;
-    target_grid_y: number | null;
-    created_at: string | null;
-    updated_at: string | null;
-}
-
-export interface ProjectHealthIssue {
-    code: ProjectHealthCode;
-    severity: ProjectHealthSeverity;
-    message: string;
-    tool_id: string | null;
-    bin_id: string | null;
-    other_project_id: string | null;
-    repairable: boolean;
-}
-
-export interface ProjectHealthResponse {
-    issues: ProjectHealthIssue[];
-    repairable_count: number;
-    manual_count: number;
-}
-
-// --- bins ---
-
-export interface PlacedTool {
-    id: string;
-    tool_id: string;
-    name: string;
-    points: Point[];
-    finger_holes: FingerHole[];
-    interior_rings: Point[][];
-    rotation: number;
-    depth_override?: number | null;
-}
-
-export interface BinData {
-    id: string;
-    name: string | null;
-    project_id: string | null;
-    bin_config: BinConfig;
-    placed_tools: PlacedTool[];
-    text_labels: TextLabel[];
-    stl_path: string | null;
-    created_at: string | null;
-}
-
-export interface BinPreviewTool {
-    points: Point[];
-    interior_rings: Point[][];
-}
-
-export interface BinSummary {
-    id: string;
-    name: string | null;
-    project_id: string | null;
-    created_at: string | null;
-    tool_ids: string[];
-    tool_count: number;
-    has_stl: boolean;
-    grid_x: number;
-    grid_y: number;
-    preview_tools: BinPreviewTool[];
-}
+    x: number
+    y: number
+  }
+  
+  export type PaperSize = 'a4' | 'letter' | 'a3' | 'tabloid'
+  
+  export interface FingerHole {
+    id: string
+    x: number
+    y: number
+    radius: number
+    rotation?: number
+    shape?: CutoutShape
+    width?: number
+    height?: number
+    depth_override?: number | null
+  }
+  
+  export type CutoutShape = 'circle' | 'cylinder' | 'square' | 'rectangle' | 'filleted_rectangle'
+  
+  export interface Polygon {
+    id: string
+    points: Point[]
+    label: string
+    finger_holes: FingerHole[]
+    interior_rings: Point[][]
+  }
+  
+  export interface TextLabel {
+    id: string
+    text: string
+    x: number
+    y: number
+    font_size: number
+    rotation: number
+    emboss: boolean
+    depth: number
+  }
+  
+  export interface Layout {
+    bin_config: BinConfig
+    polygons: Polygon[]
+    text_labels: TextLabel[]
+  }
+  
+  export interface Session {
+    id: string
+    name: string | null
+    description: string | null
+    tags: string[]
+    created_at: string | null
+    original_image_path: string | null
+    corrected_image_path: string | null
+    mask_image_path: string | null
+    corners: Point[] | null
+    paper_size: PaperSize | null
+    scale_factor: number | null
+    polygons: Polygon[] | null
+    stl_path: string | null
+    layout: Layout | null
+  }
+  
+  export interface SessionSummary {
+    id: string
+    name: string | null
+    description: string | null
+    tags: string[]
+    created_at: string | null
+    thumbnail_url: string | null
+    tool_count: number
+    has_stl: boolean
+  }
+  
+  export interface UploadResponse {
+    session_id: string
+    image_url: string
+    detected_corners: Point[] | null
+  }
+  
+  export interface CornersResponse {
+    corrected_image_url: string
+    scale_factor: number
+  }
+  
+  export interface TraceResponse {
+    polygons: Polygon[]
+    mask_url: string | null
+  }
+  
+  export interface GenerateResponse {
+    stl_url: string
+    stl_urls?: string[]
+    threemf_url?: string
+    split_count?: number
+    zip_url?: string | null
+    insert_stl_url?: string | null
+    warning?: string | null
+  }
+  
+  export interface BinDefaults {
+    grid_x: number
+    grid_y: number
+    height_units: number
+    magnets: boolean
+    magnet_diameter: number
+    magnet_depth: number
+    magnet_corners_only: boolean
+    stacking_lip: boolean
+    rim_units: number
+    wall_thickness: number
+    cutout_depth: number
+    cutout_clearance: number
+    cutout_chamfer: number
+    insert_enabled: boolean
+    insert_height: number
+    insert_clearance: number
+    half_grid_base: boolean
+    partial_bins: boolean
+    partial_bins_values: boolean[]
+    partial_bins_connect: boolean
+    partial_bins_retain_wall: boolean
+    bed_size: number
+  }
+  
+  export interface BinConfig extends BinDefaults {
+    text_labels: TextLabel[]
+  }
+  
+  // --- tool library ---
+  
+  export interface Tool {
+    id: string
+    name: string
+    points: Point[]
+    finger_holes: FingerHole[]
+    interior_rings: Point[][]
+    smoothed: boolean
+    smooth_level: number
+    source_session_id: string | null
+    image_context: ToolImageContext | null
+    category: string | null
+    drawer: string | null
+    tags: string[]
+    project_ids: string[]
+    review_status: string | null
+    needs_cleanup: boolean
+    created_at: string | null
+  }
+  
+  export type AffineMatrix = [number, number, number, number, number, number]
+  
+  export interface ToolImageContext {
+    image_url: string
+    image_width: number
+    image_height: number
+    origin_x_mm: number
+    origin_y_mm: number
+    scale_factor: number
+    transform: AffineMatrix
+  }
+  
+  export interface ToolSummary {
+    id: string
+    name: string
+    created_at: string | null
+    point_count: number
+    points: Point[]
+    interior_rings: Point[][]
+    smoothed: boolean
+    smooth_level: number
+    thumbnail_url: string | null
+    image_transform: AffineMatrix | null
+    image_context: ToolImageContext | null
+    category: string | null
+    drawer: string | null
+    tags: string[]
+    project_ids: string[]
+    review_status: string | null
+    needs_cleanup: boolean
+  }
+  
+  // --- projects ---
+  
+  export type ProjectStatus = 'active' | 'ready_to_print' | 'printed' | 'archived'
+  export type ProjectHealthSeverity = 'warning' | 'error'
+  export type ProjectHealthCode =
+    | 'missing_tool'
+    | 'missing_bin'
+    | 'bin_missing_project_id'
+    | 'bin_project_mismatch'
+    | 'outside_tool'
+    | 'tool_missing_project_id'
+    | 'tool_extra_project_id'
+  
+  export interface BinProject {
+    id: string
+    name: string
+    description: string | null
+    status: ProjectStatus
+    tool_ids: string[]
+    bin_ids: string[]
+    placed_tool_ids: string[]
+    unplaced_tool_ids: string[]
+    target_grid_x: number | null
+    target_grid_y: number | null
+    default_bin_config: BinDefaults | null
+    notes: string | null
+    created_at: string | null
+    updated_at: string | null
+  }
+  
+  export interface BinProjectSummary {
+    id: string
+    name: string
+    description: string | null
+    status: ProjectStatus
+    tool_count: number
+    bin_count: number
+    placed_count: number
+    unplaced_count: number
+    target_grid_x: number | null
+    target_grid_y: number | null
+    created_at: string | null
+    updated_at: string | null
+  }
+  
+  export interface ProjectHealthIssue {
+    code: ProjectHealthCode
+    severity: ProjectHealthSeverity
+    message: string
+    tool_id: string | null
+    bin_id: string | null
+    other_project_id: string | null
+    repairable: boolean
+  }
+  
+  export interface ProjectHealthResponse {
+    issues: ProjectHealthIssue[]
+    repairable_count: number
+    manual_count: number
+  }
+  
+  // --- bins ---
+  
+  export interface PlacedTool {
+    id: string
+    tool_id: string
+    name: string
+    points: Point[]
+    finger_holes: FingerHole[]
+    interior_rings: Point[][]
+    rotation: number
+    depth_override?: number | null
+  }
+  
+  export interface BinData {
+    id: string
+    name: string | null
+    project_id: string | null
+    bin_config: BinConfig
+    placed_tools: PlacedTool[]
+    text_labels: TextLabel[]
+    stl_path: string | null
+    created_at: string | null
+  }
+  
+  export interface BinPreviewTool {
+    points: Point[]
+    interior_rings: Point[][]
+  }
+  
+  export interface BinSummary {
+    id: string
+    name: string | null
+    project_id: string | null
+    created_at: string | null
+    tool_ids: string[]
+    tool_count: number
+    has_stl: boolean
+    grid_x: number
+    grid_y: number
+    preview_tools: BinPreviewTool[]
+  }
+  


### PR DESCRIPTION
Adds following options to the bin editor:

- `Partial Bins` (Toggle): Enables the Partial Bins sub menu.
- A Matrix where a user can select parts of the Bin to be hidden.
- `Connect Base` (Toggle): If enabled the model will be connected with the base plate.

This feature can save a lot of filament for big and sturdy objects that doesn't need a complete filled out bin. See:
Closes #106 


- [x] Run all unit tests successfull locally
- [x] Run all e2e tests successfull locally

<img width="1728" height="1425" alt="CleanShot 2026-06-25 at 19 55 14" src="https://github.com/user-attachments/assets/061e9945-4bc2-4313-b0bd-46b0efd8a837" />


With 'Connect Base' option enabled:

<img width="1726" height="1425" alt="CleanShot 2026-06-25 at 19 55 51" src="https://github.com/user-attachments/assets/71f226ab-f566-496a-9bd1-4609ee6a9ed2" />

The exported objects came out like this:
<img width="1921" height="1396" alt="CleanShot 2026-06-25 at 19 59 27" src="https://github.com/user-attachments/assets/75df6d16-33f4-4d41-865d-45cf9906b011" />
