### PR TITLE
fix: lower cutout resize minimum from 10mm to 1mm

### DIFF
--- a/backend/tests/test_small_cutouts.py
+++ b/backend/tests/test_small_cutouts.py
@@ -1,0 +1,94 @@
+"""Small rectangle cutouts (issue #114): 25x5mm and 1mm-floor sizes must
+produce valid geometry."""
+from pathlib import Path
+
+import pytest
+
+from app.models.schemas import BinParams, GenerateRequest
+from app.services.polygon_scaler import ScaledFingerHole, ScaledPolygon
+from app.services.stl_generator_manifold import (
+    ManifoldSTLGenerator,
+    _make_finger_holes,
+)
+
+
+def _poly_with_rect_hole(shape: str, width: float, height: float, hole_x=42.0, hole_y=17.0):
+    fh = ScaledFingerHole(
+        id="fh1",
+        x_mm=hole_x,
+        y_mm=hole_y,
+        radius_mm=max(width, height) / 2,
+        shape=shape,
+        width_mm=width,
+        height_mm=height,
+        rotation=0.0,
+    )
+    return ScaledPolygon(
+        id="p1",
+        points_mm=[(17, 17), (67, 17), (67, 67), (17, 67)],
+        label="test",
+        finger_holes=[fh],
+    )
+
+
+def _poly_without_hole():
+    return ScaledPolygon(
+        id="p1",
+        points_mm=[(17, 17), (67, 17), (67, 67), (17, 67)],
+        label="test",
+        finger_holes=[],
+    )
+
+
+def _config():
+    return GenerateRequest(
+        grid_x=2, grid_y=2, height_units=4,
+        magnets=False, stacking_lip=False, bed_size=0,
+        cutout_depth=10.0,
+    )
+
+
+@pytest.mark.parametrize("shape", ["rectangle", "filleted_rectangle"])
+class TestSmallRectangleCutter:
+    def test_25x5_cutter_has_correct_extents(self, shape):
+        poly = _poly_with_rect_hole(shape, width=25.0, height=5.0)
+        config = BinParams(cutout_depth=10.0)
+        cutter = _make_finger_holes(
+            [poly], config, wall_top_z=25.0, max_depth=15.0,
+            offset_x=0.0, offset_y=0.0,
+        )
+        assert cutter is not None
+        assert cutter.volume() > 0
+        bb = cutter.bounding_box()
+        assert abs((bb[3] - bb[0]) - 25.0) < 0.1
+        assert abs((bb[4] - bb[1]) - 5.0) < 0.1
+
+    def test_1mm_floor_cutter_is_valid(self, shape):
+        poly = _poly_with_rect_hole(shape, width=1.0, height=1.0)
+        config = BinParams(cutout_depth=10.0)
+        cutter = _make_finger_holes(
+            [poly], config, wall_top_z=25.0, max_depth=15.0,
+            offset_x=0.0, offset_y=0.0,
+        )
+        assert cutter is not None
+        assert cutter.volume() > 0
+
+
+@pytest.mark.parametrize("shape", ["rectangle", "filleted_rectangle"])
+def test_25x5_cutout_generates_valid_bin(shape, tmp_path: Path):
+    """Reporter's exact case: 25x5mm cutout straddling the polygon edge."""
+    gen = ManifoldSTLGenerator()
+    config = _config()
+
+    with_hole, _ = gen.generate_bin(
+        [_poly_with_rect_hole(shape, width=25.0, height=5.0)],
+        config, str(tmp_path / "with.stl"),
+    )
+    without_hole, _ = gen.generate_bin(
+        [_poly_without_hole()], config, str(tmp_path / "without.stl"),
+    )
+
+    assert with_hole.volume() > 0
+    assert (tmp_path / "with.stl").exists()
+    # hole straddles the polygon edge, so it must remove extra material
+    assert with_hole.volume() < without_hole.volume()

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -12,7 +12,7 @@ import {
   type SymmetryAxis, type KeepSide,
 } from '@/lib/symmetry'
 import { DISPLAY_SCALE, SNAP_GRID, ZOOM_FACTOR } from '@/lib/constants'
-import { cutoutShapeLabel, isRectangularCutout } from '@/lib/cutouts'
+import { cutoutShapeLabel, isRectangularCutout, resizeRectCutout, resizeRoundCutout } from '@/lib/cutouts'
 import { useHistory } from '@/hooks/useHistory'
 import { ToolEditorToolbar } from '@/components/ToolEditorToolbar'
 import { ToolEditorCanvas } from '@/components/ToolEditorCanvas'
