### PR TITLE
fix: skip ONNX on non-AVX CPUs to prevent SIGILL crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Backend: ruff, configured in `pyproject.toml` (rules E/F/W/I, ignores E402/E501)
 
 Configurable via `GEMINI_IMAGE_MODEL` env var. Defaults to `gemini-3.1-flash-image-preview` locally, `gemini-3-pro-image-preview` in Docker. Also supports `gemini-2.5-flash-image` (faster, needs alignment).
 
-Two models run at all times: U2-Net Portable for paper detection and the configured tracer for tool tracing. Both load at startup. RAM figures are combined (tested in Linux containers).
+Two models run at all times: U2-Net Portable for paper detection and the configured tracer for tool tracing. Both load at startup. RAM figures are combined (tested in Linux containers). All local models require ONNX Runtime, which needs AVX CPU instructions. On non-AVX CPUs, U2-Net is skipped (paper detection falls back to OpenCV-only) and local tracers are unavailable -- use a remote tracer instead.
 
 Tracers (configurable via `TRACERS` env var):
 - `isnet` (default) -- IS-Net, good quality, ~0.8s/image, min 2GB

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ When no API key is configured, Tracefinity runs a local salient object detection
 | [BiRefNet Lite](https://github.com/ZhengPeng7/BiRefNet) | ~3.6s | 8GB | Best | Handles reflections and shiny surfaces well |
 | [InSPyReNet](https://github.com/plemeri/InSPyReNet) | ~2.8s | 6GB | Good | Apple Silicon (MPS) support |
 
-Paper corner detection runs [U2-Net Portable](https://github.com/xuebinqin/U-2-Net) alongside the tracer. RAM figures include both models. All models load at startup.
+Paper corner detection runs [U2-Net Portable](https://github.com/xuebinqin/U-2-Net) alongside the tracer. RAM figures include both models. All models load at startup. All local models require ONNX Runtime, which needs **AVX** CPU instructions. On non-AVX CPUs (some older VMs, Atoms), U2-Net is skipped (paper detection falls back to OpenCV-only, less accurate) and local tracers are unavailable. Remote tracers (Gemini, Replicate, fal) work regardless.
 
 **Minimum RAM: 2GB** (IS-Net). BiRefNet Lite needs **8GB**. See [Resource Requirements](docs/resource-requirements.md) for full details including Docker memory limits and platform support.
 

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -163,6 +163,12 @@ class AITracer:
             return
         label = LOCAL_MODEL_LABELS.get(name, name)
         if name in REMBG_MODELS:
+            from app.services.onnx_check import is_onnx_available
+            if not is_onnx_available():
+                raise RuntimeError(
+                    f"local tracer '{name}' requires ONNX runtime but this CPU "
+                    "lacks AVX support. Use a remote tracer (gemini/replicate/fal) instead."
+                )
             from rembg import new_session
 
             from app.services.ort_runtime import get_onnx_providers

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -108,11 +108,17 @@ def pick_paper_orientation(
 
 class ImageProcessor:
     def __init__(self):
-        from rembg import new_session
+        from app.services.onnx_check import is_onnx_available
 
-        from app.services.ort_runtime import get_onnx_providers
-        logger.info("loading U2-Net Portable for paper detection")
-        self._tool_mask_session = new_session("u2netp", providers=get_onnx_providers())
+        if is_onnx_available():
+            from rembg import new_session
+
+            from app.services.ort_runtime import get_onnx_providers
+            logger.info("loading U2-Net Portable for paper detection")
+            self._tool_mask_session = new_session("u2netp", providers=get_onnx_providers())
+        else:
+            logger.warning("U2-Net unavailable (no ONNX runtime), paper detection using OpenCV-only")
+            self._tool_mask_session = None
 
     def _get_tool_mask(self, image_path: str) -> np.ndarray:
         """get a rough tool mask via U2-Net Portable for paper detection."""
@@ -126,13 +132,14 @@ class ImageProcessor:
         return mask
 
     def detect_paper_corners(self, image_path: str) -> list[tuple[float, float]] | None:
-        """detect paper corners by masking out tools first."""
+        """detect paper corners, masking out tools when U2-Net is available."""
         img = cv2.imread(image_path)
         if img is None:
             return None
 
-        tool_mask = self._get_tool_mask(image_path)
-        img[tool_mask > 0] = [0, 0, 0]
+        if self._tool_mask_session is not None:
+            tool_mask = self._get_tool_mask(image_path)
+            img[tool_mask > 0] = [0, 0, 0]
 
         return self._detect_paper(img)
 

--- a/backend/app/services/onnx_check.py
+++ b/backend/app/services/onnx_check.py
@@ -1,0 +1,113 @@
+"""detect whether onnxruntime can run on this CPU.
+
+belt and braces: fast cpu flag check, then subprocess probe as fallback.
+result is cached at startup so the check runs once.
+"""
+from __future__ import annotations
+
+import logging
+import platform
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+_onnx_available: bool | None = None
+
+
+def _check_cpu_avx(cpuinfo_path: str = "/proc/cpuinfo") -> bool | None:
+    """check /proc/cpuinfo for avx flag (linux only).
+
+    returns True if avx found, False if flags line exists but no avx,
+    None if the file can't be read (not linux, or no access).
+    """
+    try:
+        with open(cpuinfo_path) as f:
+            for line in f:
+                if line.startswith("flags"):
+                    flags = line.split(":", 1)[1].split()
+                    return "avx" in flags
+    except (OSError, IOError):
+        return None
+    return None
+
+
+def _check_cpu_avx_macos() -> bool | None:
+    """check sysctl for avx flag on macos.
+
+    returns True/False/None same as _check_cpu_avx.
+    """
+    try:
+        result = subprocess.run(
+            ["sysctl", "machdep.cpu.features"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            features = result.stdout.upper().split(":", 1)
+            if len(features) == 2:
+                return "AVX" in features[1].split()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _probe_onnx_subprocess() -> bool:
+    """spawn a child process that tries to import onnxruntime.
+
+    catches SIGILL without killing the main process. this is the
+    robust fallback for any onnx incompatibility beyond avx.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c",
+             "import onnxruntime; onnxruntime.get_available_providers()"],
+            capture_output=True, timeout=30,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def is_onnx_available() -> bool:
+    """check if onnxruntime can safely run on this cpu.
+
+    uses a two-tier strategy:
+    1. cpu flag check (fast, no subprocess)
+    2. subprocess probe (catches SIGILL without killing main process)
+
+    result is cached after first call.
+    """
+    global _onnx_available
+    if _onnx_available is not None:
+        return _onnx_available
+
+    # tier 1: cpu flag check
+    avx = _check_cpu_avx()
+    if avx is None and platform.system() == "Darwin":
+        avx = _check_cpu_avx_macos()
+
+    if avx is True:
+        logger.debug("cpu avx support confirmed via flags")
+        _onnx_available = True
+        return True
+
+    if avx is False:
+        logger.warning(
+            "ONNX runtime not available (no AVX support). "
+            "Paper detection will use OpenCV-only mode. "
+            "Tool tracing requires a remote provider (gemini/replicate/fal)."
+        )
+        _onnx_available = False
+        return False
+
+    # tier 2: cpu flags indeterminate, try subprocess probe
+    logger.debug("cpu avx check indeterminate, probing onnxruntime via subprocess")
+    available = _probe_onnx_subprocess()
+    if not available:
+        logger.warning(
+            "ONNX runtime not available (subprocess probe failed). "
+            "Paper detection will use OpenCV-only mode. "
+            "Tool tracing requires a remote provider (gemini/replicate/fal)."
+        )
+    _onnx_available = available
+    return available

--- a/backend/tests/test_onnx_check.py
+++ b/backend/tests/test_onnx_check.py
@@ -1,0 +1,130 @@
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from app.services import onnx_check
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """clear the cached result between tests."""
+    onnx_check._onnx_available = None
+    yield
+    onnx_check._onnx_available = None
+
+
+class TestCheckCpuAvx:
+    def test_linux_with_avx(self, tmp_path):
+        cpuinfo = tmp_path / "cpuinfo"
+        cpuinfo.write_text(
+            "processor\t: 0\n"
+            "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic avx avx2\n"
+        )
+        assert onnx_check._check_cpu_avx(str(cpuinfo)) is True
+
+    def test_linux_without_avx(self, tmp_path):
+        cpuinfo = tmp_path / "cpuinfo"
+        cpuinfo.write_text(
+            "processor\t: 0\n"
+            "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sse4_2\n"
+        )
+        assert onnx_check._check_cpu_avx(str(cpuinfo)) is False
+
+    def test_linux_cpuinfo_missing(self):
+        assert onnx_check._check_cpu_avx("/nonexistent/cpuinfo") is None
+
+    def test_macos_with_avx(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0,
+                stdout="machdep.cpu.features: FPU VME SSE SSE2 AVX AVX2\n",
+            )
+            assert onnx_check._check_cpu_avx_macos() is True
+
+    def test_macos_without_avx(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0,
+                stdout="machdep.cpu.features: FPU VME SSE SSE2 SSE4.2\n",
+            )
+            assert onnx_check._check_cpu_avx_macos() is False
+
+    def test_macos_sysctl_fails(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert onnx_check._check_cpu_avx_macos() is None
+
+
+class TestSubprocessProbe:
+    def test_probe_succeeds(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0,
+            )
+            assert onnx_check._probe_onnx_subprocess() is True
+
+    def test_probe_fails_sigill(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=-4,  # SIGILL on linux
+            )
+            assert onnx_check._probe_onnx_subprocess() is False
+
+    def test_probe_fails_nonzero(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1,
+            )
+            assert onnx_check._probe_onnx_subprocess() is False
+
+    def test_probe_timeout(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="", timeout=10)):
+            assert onnx_check._probe_onnx_subprocess() is False
+
+    def test_probe_not_installed(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1,
+            )
+            assert onnx_check._probe_onnx_subprocess() is False
+
+
+class TestIsOnnxAvailable:
+    def test_cached_after_first_call(self):
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=True):
+            result1 = onnx_check.is_onnx_available()
+            assert result1 is True
+
+        # second call should use cache, not re-check
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=False):
+            result2 = onnx_check.is_onnx_available()
+            assert result2 is True  # still cached
+
+    def test_avx_present_skips_subprocess(self):
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=True) as cpu_check, \
+             patch.object(onnx_check, "_probe_onnx_subprocess") as probe:
+            result = onnx_check.is_onnx_available()
+            assert result is True
+            cpu_check.assert_called_once()
+            probe.assert_not_called()
+
+    def test_no_avx_returns_false(self):
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=False):
+            result = onnx_check.is_onnx_available()
+            assert result is False
+
+    def test_cpu_check_indeterminate_falls_back_to_probe(self):
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=None), \
+             patch.object(onnx_check, "_check_cpu_avx_macos", return_value=None), \
+             patch.object(onnx_check, "_probe_onnx_subprocess", return_value=True) as probe:
+            result = onnx_check.is_onnx_available()
+            assert result is True
+            probe.assert_called_once()
+
+    def test_cpu_check_indeterminate_probe_fails(self):
+        with patch.object(onnx_check, "_check_cpu_avx", return_value=None), \
+             patch.object(onnx_check, "_check_cpu_avx_macos", return_value=None), \
+             patch.object(onnx_check, "_probe_onnx_subprocess", return_value=False):
+            result = onnx_check.is_onnx_available()
+            assert result is False

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 ## Backend (Python/FastAPI)
-- Image upload with model-assisted paper corner detection (U2-Net Portable + OpenCV)
+- Image upload with model-assisted paper corner detection (U2-Net Portable + OpenCV; falls back to OpenCV-only on non-AVX CPUs where ONNX is unavailable)
 - Perspective correction using user-adjusted corners (portrait + landscape)
 - Tool tracing via local models (BiRefNet Lite, IS-Net, InSPyReNet) or Gemini API
 - Manual mask upload as alternative

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -47,6 +47,12 @@ Boolean operations (add, subtract) are single-threaded in OCCT. More cores don't
 - Undo/redo uses the `useHistory` hook (deep-clone, Cmd+Z handling). The `set()` method pushes to history; `undo()`/`redo()` call the `onChange` callback.
 - ToolEditor and BinEditor are split into orchestrator + toolbar + canvas sub-components. `CutoutOverlay` renders finger holes in both.
 
+## AVX / ONNX requirement
+
+U2-Net paper detection and all local tracers (`isnet`, `birefnet-lite`, `inspyrenet`) require ONNX Runtime, which needs AVX CPU instructions. On non-AVX CPUs (some older VMs, Atoms), ONNX is disabled at startup and paper detection falls back to OpenCV-only brightness thresholding -- less accurate, may need manual corner adjustment. Local tracers won't load; use a remote tracer (`gemini`, `replicate`, `fal`).
+
+Detection is two-tier: CPU flag check (`/proc/cpuinfo` on Linux, `sysctl` on macOS), then a subprocess probe that catches SIGILL without killing the main process. Result is cached for the process lifetime.
+
 ## Paper corner detection
 
 Uses a two-stage approach: U2-Net Portable generates a rough tool mask (~0.17s), tool pixels are blacked out, then OpenCV brightness thresholding finds the paper rectangle in the cleaned image. This prevents tools (especially dark ones on white paper) from fragmenting the paper region during detection.

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -16,7 +16,15 @@ RAM figures are measured in Linux containers with both models loaded. Models loa
 
 ## CPU
 
-Any modern x86-64 processor. All local models use ONNX Runtime on CPU by default. CUDA acceleration is available for NVIDIA GPUs (see README).
+Any modern x86-64 processor with AVX support. All local models (including U2-Net paper detection) use ONNX Runtime, which requires AVX instructions.
+
+On CPUs without AVX (some older VMs, Atoms, low-power NAS boxes):
+- U2-Net paper detection falls back to OpenCV-only brightness thresholding. Less accurate -- users may need to adjust corners manually more often.
+- Local ONNX tracers (`isnet`, `birefnet-lite`, `inspyrenet`) are unavailable.
+- Remote tracers (`gemini`, `replicate`, `fal`) work normally.
+- AVX availability is detected at startup (CPU flags + subprocess probe). A warning is logged when ONNX is unavailable.
+
+CUDA acceleration is available for NVIDIA GPUs (see README).
 
 ARM is supported: the Docker image ships linux/arm64 builds. Raspberry Pi 4/5 with 4GB+ RAM works (IS-Net or a remote tracer).
 


### PR DESCRIPTION
## Summary

Fixes #122. Backend crashes with SIGILL on non-AVX CPUs (e.g. AMD A6-3620) because onnxruntime loads unconditionally at startup for U2-Net paper detection, regardless of TRACERS config.

## Changes

- **New `onnx_check.py`**: two-tier ONNX availability detection. Checks CPU flags for AVX first (fast path via `/proc/cpuinfo` or `sysctl`), then spawns a subprocess probe that tries `import onnxruntime` (catches SIGILL without killing the main process). Result is cached after first call.
- **`image_processor.py`**: conditional U2-Net loading. When ONNX is unavailable, `_tool_mask_session` is `None` and paper detection skips the tool-masking preprocessing step, falling through to the existing OpenCV multi-strategy pipeline (brightness, Canny edges, adaptive threshold, saturation).
- **`ai_tracer.py`**: local rembg-based tracers (isnet, birefnet-lite, inspyrenet) check ONNX availability before loading. Raises a clear RuntimeError instead of crashing with SIGILL.
- **16 new tests** covering CPU flag parsing, subprocess probe (success, crash, timeout), caching, and the full fallback chain.

## Behaviour

| CPU | Effect |
|-|-|
| AVX present | No change. U2-Net loads, full paper detection accuracy |
| AVX absent, remote tracer (gemini/replicate/fal) | Paper detection degrades to OpenCV-only (less accurate, user can drag corners). Tracing works via remote API |
| AVX absent, local tracer | Clear error at tracer init, not a SIGILL crash |

## Test evidence

201/201 backend tests pass. Lint clean (0 errors).