### PR TITLE
chore: add .gitattributes to enforce line endings for shell scripts and normalize text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must stay LF — they run inside Linux containers.
+*.sh text eol=lf
+
+# Keep other text files normalized
+* text=auto


### PR DESCRIPTION
If developing on Windows with WSL default git behavior uses CRLF for files.
Added .gitattributes so shell scripts always have LF line endings.