### PR TITLE
fix: keep photo aligned with tool outline under rotation

### DIFF
--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -3,6 +3,45 @@ import path from 'path'
 
 const FIXTURE_IMAGE = path.join(__dirname, 'fixtures', 'tool.jpg')
 
+type Mat = [number, number, number, number, number, number]
+
+// matrix(a, b, c, d, e, f) maps (x, y) -> (a*x + c*y + e, b*x + d*y + f)
+function parseMatrix(s: string): Mat {
+  const m = s.match(/matrix\(([^)]+)\)/)
+  if (!m) throw new Error(`not a matrix: ${s}`)
+  const v = m[1].split(/[\s,]+/).map(Number)
+  return [v[0], v[1], v[2], v[3], v[4], v[5]]
+}
+
+function invertMatrix([a, b, c, d, e, f]: Mat): Mat {
+  const det = a * d - c * b
+  const ia = d / det, ib = -b / det, ic = -c / det, id = a / det
+  return [ia, ib, ic, id, -(ia * e + ic * f), -(ib * e + id * f)]
+}
+
+function composeMatrix(m2: Mat, m1: Mat): Mat {
+  const [a2, b2, c2, d2, e2, f2] = m2
+  const [a1, b1, c1, d1, e1, f1] = m1
+  return [
+    a2 * a1 + c2 * b1,
+    b2 * a1 + d2 * b1,
+    a2 * c1 + c2 * d1,
+    b2 * c1 + d2 * d1,
+    a2 * e1 + c2 * f1 + e2,
+    b2 * e1 + d2 * f1 + f2,
+  ]
+}
+
+function applyMatrix([a, b, c, d, e, f]: Mat, p: { x: number; y: number }) {
+  return { x: a * p.x + c * p.y + e, y: b * p.x + d * p.y + f }
+}
+
+function firstVertex(d: string): { x: number; y: number } {
+  const m = d.match(/M\s*([\d.eE+-]+)[ ,]\s*([\d.eE+-]+)/)
+  if (!m) throw new Error(`no moveto in path: ${d.slice(0, 40)}`)
+  return { x: Number(m[1]), y: Number(m[2]) }
+}
+
 test.describe.serial('happy path', () => {
   let page: Page
 
@@ -106,6 +145,135 @@ test.describe.serial('happy path', () => {
 
     await page.getByRole('button', { name: 'Smooth' }).click()
     await expect(statusText).not.toHaveText(accurateText!, { timeout: 5_000 })
+  })
+
+  test('rotating keeps the source photo aligned through undo/redo', async () => {
+    // tools saved from a traced session carry their source photo
+    const image = page.locator('svg image')
+    await expect(image).toBeVisible({ timeout: 5_000 })
+    const before = await image.getAttribute('transform')
+    expect(before).toBeTruthy()
+
+    await page.getByRole('button', { name: 'Rotate 90 clockwise' }).click()
+    await expect(image).not.toHaveAttribute('transform', before!, { timeout: 5_000 })
+    const rotated = await image.getAttribute('transform')
+
+    // undo must restore the photo transform along with the outline
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', before!, { timeout: 5_000 })
+
+    // redo must re-apply it
+    await page.getByRole('button', { name: 'Redo (Ctrl+Shift+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', rotated!, { timeout: 5_000 })
+
+    // back to the original orientation for the rest of the flow
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', before!, { timeout: 5_000 })
+  })
+
+  test('auto-rotate keeps the source photo aligned', async () => {
+    // fresh mount so this test owns its undo history
+    await page.goto(`/tools/${toolId}`)
+    const image = page.locator('svg image')
+    await expect(image).toBeVisible({ timeout: 10_000 })
+    // accurate mode renders raw vertices, so the path's first vertex is stable
+    await page.getByRole('button', { name: 'Accurate' }).click()
+
+    // scope to the editor canvas: the dev overlay's shadow DOM also holds
+    // evenodd paths and playwright locators pierce shadow roots
+    const outline = page.locator('svg:has(image) path[fill-rule="evenodd"]')
+    const before = (await image.getAttribute('transform'))!
+    const dBefore = (await outline.getAttribute('d'))!
+
+    // deterministic angle: the endpoint only computes a number, the frontend
+    // applies it, so mocking it still exercises the whole rotation path
+    await page.route('**/api/tools/*/auto-rotate', route => route.fulfill({ json: { angle: 30 } }))
+    await page.getByRole('button', { name: 'Auto', exact: true }).click()
+    await expect(image).not.toHaveAttribute('transform', before, { timeout: 5_000 })
+    await page.unroute('**/api/tools/*/auto-rotate')
+
+    // outline and photo must undergo the same rigid transform: the photo's
+    // delta applied to the old first vertex must land on the new first vertex
+    const rotated = (await image.getAttribute('transform'))!
+    const delta = composeMatrix(parseMatrix(rotated), invertMatrix(parseMatrix(before)))
+    const expected = applyMatrix(delta, firstVertex(dBefore))
+    const vertexAfter = firstVertex((await outline.getAttribute('d'))!)
+    expect(vertexAfter.x).toBeCloseTo(expected.x, 3)
+    expect(vertexAfter.y).toBeCloseTo(expected.y, 3)
+
+    // undo restores both together, redo re-applies both
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', before, { timeout: 5_000 })
+    await expect(outline).toHaveAttribute('d', dBefore)
+    await page.getByRole('button', { name: 'Redo (Ctrl+Shift+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', rotated, { timeout: 5_000 })
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', before, { timeout: 5_000 })
+
+    await page.getByRole('button', { name: 'Smooth' }).click()
+  })
+
+  test('flips and drag-rotate carry the photo through undo', async () => {
+    await page.goto(`/tools/${toolId}`)
+    const image = page.locator('svg image')
+    await expect(image).toBeVisible({ timeout: 10_000 })
+    const t0 = (await image.getAttribute('transform'))!
+
+    await page.getByRole('button', { name: 'Flip horizontally' }).click()
+    await expect(image).not.toHaveAttribute('transform', t0, { timeout: 5_000 })
+    const t1 = (await image.getAttribute('transform'))!
+
+    await page.getByRole('button', { name: 'Flip vertically' }).click()
+    await expect(image).not.toHaveAttribute('transform', t1, { timeout: 5_000 })
+    const t2 = (await image.getAttribute('transform'))!
+
+    // drag-rotate from a corner rotation zone; mousedown is dispatched on the
+    // element because the zone rect is transparent to hit-testing
+    const zone = page.locator('svg:has(image) rect.cursor-rotate').first()
+    const box = (await zone.boundingBox())!
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await zone.evaluate((el, c) => {
+      el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientX: c.x, clientY: c.y }))
+    }, { x: cx, y: cy })
+    await page.mouse.move(cx + 80, cy + 30, { steps: 5 })
+    await page.mouse.up()
+    await expect(image).not.toHaveAttribute('transform', t2, { timeout: 5_000 })
+
+    // three entries, three undos, each restoring the photo with the outline
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', t2, { timeout: 5_000 })
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', t1, { timeout: 5_000 })
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', t0, { timeout: 5_000 })
+  })
+
+  test('edits during auto-rotate keep history intact', async () => {
+    await page.goto(`/tools/${toolId}`)
+    const image = page.locator('svg image')
+    await expect(image).toBeVisible({ timeout: 10_000 })
+    const t0 = (await image.getAttribute('transform'))!
+
+    // slow the angle fetch so a manual rotate can land mid-flight
+    await page.route('**/api/tools/*/auto-rotate', async route => {
+      await new Promise(resolve => setTimeout(resolve, 2_000))
+      await route.fulfill({ json: { angle: 30 } })
+    })
+    await page.getByRole('button', { name: 'Auto', exact: true }).click()
+    await page.getByRole('button', { name: 'Rotate 90 clockwise' }).click()
+    await expect(image).not.toHaveAttribute('transform', t0, { timeout: 1_000 })
+    const t1 = (await image.getAttribute('transform'))!
+
+    // auto-rotate resolves on top of the interleaved edit
+    await expect(image).not.toHaveAttribute('transform', t1, { timeout: 5_000 })
+    await page.unroute('**/api/tools/*/auto-rotate')
+
+    // both operations must be separate history entries, in order
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', t1, { timeout: 5_000 })
+    await page.getByRole('button', { name: 'Undo (Ctrl+Z)' }).click()
+    await expect(image).toHaveAttribute('transform', t0, { timeout: 5_000 })
   })
 
   test('navigate home', async () => {

--- a/frontend/src/app/tools/[id]/page.tsx
+++ b/frontend/src/app/tools/[id]/page.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Loader2, Check, Download, Folder } from 'lucide-react'
 import { getTool, updateTool, autoRotateTool, getToolSvgUrl, getImageUrl, listProjects } from '@/lib/api'
-import { rotateGeometry } from '@/lib/geometry'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { useProjectSource } from '@/hooks/useProjectSource'
 import { projectNameMap } from '@/lib/projectSelectors'
@@ -100,19 +99,13 @@ export default function ToolPage() {
     setTool(prev => prev ? { ...prev, interior_rings } : null)
   }, [])
 
+  // fetches the optimal angle only; ToolEditor applies it so the outline,
+  // photo transform and undo history change as one operation
   const handleAutoRotate = useCallback(async (): Promise<number | null> => {
     if (!tool || autoRotating) return null
     setAutoRotating(true)
     try {
       const { angle } = await autoRotateTool(toolId)
-      if (Math.abs(angle) < 0.01) return null
-      const rotated = rotateGeometry(tool.points, tool.finger_holes, tool.interior_rings, angle)
-      setTool(prev => prev ? {
-        ...prev,
-        points: rotated.points,
-        finger_holes: rotated.fingerHoles,
-        interior_rings: rotated.interiorRings,
-      } : prev)
       return angle
     } catch (err) {
       console.error('auto-rotate failed:', err)

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
+import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
 import { Plus, Circle, Disc, Square, RectangleHorizontal, Fingerprint, ImageIcon, Eye, EyeOff } from 'lucide-react'
 import type { Point, FingerHole, ToolImageContext, AffineMatrix } from '@/types'
 import { simplifyPolygon, smoothEpsilon, simplifyEpsilon, snapToGrid as snapToGridUtil } from '@/lib/svg'
@@ -55,6 +55,7 @@ interface HistoryEntry {
   points: Point[]
   fingerHoles: FingerHole[]
   interiorRings: Point[][]
+  imageTransform: AffineMatrix | null
 }
 
 export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoothLevel, sourceImageContext, showSourceImage = false, onShowSourceImageChange, sourceImageOpacity = 0.45, onSourceImageOpacityChange, onImageTransformChange, onPointsChange, onFingerHolesChange, onSmoothedChange, onSmoothLevelChange, onInteriorRingsChange, onAutoRotate, autoRotating }: Props) {
@@ -87,18 +88,36 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   useEffect(() => { axisRef.current = symmetryAxis }, [symmetryAxis])
   useEffect(() => { keepSideRef.current = keepSide }, [keepSide])
 
+  const imageTransformRef = useRef<AffineMatrix | null>(sourceImageContext?.transform ?? null)
+  const onImageTransformRef = useRef(onImageTransformChange)
+
   // undo/redo
   const historyOnChange = useCallback((entry: HistoryEntry) => {
     onPointsChange(entry.points)
     onFingerHolesChange(entry.fingerHoles)
     onInteriorRingsChange?.(entry.interiorRings)
+    // restore the photo transform captured with this entry so the source
+    // image stays aligned with the outline across undo/redo
+    if (entry.imageTransform) {
+      imageTransformRef.current = entry.imageTransform
+      onImageTransformRef.current?.(entry.imageTransform)
+    }
   }, [onPointsChange, onFingerHolesChange, onInteriorRingsChange])
 
   const currentRings = interiorRings ?? []
 
-  const { set: pushHistory, undo: handleUndo, redo: handleRedo, canUndo, canRedo } = useHistory<HistoryEntry>(
-    { points, fingerHoles, interiorRings: currentRings },
+  const { set: pushEntry, undo: handleUndo, redo: handleRedo, canUndo, canRedo } = useHistory<HistoryEntry>(
+    { points, fingerHoles, interiorRings: currentRings, imageTransform: sourceImageContext?.transform ?? null },
     historyOnChange
+  )
+
+  // every entry snapshots the photo transform alongside the geometry;
+  // rotate/flip pass their post-op transform explicitly
+  const pushHistory = useCallback(
+    (entry: Omit<HistoryEntry, 'imageTransform'>, imageTransform: AffineMatrix | null = imageTransformRef.current) => {
+      pushEntry({ ...entry, imageTransform })
+    },
+    [pushEntry]
   )
 
   // local drag state: renders locally during drag, flushes to parent on mouseup
@@ -123,8 +142,6 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
   const onPointsRef = useRef(onPointsChange)
   const onHolesRef = useRef(onFingerHolesChange)
   const onRingsRef = useRef(onInteriorRingsChange)
-  const imageTransformRef = useRef<AffineMatrix | null>(sourceImageContext?.transform ?? null)
-  const onImageTransformRef = useRef(onImageTransformChange)
   useEffect(() => { pointsRef.current = points }, [points])
   useEffect(() => { holesRef.current = fingerHoles }, [fingerHoles])
   useEffect(() => { dragPointsRef.current = dragPoints }, [dragPoints])
@@ -358,37 +375,32 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
     if (pts.length === 0) return
     const { x: cx, y: cy } = centroidOf(pts)
     const rotated = rotateGeometry(pts, holesRef.current, currentRingsRef.current, angleDeg)
-    pushHistory({ points: rotated.points, fingerHoles: rotated.fingerHoles, interiorRings: rotated.interiorRings })
+    // rotate the photo about the same centre so it stays under the outline
+    const m = imageTransformRef.current
+    const nextTransform = m ? rotateAround(m, angleDeg * Math.PI / 180, cx, cy) : null
+    pushHistory({ points: rotated.points, fingerHoles: rotated.fingerHoles, interiorRings: rotated.interiorRings }, nextTransform)
     onPointsRef.current(rotated.points)
     onHolesRef.current(rotated.fingerHoles)
     onRingsRef.current?.(rotated.interiorRings)
-    const m = imageTransformRef.current
-    if (m && onImageTransformRef.current) {
-      const rad = angleDeg * Math.PI / 180
-      const next = rotateAround(m, rad, cx, cy)
-      imageTransformRef.current = next
-      onImageTransformRef.current(next)
+    if (nextTransform) {
+      imageTransformRef.current = nextTransform
+      onImageTransformRef.current?.(nextTransform)
     }
   }, [pushHistory])
 
-  // wraps the parent's auto-rotate to add undo history and image transform rotation
+  // edits can land while the angle fetch is in flight; the ref must point at
+  // the latest rotateAll (whose history push closes over the current index)
+  // before the await resumes, hence layout effect rather than passive effect
+  const rotateAllRef = useRef(rotateAll)
+  useLayoutEffect(() => { rotateAllRef.current = rotateAll }, [rotateAll])
+
+  // fetches the optimal angle from the parent, then applies it through
+  // rotateAll so geometry, photo and undo history stay in lockstep
   const handleAutoRotateWrapped = useCallback(async () => {
     if (!onAutoRotate) return
-    const pts = pointsRef.current
-    if (pts.length === 0) return
-    pushHistory({ points: pts, fingerHoles: holesRef.current, interiorRings: currentRingsRef.current })
     const angle = await onAutoRotate()
-    if (angle != null && Math.abs(angle) >= 0.01) {
-      const { x: cx, y: cy } = centroidOf(pts)
-      const m = imageTransformRef.current
-      if (m && onImageTransformRef.current) {
-        const rad = angle * Math.PI / 180
-        const next = rotateAround(m, rad, cx, cy)
-        imageTransformRef.current = next
-        onImageTransformRef.current(next)
-      }
-    }
-  }, [onAutoRotate, pushHistory])
+    if (angle != null && Math.abs(angle) >= 0.01) rotateAllRef.current(angle)
+  }, [onAutoRotate])
 
   const flipAll = useCallback((axis: 'horizontal' | 'vertical') => {
     const pts = pointsRef.current
@@ -409,15 +421,16 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       rotation: -((fh.rotation || 0) % 360),
     }))
     const newRings = rings.map(ring => ring.map(flip).reverse())
