### PR TITLE
feat: import SVG outlines (e.g. Shaper Trace) directly as library tools

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -85,6 +85,7 @@ from app.services.project_service import (
 from app.services.project_store import ProjectStore
 from app.services.session_store import SessionStore
 from app.services.stl_generator_manifold import ManifoldSTLGenerator
+from app.services.svg_import import SvgImportError, parse_svg_outline
 from app.services.tool_store import ToolStore
 from app.services.tracer_registry import TRACER_LABELS, tracer_kind, validate_tracer_ids
 
@@ -1116,6 +1117,56 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
         tool_ids.append(tool_id)
 
     return SaveToolsResponse(tool_ids=tool_ids)
+
+
+@router.post("/tools/import-svg", response_model=SaveToolsResponse)
+async def import_svg_tool(
+    request: Request,
+    file: UploadFile,
+    name: str | None = None,
+    user_id: str = Depends(get_user_id),
+):
+    """Import a vector SVG (e.g. Shaper Trace) directly as a library tool.
+
+    The SVG's own width/height + viewBox give real-world scale, so the outline is
+    stored at exact millimetre size with no photo tracing.
+    """
+    raw = await file.read()
+    if len(raw) > settings.max_upload_mb * 1024 * 1024:
+        raise HTTPException(status_code=413, detail=f"file too large (max {settings.max_upload_mb}MB)")
+    try:
+        outline_mm, rings_mm, meta = parse_svg_outline(raw.decode("utf-8", errors="replace"))
+    except SvgImportError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    _, user_tools, _ = get_stores(user_id)
+    tool_name = (name or Path(file.filename or "Imported tool").stem or "Imported tool").strip()
+
+    # points are already mm; scale_factor=1.0 just centres them at the origin
+    source_poly = Polygon(
+        id=str(uuid.uuid4()),
+        points=[Point(x=x, y=y) for x, y in outline_mm],
+        label=tool_name,
+        interior_rings=[[Point(x=x, y=y) for x, y in ring] for ring in rings_mm],
+    )
+    centered, fholes, interior_rings = polygon_scaler.scale_and_centre(source_poly, 1.0)
+    if not centered:
+        raise HTTPException(status_code=400, detail="SVG outline is empty after parsing")
+
+    tool_id = str(uuid.uuid4())
+    user_tools.set(tool_id, Tool(
+        id=tool_id,
+        name=tool_name,
+        points=centered,
+        finger_holes=fholes,
+        interior_rings=interior_rings,
+        created_at=datetime.utcnow().isoformat(),
+    ))
+    logger.info(
+        "imported svg tool %s: %.1f x %.1f mm, %d holes",
+        tool_id, meta["width_mm"], meta["height_mm"], meta["hole_count"],
+    )
+    return SaveToolsResponse(tool_ids=[tool_id])
 
 
 # --- bin projects ---

--- a/backend/app/services/svg_import.py
+++ b/backend/app/services/svg_import.py
@@ -1,0 +1,253 @@
+"""Parse a Shaper Trace (or generic) SVG into a tool outline in millimetres.
+
+Shaper Trace exports carry real-world size on the root <svg>: ``width``/``height``
+in physical units plus a ``viewBox`` in internal units, so every path coordinate
+converts to millimetres exactly, with no photo tracing / calibration needed.
+
+The largest closed path becomes the tool outline; any other closed path that is
+large enough and sits inside the outline becomes an interior ring (hole).
+"""
+from __future__ import annotations
+
+import re
+
+# subdivisions per cubic/quadratic bezier segment when flattening to a polyline
+BEZIER_STEPS = 10
+# an interior path must be at least this fraction of the outline area to count as a hole
+INTERIOR_MIN_FRAC = 0.03
+# unit -> millimetre conversion (CSS px are 96 per inch)
+_UNIT_MM = {"mm": 1.0, "cm": 10.0, "in": 25.4, "pt": 25.4 / 72.0, "pc": 25.4 / 6.0,
+            "px": 25.4 / 96.0, "": 25.4 / 96.0}
+
+_NUM = re.compile(r"-?\d*\.?\d+(?:[eE][-+]?\d+)?")
+_LEN = re.compile(r"^\s*(-?\d*\.?\d+(?:[eE][-+]?\d+)?)\s*([a-z%]*)\s*$", re.I)
+
+
+class SvgImportError(ValueError):
+    """Raised when an SVG cannot be interpreted as a tool outline."""
+
+
+def _length_mm(value: str) -> float | None:
+    m = _LEN.match(value or "")
+    if not m:
+        return None
+    num, unit = float(m.group(1)), m.group(2).lower()
+    if unit == "%" or unit not in _UNIT_MM:
+        return None
+    return num * _UNIT_MM[unit]
+
+
+def _tokens(d: str):
+    i, out = 0, []
+    while i < len(d):
+        c = d[i]
+        if c.isalpha():
+            out.append(c)
+            i += 1
+        elif c in " ,\t\n\r":
+            i += 1
+        else:
+            m = _NUM.match(d, i)
+            if not m:
+                i += 1
+                continue
+            out.append(float(m.group()))
+            i = m.end()
+    return out
+
+
+def _bezier3(p0, p1, p2, p3):
+    pts = []
+    for s in range(1, BEZIER_STEPS + 1):
+        u = s / BEZIER_STEPS
+        v = 1 - u
+        pts.append((
+            v * v * v * p0[0] + 3 * v * v * u * p1[0] + 3 * v * u * u * p2[0] + u * u * u * p3[0],
+            v * v * v * p0[1] + 3 * v * v * u * p1[1] + 3 * v * u * u * p2[1] + u * u * u * p3[1],
+        ))
+    return pts
+
+
+def _bezier2(p0, p1, p2):
+    pts = []
+    for s in range(1, BEZIER_STEPS + 1):
+        u = s / BEZIER_STEPS
+        v = 1 - u
+        pts.append((
+            v * v * p0[0] + 2 * v * u * p1[0] + u * u * p2[0],
+            v * v * p0[1] + 2 * v * u * p1[1] + u * u * p2[1],
+        ))
+    return pts
+
+
+def _flatten(d: str):
+    """Flatten one path 'd' string into a list of (x, y) polylines (subpaths)."""
+    toks = _tokens(d)
+    subpaths, cur_pts = [], []
+    cur = (0.0, 0.0)
+    start = (0.0, 0.0)
+    i, cmd = 0, None
+    while i < len(toks):
+        t = toks[i]
+        if isinstance(t, str):
+            cmd = t
+            i += 1
+            if cmd in ("Z", "z"):
+                if cur_pts:
+                    subpaths.append(cur_pts)
+                    cur_pts = []
+                cur = start
+            continue
+        rel = cmd.islower()
+        base = cmd.upper()
+        if base == "M":
+            if cur_pts:
+                subpaths.append(cur_pts)
+            x, y = toks[i], toks[i + 1]
+            i += 2
+            cur = (cur[0] + x, cur[1] + y) if rel else (x, y)
+            start = cur
+            cur_pts = [cur]
+            cmd = "l" if rel else "L"  # subsequent implicit lineto
+        elif base == "L":
+            x, y = toks[i], toks[i + 1]
+            i += 2
+            cur = (cur[0] + x, cur[1] + y) if rel else (x, y)
+            cur_pts.append(cur)
+        elif base == "H":
+            x = toks[i]
+            i += 1
+            cur = (cur[0] + x, cur[1]) if rel else (x, cur[1])
+            cur_pts.append(cur)
+        elif base == "V":
+            y = toks[i]
+            i += 1
+            cur = (cur[0], cur[1] + y) if rel else (cur[0], y)
+            cur_pts.append(cur)
+        elif base == "C":
+            c = toks[i:i + 6]
+            i += 6
+            if rel:
+                p1 = (cur[0] + c[0], cur[1] + c[1]); p2 = (cur[0] + c[2], cur[1] + c[3]); p3 = (cur[0] + c[4], cur[1] + c[5])
+            else:
+                p1 = (c[0], c[1]); p2 = (c[2], c[3]); p3 = (c[4], c[5])
+            cur_pts.extend(_bezier3(cur, p1, p2, p3))
+            cur = p3
+        elif base == "Q":
+            c = toks[i:i + 4]
+            i += 4
+            if rel:
+                p1 = (cur[0] + c[0], cur[1] + c[1]); p2 = (cur[0] + c[2], cur[1] + c[3])
+            else:
+                p1 = (c[0], c[1]); p2 = (c[2], c[3])
+            cur_pts.extend(_bezier2(cur, p1, p2))
+            cur = p2
+        else:
+            # unsupported command (S/T/A) — skip its operands conservatively
+            i += 1
+    if cur_pts:
+        subpaths.append(cur_pts)
+    return subpaths
+
+
+def _area(pts):
+    a = 0.0
+    n = len(pts)
+    for j in range(n):
+        x1, y1 = pts[j]
+        x2, y2 = pts[(j + 1) % n]
+        a += x1 * y2 - x2 * y1
+    return abs(a) / 2.0
+
+
+def _centroid(pts):
+    n = len(pts)
+    return (sum(p[0] for p in pts) / n, sum(p[1] for p in pts) / n)
+
+
+def _point_in(poly, pt):
+    x, y = pt
+    inside = False
+    n = len(poly)
+    for j in range(n):
+        xi, yi = poly[j]
+        xj, yj = poly[(j - 1) % n]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+    return inside
+
+
+def parse_svg_outline(svg_text: str):
+    """Return (outline_mm, interior_rings_mm, meta).
+
+    outline_mm and each ring are lists of (x, y) tuples in millimetres, with the
+    viewBox top-left as origin. Raises SvgImportError on unusable input.
+    """
+    try:
+        header = svg_text[: svg_text.index(">") + 1]
+    except ValueError:
+        raise SvgImportError("not a valid SVG document")
+
+    vb_match = re.search(r'viewBox\s*=\s*"([^"]+)"', header)
+    w_match = re.search(r'\bwidth\s*=\s*"([^"]+)"', header)
+    h_match = re.search(r'\bheight\s*=\s*"([^"]+)"', header)
+
+    if vb_match:
+        vb = [float(x) for x in _NUM.findall(vb_match.group(1))]
+        if len(vb) != 4 or vb[2] <= 0 or vb[3] <= 0:
+            raise SvgImportError("SVG viewBox is malformed")
+        w_mm = _length_mm(w_match.group(1)) if w_match else None
+        h_mm = _length_mm(h_match.group(1)) if h_match else None
+        if w_mm and h_mm:
+            mm_per_unit = ((w_mm / vb[2]) + (h_mm / vb[3])) / 2.0
+        elif w_mm:
+            mm_per_unit = w_mm / vb[2]
+        elif h_mm:
+            mm_per_unit = h_mm / vb[3]
+        else:
+            # no physical size on the file — assume viewBox units are CSS px
+            mm_per_unit = _UNIT_MM["px"]
+        minx, miny = vb[0], vb[1]
+    else:
+        # no viewBox: treat width/height as the user-unit extent
+        w_mm = _length_mm(w_match.group(1)) if w_match else None
+        if not w_mm:
+            raise SvgImportError("SVG has no viewBox or physical dimensions")
+        mm_per_unit = _UNIT_MM["px"]
+        minx = miny = 0.0
+
+    paths = re.findall(r'<path\b[^>]*\bd\s*=\s*"([^"]+)"', svg_text)
+    if not paths:
+        raise SvgImportError("SVG contains no <path> elements")
+
+    subpaths = []
+    for d in paths:
+        for sp in _flatten(d):
+            if len(sp) >= 3:
+                subpaths.append(sp)
+    if not subpaths:
+        raise SvgImportError("no usable closed outlines found in SVG")
+
+    subpaths.sort(key=_area, reverse=True)
+    outline = subpaths[0]
+    a_out = _area(outline)
+    rings = [
+        sp for sp in subpaths[1:]
+        if _area(sp) >= INTERIOR_MIN_FRAC * a_out and _point_in(outline, _centroid(sp))
+    ]
+
+    def to_mm(pts):
+        return [((x - minx) * mm_per_unit, (y - miny) * mm_per_unit) for x, y in pts]
+
+    outline_mm = to_mm(outline)
+    rings_mm = [to_mm(r) for r in rings]
+    xs = [p[0] for p in outline_mm]
+    ys = [p[1] for p in outline_mm]
+    meta = {
+        "mm_per_unit": mm_per_unit,
+        "width_mm": max(xs) - min(xs),
+        "height_mm": max(ys) - min(ys),
+        "path_count": len(subpaths),
+        "hole_count": len(rings_mm),
+    }
+    return outline_mm, rings_mm, meta

--- a/backend/tests/test_svg_import.py
+++ b/backend/tests/test_svg_import.py
@@ -1,0 +1,81 @@
+"""Tests for SVG import: the tool outline must come out at the SVG's real-world
+size (from width/height + viewBox), with interior paths detected as holes."""
+import math
+
+import pytest
+
+from app.services.svg_import import SvgImportError, parse_svg_outline
+
+
+def _bbox(pts):
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return max(xs) - min(xs), max(ys) - min(ys)
+
+
+def test_mm_dimensions_from_width_height_viewbox():
+    # 40mm x 80mm sheet, viewBox in arbitrary internal units
+    svg = (
+        '<svg viewBox="0 0 400 800" width="40mm" height="80mm">'
+        '<path d="M0 0 L400 0 L400 800 L0 800 Z"/></svg>'
+    )
+    outline, rings, meta = parse_svg_outline(svg)
+    w, h = _bbox(outline)
+    assert math.isclose(w, 40.0, abs_tol=1e-6)
+    assert math.isclose(h, 80.0, abs_tol=1e-6)
+    assert rings == []
+    assert math.isclose(meta["mm_per_unit"], 0.1, abs_tol=1e-9)
+
+
+def test_interior_ring_detected_as_hole():
+    # big outer square with a large centered inner square -> one hole
+    svg = (
+        '<svg viewBox="0 0 100 100" width="100mm" height="100mm">'
+        '<path d="M0 0 L100 0 L100 100 L0 100 Z"/>'
+        '<path d="M30 30 L70 30 L70 70 L30 70 Z"/></svg>'
+    )
+    outline, rings, meta = parse_svg_outline(svg)
+    assert meta["hole_count"] == 1
+    assert len(rings) == 1
+    w, h = _bbox(outline)
+    assert math.isclose(w, 100.0, abs_tol=1e-6)
+
+
+def test_tiny_detail_paths_are_ignored():
+    # a speck far below the interior threshold should not become a hole
+    svg = (
+        '<svg viewBox="0 0 100 100" width="100mm" height="100mm">'
+        '<path d="M0 0 L100 0 L100 100 L0 100 Z"/>'
+        '<path d="M50 50 L52 50 L52 52 L50 52 Z"/></svg>'
+    )
+    _, rings, meta = parse_svg_outline(svg)
+    assert meta["hole_count"] == 0
+    assert rings == []
+
+
+def test_relative_commands_and_bezier():
+    # relative moveto/lineto plus a cubic curve must still parse
+    svg = (
+        '<svg viewBox="0 0 10 10" width="10mm" height="10mm">'
+        '<path d="m0 0 l10 0 c0 5 0 5 -10 10 z"/></svg>'
+    )
+    outline, _, _ = parse_svg_outline(svg)
+    assert len(outline) >= 3
+
+
+def test_no_physical_size_falls_back_to_px():
+    # no width/height -> viewBox units treated as CSS px (96/inch)
+    svg = '<svg viewBox="0 0 96 96"><path d="M0 0 L96 0 L96 96 L0 96 Z"/></svg>'
+    outline, _, _ = parse_svg_outline(svg)
+    w, h = _bbox(outline)
+    assert math.isclose(w, 25.4, abs_tol=1e-6)  # 96px @ 96dpi = 1in = 25.4mm
+
+
+def test_rejects_svg_without_paths():
+    with pytest.raises(SvgImportError):
+        parse_svg_outline('<svg viewBox="0 0 10 10" width="10mm" height="10mm"></svg>')
+
+
+def test_rejects_non_svg():
+    with pytest.raises(SvgImportError):
+        parse_svg_outline("not an svg at all")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,10 +5,10 @@ import { useRouter } from 'next/navigation'
 import { ImageUploader } from '@/components/ImageUploader'
 import { ConfirmModal } from '@/components/ConfirmModal'
 import { SectionHeader } from '@/components/SectionHeader'
-import { uploadImage, listTools, listBins, listProjects, deleteTool, deleteBin, deleteProject, createBin, createProject, getImageUrl } from '@/lib/api'
+import { uploadImage, importSvgTool, listTools, listBins, listProjects, deleteTool, deleteBin, deleteProject, createBin, createProject, getImageUrl } from '@/lib/api'
 import type { ToolSummary, BinSummary, BinPreviewTool, BinProjectSummary, Point, ToolImageContext, AffineMatrix, ProjectStatus } from '@/types'
 import { polygonPathData } from '@/lib/svg'
-import { Trash2, Package, Plus, Loader2, Grid3X3, Folder } from 'lucide-react'
+import { Trash2, Package, Plus, Loader2, Grid3X3, Folder, FileUp } from 'lucide-react'
 import { Alert } from '@/components/Alert'
 import { PhotoIllustration, CornersIllustration, TraceIllustration, OrganiseIllustration } from '@/components/OnboardingIllustrations'
 import { GRID_UNIT } from '@/lib/constants'
@@ -234,6 +234,8 @@ function loadSectionCollapseState(): MainSectionCollapseState {
 export default function HomePage() {
   const router = useRouter()
   const [uploading, setUploading] = useState(false)
+  const [importingSvg, setImportingSvg] = useState(false)
+  const svgInputRef = useRef<HTMLInputElement>(null)
   const [error, setError] = useState<string | null>(null)
   const [toolsList, setToolsList] = useState<ToolSummary[]>([])
   const [binsList, setBinsList] = useState<BinSummary[]>([])
@@ -340,6 +342,22 @@ export default function HomePage() {
     }
   }
 
+  async function handleImportSvg(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    setImportingSvg(true)
+    setError(null)
+    try {
+      await importSvgTool(file)
+      setToolsList(await listTools())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'SVG import failed')
+    } finally {
+      setImportingSvg(false)
+    }
+  }
+
   async function handleDeleteTool(id: string) {
     try {
       await deleteTool(id)
@@ -407,6 +425,26 @@ export default function HomePage() {
       {/* upload */}
       <div data-tour="upload">
         <ImageUploader onUpload={handleUpload} disabled={uploading} />
+        <div className="mt-2 flex items-center justify-center gap-2 text-xs text-text-muted">
+          <span>or</span>
+          <input
+            ref={svgInputRef}
+            type="file"
+            accept=".svg,image/svg+xml"
+            onChange={handleImportSvg}
+            className="hidden"
+          />
+          <button
+            onClick={() => svgInputRef.current?.click()}
+            disabled={importingSvg}
+            className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 hover:bg-glass-hover transition-colors disabled:opacity-50"
+          >
+            {importingSvg
+              ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              : <FileUp className="w-3.5 h-3.5" />}
+            <span>Import SVG outline (Shaper Trace, etc.)</span>
+          </button>
+        </div>
       </div>
 
       {uploading && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,6 +71,13 @@ export async function uploadImage(file: File): Promise<UploadResponse> {
   return fetchForm('/api/upload', formData)
 }
 
+export async function importSvgTool(file: File, name?: string): Promise<{ tool_ids: string[] }> {
+  const formData = new FormData()
+  formData.append('file', file)
+  const query = name ? `?name=${encodeURIComponent(name)}` : ''
+  return fetchForm(`/api/tools/import-svg${query}`, formData)
+}
+
 export async function setCorners(
   sessionId: string,
   corners: Point[],


### PR DESCRIPTION
## Import SVG outlines directly as library tools

Adds an **"Import SVG outline"** path so users can bring in an existing vector outline (e.g. a **Shaper Trace** export, or anything from a CAD/vector tool) and get a library tool at exact real-world size — no photo tracing, paper, or corner detection required.

### Why
Shaper Trace (and most vector tools) already produce a dimensionally-accurate outline. Shaper's SVGs encode real-world size on the root element:

```
width="38.51689961751302mm" height="245.38482818603515mm"
viewBox="588.6 142.5 291.2 1854.9"
```

Dividing `width`/`height` by the `viewBox` extent yields an exact mm-per-unit, so every path coordinate converts to millimetres with no calibration. Photo tracing throws that precision away and re-derives it (less accurately). This lets people who already have a clean outline skip straight to bins.

### What's included
- **`backend/app/services/svg_import.py`** — dependency-free SVG parser: handles `M/L/H/V/C/Q/Z` (absolute + relative), flattens béziers, converts to mm via `width`/`height` + `viewBox` (falls back to CSS-px @96dpi when no physical size is present). The largest closed path becomes the outline; sufficiently large contained paths (≥3% of outline area) become interior rings; specks are ignored.
- **`POST /api/tools/import-svg`** (multipart `file`, optional `?name=`) — parses, centres via the existing `PolygonScaler`, and saves a `Tool` straight to the library. Reuses existing model/store code.
- **Frontend** — `importSvgTool()` client + an "Import SVG outline (Shaper Trace, etc.)" button under the photo uploader that imports and refreshes the library.
- **Tests** — `backend/tests/test_svg_import.py` covering mm scaling, hole detection, speck rejection, relative/bézier commands, px fallback, and error cases.

### Notes
- Purely additive and opt-in; the photo pipeline is unchanged.
- The parser deliberately covers the common Shaper/CAD command set; `S/T/A` (smooth/arc) are skipped rather than approximated — easy to extend if real files need them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