@@ -650,26 +650,11 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       let updated = currentHoles.map(fh => {
         if (fh.id !== dragging.holeId) return fh
         if (isRectangularCutout(fh.shape) && dragging.anchorX !== undefined && dragging.anchorY !== undefined) {
-          // pinned corner resize: anchor stays fixed, dragged corner follows mouse
-          const rot = (dragging.rotation || 0) * Math.PI / 180
-          const cosR = Math.cos(rot), sinR = Math.sin(rot)
-          // vector from anchor to mouse in local space
-          const gdx = pos.x - dragging.anchorX
-          const gdy = pos.y - dragging.anchorY
-          const localW = gdx * cosR + gdy * sinR
-          const localH = -gdx * sinR + gdy * cosR
-          const newW = Math.max(10, Math.abs(localW))
-          const newH = Math.max(10, Math.abs(localH))
-          // new centre = midpoint of anchor and dragged corner
-          const cx = (dragging.anchorX + pos.x) / 2
-          const cy = (dragging.anchorY + pos.y) / 2
-          resized = { ...fh, x: snap(cx), y: snap(cy), width: newW, height: newH, radius: Math.max(newW, newH) / 2 }
+          const r = resizeRectCutout(dragging.anchorX, dragging.anchorY, pos.x, pos.y, dragging.rotation || 0)
+          resized = { ...fh, x: snap(r.x), y: snap(r.y), width: r.width, height: r.height, radius: Math.max(r.width, r.height) / 2 }
           return resized
         }
-        // circle / square: distance from centre
-        const dx = pos.x - dragging.centerX
-        const dy = pos.y - dragging.centerY
-        resized = { ...fh, radius: Math.max(5, Math.sqrt(dx * dx + dy * dy)) }
+        resized = { ...fh, radius: resizeRoundCutout(dragging.centerX, dragging.centerY, pos.x, pos.y) }
         return resized
       })
       if (mirror && axis && dragging.mirrorId && resized) {

--- a/frontend/src/lib/cutouts.test.ts
+++ b/frontend/src/lib/cutouts.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { MIN_CUTOUT_SIZE_MM, resizeRectCutout, resizeRoundCutout } from './cutouts'
+
+// guards issue #114: rectangle cutouts must resize below 10mm
+describe('resizeRectCutout', () => {
+  it('allows a 25x5mm rectangle', () => {
+    const r = resizeRectCutout(0, 0, 25, 5, 0)
+    expect(r.width).toBeCloseTo(25)
+    expect(r.height).toBeCloseTo(5)
+  })
+
+  it('clamps dimensions to the minimum cutout size', () => {
+    const r = resizeRectCutout(0, 0, 0.4, 0.4, 0)
+    expect(r.width).toBe(MIN_CUTOUT_SIZE_MM)
+    expect(r.height).toBe(MIN_CUTOUT_SIZE_MM)
+  })
+
+  it('allows the minimum size exactly', () => {
+    const r = resizeRectCutout(0, 0, MIN_CUTOUT_SIZE_MM, MIN_CUTOUT_SIZE_MM, 0)
+    expect(r.width).toBeCloseTo(MIN_CUTOUT_SIZE_MM)
+    expect(r.height).toBeCloseTo(MIN_CUTOUT_SIZE_MM)
+  })
+
+  it('measures dimensions in local space under rotation', () => {
+    // 90deg rotation: global (5, 25) drag reads as 25 wide x 5 high locally
+    const r = resizeRectCutout(0, 0, 5, 25, 90)
+    expect(r.width).toBeCloseTo(25)
+    expect(r.height).toBeCloseTo(5)
+  })
+
+  it('centres the rectangle at the anchor-mouse midpoint', () => {
+    const r = resizeRectCutout(10, 20, 30, 40, 0)
+    expect(r.x).toBeCloseTo(20)
+    expect(r.y).toBeCloseTo(30)
+  })
+
+  it('handles dragging past the anchor (negative local dims)', () => {
+    const r = resizeRectCutout(25, 5, 0, 0, 0)
+    expect(r.width).toBeCloseTo(25)
+    expect(r.height).toBeCloseTo(5)
+  })
+})
+
+// guards the circle/square radius floor against regressing to the old 5mm
+describe('resizeRoundCutout', () => {
+  it('returns the centre-to-mouse distance as radius', () => {
+    expect(resizeRoundCutout(0, 0, 3, 4)).toBeCloseTo(5)
+  })
+
+  it('allows radii below the old 5mm floor', () => {
+    expect(resizeRoundCutout(0, 0, 2, 0)).toBeCloseTo(2)
+  })
+
+  it('clamps the radius to half the minimum cutout size', () => {
+    expect(resizeRoundCutout(0, 0, 0.1, 0)).toBe(MIN_CUTOUT_SIZE_MM / 2)
+  })
+})
+
+describe('MIN_CUTOUT_SIZE_MM', () => {
+  it('is well below the reported 10mm floor', () => {
+    expect(MIN_CUTOUT_SIZE_MM).toBeLessThanOrEqual(5)
+    expect(MIN_CUTOUT_SIZE_MM).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/lib/cutouts.ts
+++ b/frontend/src/lib/cutouts.ts
@@ -1,5 +1,9 @@
 import type { CutoutShape } from '@/types'
 
+// floor for cutout dimensions in mm; keeps geometry non-degenerate and
+// shapes grabbable in the editor while allowing narrow slots (issue #114)
+export const MIN_CUTOUT_SIZE_MM = 1
+
 const CUTOUT_SHAPE_LABELS: Record<CutoutShape, string> = {
   circle: 'circle',
   cylinder: 'cylinder',
@@ -22,4 +26,43 @@ export function filletedRectangleRadius(width: number, cutoutDepth: number): num
 
 export function cutoutShapeLabel(shape?: CutoutShape): string {
   return shape ? CUTOUT_SHAPE_LABELS[shape] : CUTOUT_SHAPE_LABELS.circle
+}
+
+// pinned-corner resize: dragged corner follows the mouse, dims measured in
+// the rectangle's local (rotated) space and floored at MIN_CUTOUT_SIZE_MM.
+// centre is always the anchor-mouse midpoint, so when the floor clamps the
+// anchored corner drifts slightly rather than staying fixed
+export function resizeRectCutout(
+  anchorX: number,
+  anchorY: number,
+  mouseX: number,
+  mouseY: number,
+  rotationDeg: number,
+): { x: number; y: number; width: number; height: number } {
+  const rot = rotationDeg * Math.PI / 180
+  const cosR = Math.cos(rot)
+  const sinR = Math.sin(rot)
+  const gdx = mouseX - anchorX
+  const gdy = mouseY - anchorY
+  const localW = gdx * cosR + gdy * sinR
+  const localH = -gdx * sinR + gdy * cosR
+  return {
+    x: (anchorX + mouseX) / 2,
+    y: (anchorY + mouseY) / 2,
+    width: Math.max(MIN_CUTOUT_SIZE_MM, Math.abs(localW)),
+    height: Math.max(MIN_CUTOUT_SIZE_MM, Math.abs(localH)),
+  }
+}
+
+// circle/square resize: radius is the centre-to-mouse distance, floored at
+// half MIN_CUTOUT_SIZE_MM (1mm diameter / side)
+export function resizeRoundCutout(
+  centerX: number,
+  centerY: number,
+  mouseX: number,
+  mouseY: number,
+): number {
+  const dx = mouseX - centerX
+  const dy = mouseY - centerY
+  return Math.max(MIN_CUTOUT_SIZE_MM / 2, Math.sqrt(dx * dx + dy * dy))
 }


### PR DESCRIPTION
## Summary

- Rectangle cutout drag-resize was floored at 10mm per dimension (radius 5mm for circle/square), an arbitrary default carried from the initial release with no geometric justification. The reporter wanted a 25x5mm slot.
- New floor is 1mm per dimension (0.5mm radius): the practical FDM printing floor. Backend verified safe down to 1x1mm: cutters are plain solids, fillet radii self-clamp, clearance buffers only apply to traced polygon outlines.
- Resize maths extracted from the component into pure helpers (`resizeRectCutout`, `resizeRoundCutout`) with unit tests, including a mutation-guard against the floor regressing.

## Test evidence

- Frontend vitest: 90/90, 10 new tests (25x5mm allowed, sub-floor clamps, rotation-local dims, midpoint centring, radius floor regression guard). New tests verified red before the fix.
- Backend pytest: 235/235, 6 new tests: 1x1mm and 25x5mm cutters produce valid geometry with correct extents; full `generate_bin` for the reporter's exact 25x5mm case yields a valid STL that removes material.
- `make lint`: 0 errors.

Closes #114
