### PR TITLE
fix: clip tool cutouts at bin interior boundary

### DIFF
--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -399,6 +399,58 @@ def _shapely_to_cross_sections(shifted_pts: list[tuple], interior_rings: list[li
     return rings
 
 
+def _clip_to_interior(
+    shifted: list[tuple],
+    shifted_holes: list[list[tuple]],
+    interior_rect,
+) -> tuple[list[tuple], list[list[tuple]]]:
+    """clip a shifted polygon (+ holes) to the bin interior boundary.
+
+    returns (clipped_exterior, clipped_holes). if the polygon is entirely
+    outside the interior, returns empty lists.
+    """
+    from shapely.geometry import MultiPolygon as _SMPoly
+    from shapely.geometry import Polygon as _SPoly
+
+    poly = _SPoly(shifted, holes=shifted_holes if shifted_holes else [])
+    if not poly.is_valid:
+        poly = poly.buffer(0)
+    clipped = poly.intersection(interior_rect)
+    if clipped.is_empty:
+        return [], []
+
+    # intersection can return LineString/Point/GeometryCollection when
+    # a polygon only touches the clip rect at an edge or corner
+    if not isinstance(clipped, (_SPoly, _SMPoly)):
+        return [], []
+
+    # intersection can produce MultiPolygon; take the largest piece
+    if isinstance(clipped, _SMPoly):
+        clipped = max(clipped.geoms, key=lambda g: g.area)
+
+    ext = list(clipped.exterior.coords[:-1])
+    holes = [list(ring.coords[:-1]) for ring in clipped.interiors if len(ring.coords) >= 4]
+    return ext, holes
+
+
+def _interior_clip_rect(config):
+    """clip boundary for the bin interior in manifold coordinates (centred at origin).
+
+    when the stacking lip is enabled its inner profile protrudes inward by
+    LIP_D0+LIP_D2 (2.6mm) from the outer wall -- wider than typical wall_thickness.
+    use the larger of the two so cutouts never breach the lip zone.
+    """
+    from shapely.geometry import Polygon as _SPoly
+
+    outer_w = config.grid_x * GF_GRID - 0.5
+    outer_h = config.grid_y * GF_GRID - 0.5
+    lip_inset = (LIP_D0 + LIP_D2) if getattr(config, "stacking_lip", False) else 0.0
+    inset = max(config.wall_thickness, lip_inset)
+    hw = outer_w / 2 - inset
+    hh = outer_h / 2 - inset
+    return _SPoly([(-hw, -hh), (hw, -hh), (hw, hh), (-hw, hh)])
+
+
 def _make_polygon_cutouts(
     polygons: list[ScaledPolygon],
     config: GenerateRequest,
@@ -409,6 +461,8 @@ def _make_polygon_cutouts(
 ):
     """Batch union of all polygon cutout extrusions."""
     import manifold3d as mf
+
+    interior_rect = _interior_clip_rect(config)
 
     cutters = []
     for poly in polygons:
@@ -427,13 +481,19 @@ def _make_polygon_cutouts(
             ]
             if len(shifted_hole) >= 3:
                 shifted_holes.append(shifted_hole)
+
+        # clip to bin interior so oversized tools don't breach walls
+        shifted, shifted_holes = _clip_to_interior(shifted, shifted_holes, interior_rect)
+        if len(shifted) < 3:
+            continue
+
         try:
             rings = _shapely_to_cross_sections(shifted, shifted_holes)
             if not rings:
                 continue
             has_holes = len(rings) > 1
             if has_holes:
-                # use EvenOdd to handle holes — same pattern as text labels
+                # use EvenOdd to handle holes -- same pattern as text labels
                 cs = mf.CrossSection(rings, mf.FillRule.EvenOdd)
             else:
                 cs = mf.CrossSection(rings)
@@ -473,6 +533,8 @@ def _make_chamfer_cutouts(
     """
     import manifold3d as mf
 
+    interior_rect = _interior_clip_rect(config)
+
     cutters = []
     for poly in polygons:
         shifted = [
@@ -486,6 +548,11 @@ def _make_chamfer_cutouts(
             sh = [(p[0] + offset_x, -(p[1] + offset_y)) for p in hole]
             if len(sh) >= 3:
                 shifted_holes.append(sh)
+
+        # clip to bin interior so oversized tools don't breach walls
+        shifted, shifted_holes = _clip_to_interior(shifted, shifted_holes, interior_rect)
+        if len(shifted) < 3:
+            continue
 
         pocket_depth = _resolve_pocket_depth(poly.depth_override, config, max_depth)
         eff_chamfer = min(chamfer_size, max(0.0, pocket_depth - 1))

--- a/backend/tests/test_interior_clip_rect.py
+++ b/backend/tests/test_interior_clip_rect.py
@@ -1,0 +1,52 @@
+"""Tests for _interior_clip_rect lip-aware clipping."""
+import pytest
+
+from app.models.schemas import GenerateRequest
+from app.services.stl_generator_manifold import (
+    _interior_clip_rect,
+    GF_GRID,
+    LIP_D0,
+    LIP_D2,
+)
+
+
+def _make_config(**overrides):
+    defaults = dict(grid_x=2, grid_y=2, wall_thickness=1.2, stacking_lip=True)
+    defaults.update(overrides)
+    return GenerateRequest(**defaults)
+
+
+class TestInteriorClipRect:
+    def test_lip_inset_wider_than_wall(self):
+        """clip rect must account for stacking lip, not just wall_thickness."""
+        config = _make_config(wall_thickness=1.2, stacking_lip=True)
+        outer_w = config.grid_x * GF_GRID - 0.5
+        rect = _interior_clip_rect(config)
+        bounds = rect.bounds  # (minx, miny, maxx, maxy)
+
+        lip_inset = LIP_D0 + LIP_D2  # 2.6mm
+        expected_hw = outer_w / 2 - lip_inset
+        assert bounds[2] == pytest.approx(expected_hw, abs=0.01), (
+            f"clip rect half-width {bounds[2]} should use lip inset {lip_inset}, "
+            f"not wall_thickness {config.wall_thickness}"
+        )
+
+    def test_no_lip_uses_wall_thickness(self):
+        """without stacking lip, clip rect uses wall_thickness only."""
+        config = _make_config(wall_thickness=1.2, stacking_lip=False)
+        outer_w = config.grid_x * GF_GRID - 0.5
+        rect = _interior_clip_rect(config)
+        bounds = rect.bounds
+
+        expected_hw = outer_w / 2 - config.wall_thickness
+        assert bounds[2] == pytest.approx(expected_hw, abs=0.01)
+
+    def test_thick_wall_overrides_lip(self):
+        """if wall_thickness > lip inset, wall_thickness wins."""
+        config = _make_config(wall_thickness=3.0, stacking_lip=True)
+        outer_w = config.grid_x * GF_GRID - 0.5
+        rect = _interior_clip_rect(config)
+        bounds = rect.bounds
+
+        expected_hw = outer_w / 2 - config.wall_thickness
+        assert bounds[2] == pytest.approx(expected_hw, abs=0.01)

--- a/backend/tests/test_interior_clip_rect.py
+++ b/backend/tests/test_interior_clip_rect.py
@@ -3,10 +3,10 @@ import pytest
 
 from app.models.schemas import GenerateRequest
 from app.services.stl_generator_manifold import (
-    _interior_clip_rect,
     GF_GRID,
     LIP_D0,
     LIP_D2,
+    _interior_clip_rect,
 )
 
 

--- a/backend/tests/test_overflow_clip.py
+++ b/backend/tests/test_overflow_clip.py
@@ -1,0 +1,85 @@
+"""test that tool polygons extending beyond the bin wall are clipped
+at the interior boundary, not punched through the wall."""
+
+from pathlib import Path
+
+from app.models.schemas import GenerateRequest
+from app.services.polygon_scaler import ScaledPolygon
+from app.services.stl_generator_manifold import (
+    GF_GRID,
+    ManifoldSTLGenerator,
+)
+
+
+def test_overflow_polygon_matches_clipped_equivalent(tmp_path: Path):
+    """an oversized tool polygon should produce the same result as one
+    that's been manually trimmed to the bin interior.
+
+    we place a huge rectangle that overflows on all sides and compare
+    its bin volume against a rectangle trimmed to just inside the walls.
+    if clipping works, the two should produce identical geometry (same volume).
+    if clipping is missing, the oversized polygon carves through the walls
+    and removes more material, giving a smaller volume.
+    """
+    config = GenerateRequest(
+        grid_x=1.5,
+        grid_y=1.5,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        bed_size=0,
+        wall_thickness=1.6,
+    )
+    bin_w = config.grid_x * GF_GRID
+    bin_h = config.grid_y * GF_GRID
+
+    # oversized polygon: extends 10mm beyond each edge
+    overflow_poly = ScaledPolygon(
+        id="overflow",
+        points_mm=[
+            (-10, -10),
+            (bin_w + 10, -10),
+            (bin_w + 10, bin_h + 10),
+            (-10, bin_h + 10),
+        ],
+        label="overflow",
+    )
+
+    # manually clipped polygon: stays inside wall_thickness from each edge
+    # (the interior boundary the clipping should enforce)
+    wt = config.wall_thickness
+    clipped_poly = ScaledPolygon(
+        id="clipped",
+        points_mm=[
+            (wt, wt),
+            (bin_w - wt, wt),
+            (bin_w - wt, bin_h - wt),
+            (wt, bin_h - wt),
+        ],
+        label="clipped",
+    )
+
+    gen = ManifoldSTLGenerator()
+
+    body_overflow, _ = gen.generate_bin(
+        [overflow_poly], config, str(tmp_path / "overflow.stl")
+    )
+    body_clipped, _ = gen.generate_bin(
+        [clipped_poly], config, str(tmp_path / "clipped.stl")
+    )
+    body_empty, _ = gen.generate_bin(
+        [], config, str(tmp_path / "empty.stl")
+    )
+
+    # both should remove material compared to the empty bin
+    assert body_overflow.volume() < body_empty.volume()
+    assert body_clipped.volume() < body_empty.volume()
+
+    # the overflow and clipped bins should have the same volume
+    # (within mesh tolerance) if clipping is working
+    vol_diff = abs(body_overflow.volume() - body_clipped.volume())
+    assert vol_diff < 1.0, (
+        f"volume mismatch: overflow={body_overflow.volume():.1f} vs "
+        f"clipped={body_clipped.volume():.1f}, diff={vol_diff:.1f}mm^3. "
+        f"overflow polygon likely punching through walls."
+    )


### PR DESCRIPTION
## Summary

Tool polygons that extend beyond the bin boundary were punching through the walls, leaving holes in the STL. This clips all tool polygons against the bin interior rectangle before subtraction.

The clip boundary uses `max(wall_thickness, LIP_D0 + LIP_D2)` when a stacking lip is present, since the lip tapers inward further than the wall thickness alone.

Closes #118

## Changes

- `stl_generator_manifold.py`: added `_clip_to_interior()` and `_interior_clip_rect()` helpers, applied clipping in both `_make_polygon_cutouts()` and `_make_chamfer_cutouts()`
- `test_overflow_clip.py`: overflow polygon produces same volume as manually-clipped equivalent
- `test_interior_clip_rect.py`: lip-wider-than-wall, no-lip, and thick-wall-overrides-lip cases

## Test evidence

- 189/189 tests pass
- Verified visually: oversized tools no longer breach walls or stacking lip