### PR TITLE
fix: default snap to grid to off in bin editor

### DIFF
--- a/docs/usage/bin-layout.md
+++ b/docs/usage/bin-layout.md
@@ -14,7 +14,7 @@ The tool library strip shows all available tools (filtered to the current projec
 
 Click a placed tool to select it. Drag to reposition. The toolbar updates to show options for the selected tool.
 
-Snap is on by default (5mm grid). Toggle it with the **Snap** button in the floating toolbar.
+Snap is off by default (5mm grid when enabled). Toggle it with the **Snap** button in the floating toolbar.
 
 ## Rotating tools
 

--- a/frontend/src/components/BinEditor.test.tsx
+++ b/frontend/src/components/BinEditor.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { BinEditor } from './BinEditor'
+import { SNAP_GRID } from '@/lib/constants'
+
+const baseProps = {
+  placedTools: [],
+  onPlacedToolsChange: () => {},
+  textLabels: [],
+  onTextLabelsChange: () => {},
+  gridX: 2,
+  gridY: 2,
+  partialBins: false,
+  partialBinsValues: [false, false],
+  wallThickness: 1.6,
+  defaultCutoutDepth: 10,
+  maxCutoutDepth: 20,
+}
+
+describe('BinEditor snap to grid', () => {
+  afterEach(cleanup)
+
+  it('defaults to off', () => {
+    render(<BinEditor {...baseProps} />)
+
+    expect(screen.getByTitle(`Snap to ${SNAP_GRID}mm grid (off)`)).toBeTruthy()
+  })
+
+  it('can be toggled on', () => {
+    render(<BinEditor {...baseProps} />)
+
+    fireEvent.click(screen.getByTitle(`Snap to ${SNAP_GRID}mm grid (off)`))
+
+    expect(screen.getByTitle(`Snap to ${SNAP_GRID}mm grid (on)`)).toBeTruthy()
+  })
+})

--- a/frontend/src/components/BinEditor.tsx
+++ b/frontend/src/components/BinEditor.tsx
@@ -67,7 +67,7 @@ export function BinEditor({
   const [selection, setSelection] = useState<Selection>(null)
   const [activeTool, setActiveTool] = useState<Tool>('select')
   const [dragging, setDragging] = useState<DragState>(null)
-  const [snapEnabled, setSnapEnabled] = useState(true)
+  const [snapEnabled, setSnapEnabled] = useState(false)
   const [snapGrid, setSnapGrid] = useState(SNAP_GRID)
   const [pendingLabel, setPendingLabel] = useState<{ x: number; y: number } | null>(null)
   const [pendingText, setPendingText] = useState('')


### PR DESCRIPTION
## Summary

- Snap to grid in the bin editor defaulted to on, forcing users to toggle it off before free placement. It now defaults to off; the toggle behaviour is unchanged and the tool editor already defaulted off, so the two editors are now consistent.
- Snap state is ephemeral component state (no persistence), so this is purely the initial default.
- Usage doc updated to match.

## Test evidence

- New jsdom tests: snap shows off on mount, click flips it on. Both verified red against the old default.
- vitest 92/92, `make lint-frontend` 0 errors.

Closes #117
