### PR TITLE
fix: helm chart strategy indentation and envFrom default

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "tracefinity.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "tracefinity.selectorLabels" . | nindent 6 }}
@@ -30,8 +32,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      strategy:
-        type: Recreate
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,10 +16,10 @@ env:
   TRACEFINITY_ONNX_PROVIDER: "" # Local ONNX provider: auto, cuda, or cpu
   GEMINI_IMAGE_MODEL: "" # Gemini model for mask generation
 
-# Can be utilized to set environment variables from a ConfigMap or Secret. 
-envFrom: 
-  - secretRef:
-      name: existing-secret
+# envFrom can reference existing Secrets or ConfigMaps
+envFrom: []
+  # - secretRef:
+  #     name: existing-secret
   # - configMapRef:
   #     name: existing-config
 


### PR DESCRIPTION
## Summary

Closes #125. Follow-up from #79 (Helm chart contribution).

Two fixes:

1. **`strategy` moved to correct indent level** -- was under `spec.template.spec` (pod spec, silently ignored by K8s). Now under `spec` (deployment spec) alongside `replicas:`. Without this, upgrades default to RollingUpdate which deadlocks with the RWO PVC.

2. **`envFrom` defaults to `[]`** -- was defaulting to a concrete `secretRef: existing-secret`, causing `CreateContainerConfigError` on fresh installs. Now empty with commented examples.

## Test evidence

- `helm lint chart/` passes
- `helm template chart/` renders strategy at correct level, no envFrom block by default
- `make lint` clean