-    pushHistory({ points: newPts, fingerHoles: newHoles, interiorRings: newRings })
+    // mirror the photo about the same axis so it stays under the outline
+    const m = imageTransformRef.current
+    const nextTransform = m ? flipAround(m, axis, cx, cy) : null
+    pushHistory({ points: newPts, fingerHoles: newHoles, interiorRings: newRings }, nextTransform)
     onPointsRef.current(newPts)
     onHolesRef.current(newHoles)
     onInteriorRingsChange?.(newRings)
-    const m = imageTransformRef.current
-    if (m && onImageTransformRef.current) {
-      const next = flipAround(m, axis, cx, cy)
-      imageTransformRef.current = next
-      onImageTransformRef.current(next)
+    if (nextTransform) {
+      imageTransformRef.current = nextTransform
+      onImageTransformRef.current?.(nextTransform)
     }
   }, [pushHistory, onInteriorRingsChange])
 
@@ -725,15 +738,16 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       if (dragPointsRef.current) onPointsRef.current(finalPoints)
       if (dragHolesRef.current) onHolesRef.current(finalHoles)
       if (dragRingsRef.current) onRingsRef.current?.(finalRings)
-      pushHistory({ points: finalPoints, fingerHoles: finalHoles, interiorRings: finalRings })
-      if (dragging.type === 'rotate-polygon' && rotateDragRef.current) {
-        const { delta, cx, cy } = rotateDragRef.current
-        const m = imageTransformRef.current
-        if (m && delta !== 0 && onImageTransformRef.current) {
-          const next = rotateAround(m, delta, cx, cy)
-          imageTransformRef.current = next
-          onImageTransformRef.current(next)
-        }
+      // rotate-polygon drags carry the photo with them
+      const m = imageTransformRef.current
+      const rotDrag = dragging.type === 'rotate-polygon' ? rotateDragRef.current : null
+      const nextTransform = m && rotDrag && rotDrag.delta !== 0
+        ? rotateAround(m, rotDrag.delta, rotDrag.cx, rotDrag.cy)
+        : m
+      pushHistory({ points: finalPoints, fingerHoles: finalHoles, interiorRings: finalRings }, nextTransform)
+      if (nextTransform && nextTransform !== m) {
+        imageTransformRef.current = nextTransform
+        onImageTransformRef.current?.(nextTransform)
       }
       rotateDragRef.current = null
       setDragPoints(null)


### PR DESCRIPTION
## Summary

- Undo/redo history only snapshotted geometry, so the photo transform went stale and repeated rotations compounded into the misalignment reported in #129. History entries now carry the photo transform and undo/redo restores it.
- Auto-rotate split one operation across two layers (page rotated geometry, editor rotated the photo) with a pre-rotation history push, leaving redo dead and undo skipping a step. It now runs through a single `rotateAll` path: geometry + photo + one history entry.
- The post-await history push is routed through a ref so edits landing while the auto-rotate request is in flight cannot corrupt history.

## Test evidence

- `make lint-frontend`: 0 errors
- vitest: 80/80
- Playwright e2e: 23/23, three consecutive full-suite runs. Three new regression tests, each verified to fail before the fix: rotate/undo/redo photo round-trip, auto-rotate rigid-transform coupling between outline and photo, interleaved edit during auto-rotate fetch.

Closes #129
