### PR TITLE
Add photo station backend

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,16 +1,18 @@
 import hashlib
+import io
 import json
 import logging
 import math
 import os
 import re
+import shutil
 import threading
 import uuid
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse, Response
 from PIL import Image
 from starlette.requests import Request
@@ -36,17 +38,27 @@ from app.models.schemas import (
     BinProjectUpdateRequest,
     BinSummary,
     BinUpdateRequest,
+    CaptureCrop,
     CornersRequest,
     CornersResponse,
     CreateBinRequest,
     FingerHole,
     GenerateRequest,
     GenerateResponse,
+    PhotoStation,
+    PhotoStationCreateRequest,
+    PhotoStationListResponse,
+    PhotoStationSuggestion,
+    PhotoStationSuggestionsResponse,
+    PhotoStationUpdateRequest,
     PlacedTool,
     Point,
     Polygon,
     PolygonsRequest,
     ProjectHealthResponse,
+    RedetectCornersResponse,
+    ReuseCornersRequest,
+    ReuseCornersResponse,
     SaveToolsRequest,
     SaveToolsResponse,
     Session,
@@ -71,6 +83,7 @@ from app.services.image_ingest import ingest_image
 from app.services.image_processor import ImageProcessor
 from app.services.image_service import generate_tool_thumbnail
 from app.services.photo_checks import check_photo, extract_focal_length_35mm
+from app.services.photo_station_store import PhotoStationStore
 from app.services.polygon_scaler import PolygonScaler, ScaledFingerHole, ScaledPolygon
 from app.services.project_service import (
     add_bin_to_project,
@@ -103,6 +116,7 @@ validate_tracer_ids(settings.available_tracers)
 # per-user store registry
 _store_cache: dict[str, tuple[SessionStore, ToolStore, BinStore]] = {}
 _project_store_cache: dict[str, ProjectStore] = {}
+_photo_station_store_cache: dict[str, PhotoStationStore] = {}
 
 # serialises store creation against user deletion so a store cannot be
 # built from files that are mid-rmtree (issue #160). locks are never
@@ -138,6 +152,20 @@ def get_project_store(user_id: str) -> ProjectStore:
         return _project_store_cache[user_id]
 
 
+def get_photo_station_store(user_id: str) -> PhotoStationStore:
+    with user_lock(user_id):
+        if user_id not in _photo_station_store_cache:
+            user_path = settings.storage_path / user_id
+            ensure_user_dirs(user_path)
+            _photo_station_store_cache[user_id] = PhotoStationStore(user_path)
+        return _photo_station_store_cache[user_id]
+
+
+def _require_photo_stations_enabled():
+    if not settings.photo_stations:
+        raise HTTPException(status_code=404, detail="photo stations not found")
+
+
 def _user_path(user_id: str) -> Path:
     # defence-in-depth: even if get_user_id is bypassed, block escaping storage root
     result = (settings.storage_path / user_id).resolve()
@@ -148,6 +176,32 @@ def _user_path(user_id: str) -> Path:
 
 ALLOWED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic", ".heif"}
 MAX_UPLOAD_DIM = 2048
+CAPTURE_CROP_ORIGIN_TOLERANCE = 0.001
+CAPTURE_CROP_SIZE_TOLERANCE = 0.001
+CAPTURE_CROP_MAX_BOUND = 1.0 + CAPTURE_CROP_SIZE_TOLERANCE
+
+
+def _is_full_capture_crop(crop: CaptureCrop | None) -> bool:
+    if crop is None:
+        return True
+    return (
+        crop.x <= CAPTURE_CROP_ORIGIN_TOLERANCE
+        and crop.y <= CAPTURE_CROP_ORIGIN_TOLERANCE
+        and crop.width >= 1.0 - CAPTURE_CROP_SIZE_TOLERANCE
+        and crop.height >= 1.0 - CAPTURE_CROP_SIZE_TOLERANCE
+    )
+
+
+def _parse_capture_crop(value: str | None) -> CaptureCrop | None:
+    if not value:
+        return None
+    try:
+        crop = CaptureCrop.model_validate(json.loads(value))
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid capture area") from exc
+    if crop.x + crop.width > CAPTURE_CROP_MAX_BOUND or crop.y + crop.height > CAPTURE_CROP_MAX_BOUND:
+        raise HTTPException(status_code=400, detail="capture area is outside the image")
+    return crop
 
 
 image_processor = ImageProcessor()
@@ -192,7 +246,7 @@ stl_generator = ManifoldSTLGenerator()
 
 def _rel(abs_path: str | Path, user_path: Path) -> str:
     """store path relative to storage root (includes user_id prefix)"""
-    return str(Path(abs_path).resolve().relative_to(Path(settings.storage_path).resolve()))
+    return Path(abs_path).resolve().relative_to(Path(settings.storage_path).resolve()).as_posix()
 
 
 def _abs(rel_path: str | None) -> str | None:
@@ -200,6 +254,125 @@ def _abs(rel_path: str | None) -> str | None:
     if not rel_path:
         return None
     return str(settings.storage_path / rel_path)
+
+
+def _safe_unlink(rel_path: str | None):
+    abs_path = _abs(rel_path)
+    if abs_path:
+        Path(abs_path).unlink(missing_ok=True)
+
+
+def _copy_station_image(user_id: str, source_path: str | Path | None, station_id: str) -> str | None:
+    if not source_path:
+        return None
+    source = Path(source_path)
+    if not source.exists():
+        return None
+
+    up = _user_path(user_id)
+    station_dir = up / "station-photos"
+    station_dir.mkdir(parents=True, exist_ok=True)
+    target = station_dir / f"{station_id}{source.suffix}"
+    shutil.copy2(source, target)
+    return _rel(target, up)
+
+
+MAX_STATION_DIMENSION_DELTA_PERCENT = 2.0
+STATION_DRIFT_WARNING_PERCENT = 1.5
+
+
+def _image_dimensions(content: bytes) -> tuple[int, int]:
+    img = Image.open(io.BytesIO(content))
+    return img.size
+
+
+def _session_image_dimensions(session: Session) -> tuple[int, int]:
+    if not session.original_image_width or not session.original_image_height:
+        raise HTTPException(status_code=400, detail="session has no upload dimensions")
+    return session.original_image_width, session.original_image_height
+
+
+def _create_photo_station(
+    user_id: str,
+    session: Session,
+    name: str,
+    paper_size: str | None,
+    corners: list[Point] | None,
+    source_image_path: str | Path | None = None,
+) -> PhotoStation:
+    if not corners or len(corners) != 4 or not paper_size:
+        raise HTTPException(status_code=400, detail="session must have confirmed corners")
+
+    image_width, image_height = _session_image_dimensions(session)
+    now = _now_iso()
+    station_id = str(uuid.uuid4())
+    source_image = source_image_path or _abs(session.original_image_path)
+    station = PhotoStation(
+        id=station_id,
+        name=name.strip() or f"Station {now[:10]}",
+        image_width=image_width,
+        image_height=image_height,
+        image_path=_copy_station_image(user_id, source_image, station_id),
+        capture_crop=session.capture_crop,
+        paper_size=paper_size,
+        corners=corners,
+        created_at=now,
+        updated_at=now,
+    )
+    get_photo_station_store(user_id).set(station.id, station)
+    return station
+
+
+def _dimension_delta_percent(station_value: int, session_value: int) -> float:
+    if station_value <= 0:
+        return 100.0
+    return abs(session_value - station_value) / station_value * 100.0
+
+
+def _scaled_station_corners(station: PhotoStation, image_width: int, image_height: int) -> list[Point]:
+    sx = image_width / station.image_width
+    sy = image_height / station.image_height
+    return [Point(x=p.x * sx, y=p.y * sy) for p in station.corners]
+
+
+def _station_suggestion(station: PhotoStation, session: Session) -> PhotoStationSuggestion:
+    image_width, image_height = _session_image_dimensions(session)
+    width_delta = _dimension_delta_percent(station.image_width, image_width)
+    height_delta = _dimension_delta_percent(station.image_height, image_height)
+    max_delta = max(width_delta, height_delta)
+    match_status = "exact" if width_delta == 0 and height_delta == 0 else "near" if max_delta <= MAX_STATION_DIMENSION_DELTA_PERCENT else "far"
+
+    warnings: list[str] = []
+    if match_status == "near":
+        warnings.append("Image size differs from the saved station. Check corners before continuing.")
+    elif match_status == "far":
+        warnings.append("Image size differs too much from the saved station.")
+
+    max_corner_drift_px: float | None = None
+    max_corner_drift_percent: float | None = None
+    if session.corners and len(session.corners) == 4:
+        scaled = _scaled_station_corners(station, image_width, image_height)
+        deltas = [
+            math.hypot(detected.x - saved.x, detected.y - saved.y)
+            for detected, saved in zip(session.corners, scaled)
+        ]
+        max_corner_drift_px = max(deltas) if deltas else 0.0
+        diagonal = math.hypot(image_width, image_height)
+        max_corner_drift_percent = (max_corner_drift_px / diagonal * 100.0) if diagonal else 0.0
+        if max_corner_drift_percent >= STATION_DRIFT_WARNING_PERCENT:
+            warnings.append("Detected paper corners differ from this station.")
+    elif session.corners is None:
+        warnings.append("No paper was detected in this upload. Reused corners must be checked manually.")
+
+    return PhotoStationSuggestion(
+        station=station,
+        match_status=match_status,
+        width_delta_percent=round(width_delta, 3),
+        height_delta_percent=round(height_delta, 3),
+        max_corner_drift_px=round(max_corner_drift_px, 2) if max_corner_drift_px is not None else None,
+        max_corner_drift_percent=round(max_corner_drift_percent, 3) if max_corner_drift_percent is not None else None,
+        warnings=warnings,
+    )
 
 
 def _translate_points(points: list[Point], dx: float, dy: float) -> list[Point]:
@@ -339,7 +512,7 @@ def _tool_image_context(tool: Tool, sessions: SessionStore, load_missing_dimensi
 
 
 def _now_iso() -> str:
-    return datetime.utcnow().isoformat()
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _build_bin_from_tools(
@@ -517,7 +690,13 @@ def _run_generate(
 
 
 @router.post("/upload", response_model=UploadResponse)
-async def upload_image(request: Request, image: UploadFile, user_id: str = Depends(get_user_id)):
+async def upload_image(
+    request: Request,
+    image: UploadFile = File(...),
+    station_id: str | None = Form(None),
+    capture_crop: str | None = Form(None),
+    user_id: str = Depends(get_user_id),
+):
     if not image.content_type or not image.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="file must be an image")
 
@@ -529,6 +708,9 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
     if ext not in ALLOWED_IMAGE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="unsupported image format")
 
+    if station_id or capture_crop:
+        _require_photo_stations_enabled()
+
     max_bytes = settings.max_upload_mb * 1024 * 1024
     content = await image.read()
     if len(content) > max_bytes:
@@ -537,33 +719,72 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
     # exif is dropped when the image is re-encoded, so read it first
     focal_length = extract_focal_length_35mm(content)
 
-    content, ext, _ = ingest_image(content, ext, MAX_UPLOAD_DIM)
+    station = None
+    if station_id:
+        station = get_photo_station_store(user_id).get(station_id)
+        if not station:
+            raise HTTPException(status_code=404, detail="photo station not found")
+
+    requested_crop = _parse_capture_crop(capture_crop)
+    applied_crop = requested_crop if requested_crop is not None else station.capture_crop if station else None
+
+    ingest_crop = None if _is_full_capture_crop(applied_crop) else applied_crop
+    content, ext, _ = ingest_image(content, ext, MAX_UPLOAD_DIM, capture_crop=ingest_crop)
+    image_width, image_height = _image_dimensions(content)
     image_path = up / "uploads" / f"{session_id}{ext}"
+
+    paper_size = None
+    applied_station_id = None
+    if station:
+        width_delta = _dimension_delta_percent(station.image_width, image_width)
+        height_delta = _dimension_delta_percent(station.image_height, image_height)
+        if max(width_delta, height_delta) > MAX_STATION_DIMENSION_DELTA_PERCENT:
+            raise HTTPException(status_code=400, detail="photo station image size differs too much from this upload")
+
+        corner_points = _scaled_station_corners(station, image_width, image_height)
+        paper_size = station.paper_size
+        applied_station_id = station.id
+
     # the awaited read can outlive a concurrent account deletion; refuse
     # to write into the deleted user's tree
     user_sessions.ensure_open()
     image_path.write_bytes(content)
 
-    corners = image_processor.detect_paper_corners(str(image_path))
-    corner_points = [Point(x=c[0], y=c[1]) for c in corners] if corners else None
+    if station:
+        station.last_used_at = _now_iso()
+        get_photo_station_store(user_id).set(station.id, station)
+    else:
+        corners = image_processor.detect_paper_corners(str(image_path))
+        corner_points = [Point(x=c[0], y=c[1]) for c in corners] if corners else None
 
     user_sessions.set(session_id, Session(
         id=session_id,
-        created_at=datetime.utcnow().isoformat(),
+        created_at=_now_iso(),
         original_image_path=_rel(image_path, up),
+        original_image_width=image_width,
+        original_image_height=image_height,
+        capture_crop=None if _is_full_capture_crop(applied_crop) else applied_crop,
         corners=corner_points,
         focal_length_35mm=focal_length,
+        paper_size=paper_size,
     ))
 
     return UploadResponse(
         session_id=session_id,
         image_url=f"/storage/{user_id}/uploads/{session_id}{ext}",
         detected_corners=corner_points,
+        image_width=image_width,
+        image_height=image_height,
+        corner_source="station" if applied_station_id else "detected" if corner_points else "none",
+        station_id=applied_station_id,
     )
 
 
 @router.post("/sessions/{session_id}/corners", response_model=CornersResponse)
 async def set_corners(request: Request, session_id: str, req: CornersRequest, user_id: str = Depends(get_user_id)):
+    if req.save_station_name is not None:
+        _require_photo_stations_enabled()
+
     user_sessions, _, _ = get_stores(user_id)
     session = user_sessions.get(session_id)
     if not session or not session.original_image_path:
@@ -595,12 +816,23 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
     if ds_ratio < 1.0:
         scale_factor /= ds_ratio
 
-    # original upload is no longer needed
-    orig = _abs(session.original_image_path)
-    if orig:
-        Path(orig).unlink(missing_ok=True)
-
     up = _user_path(user_id)
+    orig_path = _abs(session.original_image_path)
+    created_station: PhotoStation | None = None
+    if req.save_station_name is not None:
+        created_station = _create_photo_station(
+            user_id=user_id,
+            session=session,
+            name=req.save_station_name,
+            paper_size=req.paper_size,
+            corners=req.corners,
+            source_image_path=orig_path,
+        )
+
+    # original upload is no longer needed for tracing; saved stations own their previews.
+    if orig_path:
+        Path(orig_path).unlink(missing_ok=True)
+
     session.corrected_image_path = _rel(output_path, up)
     session.original_image_path = None
     session.corners = req.corners
@@ -613,6 +845,160 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
         corrected_image_url=f"/storage/{session.corrected_image_path}",
         scale_factor=scale_factor,
         warnings=photo_warnings,
+        station=created_station,
+    )
+
+
+@router.post("/sessions/{session_id}/redetect-corners", response_model=RedetectCornersResponse)
+async def redetect_corners(request: Request, session_id: str, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    user_sessions, _, _ = get_stores(user_id)
+    session = user_sessions.get(session_id)
+    if not session or not session.original_image_path:
+        raise HTTPException(status_code=404, detail="session original image not found")
+
+    detected = image_processor.detect_paper_corners(_abs(session.original_image_path))
+    if not detected:
+        raise HTTPException(status_code=422, detail="paper corners not detected")
+
+    corners = [Point(x=c[0], y=c[1]) for c in detected]
+    session.corners = corners
+    user_sessions.set(session_id, session)
+    return RedetectCornersResponse(corners=corners)
+
+
+@router.get("/photo-stations", response_model=PhotoStationListResponse)
+async def list_photo_stations(request: Request, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    store = get_photo_station_store(user_id)
+    stations = list(store.all().values())
+    stations.sort(key=lambda s: s.updated_at or s.created_at or "", reverse=True)
+    return PhotoStationListResponse(stations=stations)
+
+
+@router.get("/photo-stations/{station_id}", response_model=PhotoStation)
+async def get_photo_station(request: Request, station_id: str, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    station = get_photo_station_store(user_id).get(station_id)
+    if not station:
+        raise HTTPException(status_code=404, detail="photo station not found")
+    return station
+
+
+@router.post("/photo-stations", response_model=PhotoStation)
+async def create_photo_station(request: Request, req: PhotoStationCreateRequest, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    user_sessions, _, _ = get_stores(user_id)
+    session = user_sessions.get(req.session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    station = _create_photo_station(
+        user_id=user_id,
+        session=session,
+        name=req.name,
+        paper_size=req.paper_size or session.paper_size,
+        corners=req.corners or session.corners,
+    )
+    return station
+
+
+@router.patch("/photo-stations/{station_id}", response_model=PhotoStation)
+async def update_photo_station(request: Request, station_id: str, req: PhotoStationUpdateRequest, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    store = get_photo_station_store(user_id)
+    station = store.get(station_id)
+    if not station:
+        raise HTTPException(status_code=404, detail="photo station not found")
+
+    if req.name is not None:
+        station.name = req.name.strip() or station.name
+    if req.paper_size is not None:
+        station.paper_size = req.paper_size
+    if req.corners is not None:
+        if len(req.corners) != 4:
+            raise HTTPException(status_code=400, detail="station corners must contain four points")
+        station.corners = req.corners
+    station.updated_at = _now_iso()
+    store.set(station.id, station)
+    return station
+
+
+@router.delete("/photo-stations/{station_id}", response_model=StatusResponse)
+async def delete_photo_station(request: Request, station_id: str, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    station = get_photo_station_store(user_id).delete(station_id)
+    if not station:
+        raise HTTPException(status_code=404, detail="photo station not found")
+    _safe_unlink(station.image_path)
+    return StatusResponse(status="deleted")
+
+
+@router.get("/sessions/{session_id}/station-suggestions", response_model=PhotoStationSuggestionsResponse)
+async def list_photo_station_suggestions(request: Request, session_id: str, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    user_sessions, _, _ = get_stores(user_id)
+    session = user_sessions.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    stations = list(get_photo_station_store(user_id).all().values())
+    if not session.original_image_width or not session.original_image_height:
+        return PhotoStationSuggestionsResponse(suggestions=[], station_count=len(stations))
+
+    suggestions = [
+        _station_suggestion(station, session)
+        for station in stations
+    ]
+    suggestions = [suggestion for suggestion in suggestions if suggestion.match_status != "far"]
+    suggestions.sort(
+        key=lambda suggestion: max(
+            suggestion.width_delta_percent,
+            suggestion.height_delta_percent,
+            suggestion.max_corner_drift_percent or 0.0,
+        )
+    )
+    return PhotoStationSuggestionsResponse(suggestions=suggestions, station_count=len(stations))
+
+
+@router.post("/sessions/{session_id}/reuse-corners", response_model=ReuseCornersResponse)
+async def reuse_photo_station_corners(request: Request, session_id: str, req: ReuseCornersRequest, user_id: str = Depends(get_user_id)):
+    _require_photo_stations_enabled()
+
+    user_sessions, _, _ = get_stores(user_id)
+    session = user_sessions.get(session_id)
+    if not session or not session.original_image_path:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    store = get_photo_station_store(user_id)
+    station = store.get(req.station_id)
+    if not station:
+        raise HTTPException(status_code=404, detail="photo station not found")
+
+    suggestion = _station_suggestion(station, session)
+    if suggestion.match_status == "far":
+        raise HTTPException(status_code=400, detail="photo station image size differs too much from this upload")
+
+    image_width, image_height = _session_image_dimensions(session)
+    reused_corners = _scaled_station_corners(station, image_width, image_height)
+    session.corners = reused_corners
+    session.paper_size = station.paper_size
+    user_sessions.set(session_id, session)
+
+    station.last_used_at = _now_iso()
+    store.set(station.id, station)
+
+    return ReuseCornersResponse(
+        corners=reused_corners,
+        paper_size=station.paper_size,
+        suggestion=suggestion,
     )
 
 
@@ -643,6 +1029,7 @@ async def get_available_keys(request: Request):
             {"id": t, "label": TRACER_LABELS.get(t, t)}
             for t in tracers
         ],
+        "photo_stations": settings.photo_stations,
     }
 
 
@@ -716,7 +1103,10 @@ async def trace_tools(
     if mask_path:
         mask_url = f"/storage/{user_id}/processed/{session_id}_mask.png"
 
-    return TraceResponse(polygons=polygons, mask_url=mask_url)
+    return TraceResponse(
+        polygons=polygons,
+        mask_url=mask_url,
+    )
 
 
 @router.post("/sessions/{session_id}/trace-mask", response_model=TraceResponse)
@@ -770,7 +1160,7 @@ async def trace_from_mask(
 
     return TraceResponse(
         polygons=polygons,
-        mask_url=f"/storage/{user_id}/processed/{session_id}_mask.png"
+        mask_url=f"/storage/{user_id}/processed/{session_id}_mask.png",
     )
 
 
@@ -883,11 +1273,10 @@ async def delete_session(request: Request, session_id: str, user_id: str = Depen
     for rel in [
         session.original_image_path,
         session.corrected_image_path,
+        session.mask_image_path,
         session.stl_path,
     ]:
-        p = _abs(rel)
-        if p:
-            Path(p).unlink(missing_ok=True)
+        _safe_unlink(rel)
 
     if session.stl_path:
         Path(_abs(session.stl_path)).with_suffix(".3mf").unlink(missing_ok=True)
@@ -1187,7 +1576,7 @@ async def save_tools_from_session(request: Request, session_id: str, body: SaveT
                 if source_transform else None
             ),
             thumbnail_path=thumbnail_path,
-            created_at=datetime.utcnow().isoformat(),
+            created_at=_now_iso(),
         ))
         tool_ids.append(tool_id)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     tool_label_ollama_url: str = "http://localhost:11434"
     tool_label_timeout_seconds: float = 30.0
     tool_label_max_crop_px: int = 512
+    photo_stations: bool = False
 
     model_config = {
         "env_file": ".env",

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Literal
 
 from pydantic import BaseModel, field_validator, model_validator
@@ -10,6 +11,41 @@ from app.constants import PaperSize
 class Point(BaseModel):
     x: float
     y: float
+
+    @field_validator("x", "y")
+    @classmethod
+    def validate_finite(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("point coordinate must be finite")
+        return v
+
+
+class CaptureCrop(BaseModel):
+    x: float
+    y: float
+    width: float
+    height: float
+
+    @field_validator("x", "y", "width", "height")
+    @classmethod
+    def validate_finite(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("capture crop value must be finite")
+        return v
+
+    @field_validator("x", "y")
+    @classmethod
+    def validate_origin(cls, v: float) -> float:
+        if v < 0 or v > 1:
+            raise ValueError("capture crop origin must be between 0 and 1")
+        return v
+
+    @field_validator("width", "height")
+    @classmethod
+    def validate_size(cls, v: float) -> float:
+        if v <= 0 or v > 1:
+            raise ValueError("capture crop size must be between 0 and 1")
+        return v
 
 
 class PhotoWarning(BaseModel):
@@ -52,17 +88,27 @@ class UploadResponse(BaseModel):
     session_id: str
     image_url: str
     detected_corners: list[Point] | None
+    image_width: int | None = None
+    image_height: int | None = None
+    corner_source: Literal["detected", "station", "none"] = "none"
+    station_id: str | None = None
 
 
 class CornersRequest(BaseModel):
     corners: list[Point]
     paper_size: PaperSize
+    save_station_name: str | None = None
 
 
 class CornersResponse(BaseModel):
     corrected_image_url: str
     scale_factor: float
     warnings: list[PhotoWarning] = []
+    station: "PhotoStation | None" = None
+
+
+class RedetectCornersResponse(BaseModel):
+    corners: list[Point]
 
 
 class TraceRequest(BaseModel):
@@ -221,6 +267,9 @@ class Session(BaseModel):
     tags: list[str] = []
     created_at: str | None = None
     original_image_path: str | None = None
+    original_image_width: int | None = None
+    original_image_height: int | None = None
+    capture_crop: CaptureCrop | None = None
     corrected_image_path: str | None = None
     mask_image_path: str | None = None
     corners: list[Point] | None = None
@@ -257,6 +306,81 @@ class SessionUpdateRequest(BaseModel):
 
 class StatusResponse(BaseModel):
     status: str
+
+
+# --- photo stations ---
+
+PhotoStationMatchStatus = Literal["exact", "near", "far"]
+
+
+class PhotoStation(BaseModel):
+    id: str
+    name: str
+    image_width: int
+    image_height: int
+    image_path: str | None = None
+    capture_crop: CaptureCrop | None = None
+    paper_size: PaperSize
+    corners: list[Point]
+    created_at: str | None = None
+    updated_at: str | None = None
+    last_used_at: str | None = None
+
+    @field_validator("image_width", "image_height")
+    @classmethod
+    def validate_image_dimension(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("station image dimensions must be positive")
+        return v
+
+    @field_validator("corners")
+    @classmethod
+    def validate_corners(cls, v: list[Point]) -> list[Point]:
+        if len(v) != 4:
+            raise ValueError("station corners must contain four points")
+        return v
+
+
+class PhotoStationSuggestion(BaseModel):
+    station: PhotoStation
+    match_status: PhotoStationMatchStatus
+    width_delta_percent: float = 0.0
+    height_delta_percent: float = 0.0
+    max_corner_drift_px: float | None = None
+    max_corner_drift_percent: float | None = None
+    warnings: list[str] = []
+
+
+class PhotoStationListResponse(BaseModel):
+    stations: list[PhotoStation]
+
+
+class PhotoStationSuggestionsResponse(BaseModel):
+    suggestions: list[PhotoStationSuggestion]
+    station_count: int
+
+
+class PhotoStationCreateRequest(BaseModel):
+    name: str
+    session_id: str
+    paper_size: PaperSize | None = None
+    corners: list[Point] | None = None
+
+
+class PhotoStationUpdateRequest(BaseModel):
+    name: str | None = None
+    paper_size: PaperSize | None = None
+    corners: list[Point] | None = None
+
+
+class ReuseCornersRequest(BaseModel):
+    station_id: str
+
+
+class ReuseCornersResponse(BaseModel):
+    corners: list[Point]
+    paper_size: PaperSize
+    suggestion: PhotoStationSuggestion
 
 
 # --- tool library ---

--- a/backend/app/services/image_ingest.py
+++ b/backend/app/services/image_ingest.py
@@ -11,6 +11,8 @@ import logging
 
 from PIL import Image, ImageOps
 
+from app.models.schemas import CaptureCrop
+
 logger = logging.getLogger(__name__)
 
 HEIC_EXTENSIONS = {".heic", ".heif"}
@@ -23,13 +25,27 @@ except ImportError:
     pass
 
 
-def ingest_image(content: bytes, ext: str, max_dim: int | None = None) -> tuple[bytes, str, float]:
+def _crop_bounds(width: int, height: int, crop: CaptureCrop) -> tuple[int, int, int, int]:
+    left = max(0, min(width - 1, int(round(crop.x * width))))
+    top = max(0, min(height - 1, int(round(crop.y * height))))
+    right = max(left + 4, min(width, int(round((crop.x + crop.width) * width))))
+    bottom = max(top + 4, min(height, int(round((crop.y + crop.height) * height))))
+    return left, top, right, bottom
+
+
+def ingest_image(
+    content: bytes,
+    ext: str,
+    max_dim: int | None = None,
+    capture_crop: CaptureCrop | None = None,
+) -> tuple[bytes, str, float]:
     """normalise an uploaded image. returns (bytes, ext, downscale_ratio).
 
     HEIC becomes JPEG, EXIF orientation is applied to the pixels and the tag
-    dropped, and the long edge is capped at max_dim. ratio is <1 when shrunk;
-    the long edge lands exactly on max_dim so the ratio is exact for it and
-    within half a pixel for the short edge (dimensions are rounded)."""
+    dropped, an optional fractional crop is applied to the upright image, and
+    the long edge is capped at max_dim. ratio is <1 when shrunk; the long edge
+    lands exactly on max_dim so the ratio is exact for it and within half a
+    pixel for the short edge (dimensions are rounded)."""
     img = Image.open(io.BytesIO(content))
     changed = False
     new_ext = ext.lower()
@@ -40,6 +56,12 @@ def ingest_image(content: bytes, ext: str, max_dim: int | None = None) -> tuple[
 
     if img.getexif().get(_ORIENTATION_TAG, 1) != 1:
         img = ImageOps.exif_transpose(img)
+        changed = True
+
+    if capture_crop is not None:
+        w, h = img.size
+        img = img.crop(_crop_bounds(w, h, capture_crop))
+        logger.info("cropped image %dx%d -> %dx%d", w, h, img.width, img.height)
         changed = True
 
     ratio = 1.0

--- a/backend/app/services/photo_station_store.py
+++ b/backend/app/services/photo_station_store.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from app.models.schemas import PhotoStation
+
+logger = logging.getLogger(__name__)
+
+
+class PhotoStationStore:
+    def __init__(self, storage_path: Path):
+        self.file_path = storage_path / "photo-stations.json"
+        self._stations: dict[str, PhotoStation] = {}
+        self._lock = threading.Lock()
+        self._load()
+
+    def _load(self):
+        if self.file_path.exists():
+            try:
+                data = json.loads(self.file_path.read_text())
+                for sid, sdata in data.items():
+                    self._stations[sid] = PhotoStation.model_validate(sdata)
+            except OSError:
+                logger.error(f"Failed to load {self.file_path}: permission denied")
+                raise
+            except Exception as e:
+                corrupt_path = self._corrupt_path()
+                logger.error(f"Failed to load {self.file_path}: {e}; moving to {corrupt_path}")
+                self.file_path.replace(corrupt_path)
+                self._stations = {}
+
+    def _corrupt_path(self) -> Path:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+        return self.file_path.with_name(f"{self.file_path.stem}.corrupt-{stamp}{self.file_path.suffix}")
+
+    def _save(self):
+        data = {sid: s.model_dump() for sid, s in self._stations.items()}
+        temp_fd, temp_path = tempfile.mkstemp(
+            dir=self.file_path.parent,
+            prefix=".photo-stations_",
+            suffix=".tmp",
+        )
+        try:
+            with open(temp_fd, "w") as f:
+                json.dump(data, f, indent=2)
+            Path(temp_path).replace(self.file_path)
+        except Exception:
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+    def get(self, station_id: str) -> Optional[PhotoStation]:
+        with self._lock:
+            return self._stations.get(station_id)
+
+    def set(self, station_id: str, station: PhotoStation):
+        with self._lock:
+            self._stations[station_id] = station
+            self._save()
+
+    def delete(self, station_id: str) -> Optional[PhotoStation]:
+        with self._lock:
+            station = self._stations.pop(station_id, None)
+            if station:
+                self._save()
+            return station
+
+    def all(self) -> dict[str, PhotoStation]:
+        with self._lock:
+            return self._stations.copy()

--- a/backend/tests/test_image_ingest.py
+++ b/backend/tests/test_image_ingest.py
@@ -4,6 +4,7 @@ import io
 import pytest
 from PIL import Image
 
+from app.models.schemas import CaptureCrop
 from app.services.image_ingest import ingest_image
 
 
@@ -89,3 +90,21 @@ class TestDownscale:
         img = _open(out)
         assert (img.width, img.height) == (2402, 3300)
         assert ratio == 1.0
+
+    def test_crop_happens_before_downscale(self):
+        img = Image.new("RGB", (4032, 3024), "green")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+
+        out, ext, ratio = ingest_image(
+            buf.getvalue(),
+            ".png",
+            max_dim=2048,
+            capture_crop=CaptureCrop(x=0, y=0, width=0.5, height=1),
+        )
+
+        cropped = _open(out)
+        assert ext == ".png"
+        assert cropped.height == 2048
+        assert cropped.width == round(2016 * (2048 / 3024))
+        assert ratio == pytest.approx(2048 / 3024)

--- a/backend/tests/test_photo_stations.py
+++ b/backend/tests/test_photo_stations.py
@@ -1,0 +1,690 @@
+import io
+import json
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+from pydantic import ValidationError
+
+import app.api.routes as routes
+from app.config import ensure_user_dirs, settings
+from app.main import app
+from app.models.schemas import CaptureCrop, PhotoStation, Point, Session
+from app.services.photo_station_store import PhotoStationStore
+
+
+def _api_client(tmp_path, monkeypatch, photo_stations: bool = True):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    monkeypatch.setattr(settings, "photo_stations", photo_stations)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+    routes._photo_station_store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def _corners(width: float = 100.0, height: float | None = None):
+    height = width if height is None else height
+    return [
+        Point(x=0, y=0),
+        Point(x=width, y=0),
+        Point(x=width, y=height),
+        Point(x=0, y=height),
+    ]
+
+
+def _write_image(path, size=(120, 160)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=(32, 64, 96)).save(path)
+
+
+def _image_bytes(size=(120, 160), fmt="PNG"):
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=(32, 64, 96)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def test_photo_station_feature_flag_defaults_off(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch, photo_stations=False)
+
+    assert client.get("/api/api-keys").json()["photo_stations"] is False
+    assert client.get("/api/photo-stations").status_code == 404
+
+    resp = client.post(
+        "/api/upload",
+        data={"capture_crop": json.dumps({"x": 0, "y": 0, "width": 1, "height": 1})},
+        files={"image": ("photo.png", _image_bytes(), "image/png")},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_photo_station_geometry_rejects_non_finite_values():
+    with pytest.raises(ValidationError):
+        Point(x=float("nan"), y=0)
+
+    with pytest.raises(ValidationError):
+        CaptureCrop(x=0, y=0, width=float("inf"), height=1)
+
+
+def test_photo_station_store_round_trips(tmp_path):
+    store = PhotoStationStore(tmp_path)
+    station = PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    )
+
+    store.set(station.id, station)
+    reloaded = PhotoStationStore(tmp_path)
+
+    assert reloaded.get("station-1").name == "Desk station"
+    assert reloaded.get("station-1").corners[2].x == 100
+
+
+def test_photo_station_store_logs_corrupt_json(tmp_path, caplog):
+    store_path = tmp_path / "photo-stations.json"
+    store_path.write_text("{invalid json!!!")
+
+    with caplog.at_level(logging.ERROR):
+        store = PhotoStationStore(tmp_path)
+
+    assert store.all() == {}
+    assert not store_path.exists()
+    moved = list(tmp_path.glob("photo-stations.corrupt-*.json"))
+    assert len(moved) == 1
+    assert moved[0].read_text() == "{invalid json!!!"
+    assert any("Failed to load" in record.message for record in caplog.records)
+
+
+def test_create_station_from_confirmed_session(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="letter",
+    ))
+
+    resp = client.post("/api/photo-stations", json={
+        "name": "Phone mount",
+        "session_id": "session-1",
+    })
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Phone mount"
+    assert data["paper_size"] == "letter"
+    assert data["image_width"] == 120
+
+
+def test_create_station_copies_upload_to_station_owned_photo(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    original = tmp_path / "default" / "uploads" / "session-1.jpg"
+    _write_image(original)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.jpg",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="letter",
+    ))
+
+    resp = client.post("/api/photo-stations", json={
+        "name": "Phone mount",
+        "session_id": "session-1",
+    })
+
+    assert resp.status_code == 200
+    image_path = resp.json()["image_path"]
+    assert image_path.startswith("default/station-photos/")
+    assert "\\" not in image_path
+    assert (tmp_path / image_path).exists()
+
+
+def test_create_station_requires_confirmed_corners(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_width=120,
+        original_image_height=160,
+    ))
+
+    resp = client.post("/api/photo-stations", json={
+        "name": "Phone mount",
+        "session_id": "session-1",
+    })
+
+    assert resp.status_code == 400
+
+
+def test_create_station_rejects_wrong_corner_count(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_width=120,
+        original_image_height=160,
+        paper_size="a4",
+    ))
+
+    resp = client.post("/api/photo-stations", json={
+        "name": "Phone mount",
+        "session_id": "session-1",
+        "paper_size": "a4",
+        "corners": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}],
+    })
+
+    assert resp.status_code == 400
+
+
+def test_get_photo_station_returns_single_station(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    ok = client.get("/api/photo-stations/station-1")
+    missing = client.get("/api/photo-stations/missing")
+
+    assert ok.status_code == 200
+    assert ok.json()["name"] == "Desk station"
+    assert missing.status_code == 404
+
+
+def test_list_photo_stations_returns_recent_first(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("old", PhotoStation(
+        id="old",
+        name="Old station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-02T00:00:00+00:00",
+    ))
+    station_store.set("new", PhotoStation(
+        id="new",
+        name="New station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+        created_at="2026-01-03T00:00:00+00:00",
+        updated_at="2026-01-04T00:00:00+00:00",
+    ))
+
+    resp = client.get("/api/photo-stations")
+
+    assert resp.status_code == 200
+    assert [station["id"] for station in resp.json()["stations"]] == ["new", "old"]
+
+
+def test_update_station_renames_and_edits_corners(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.patch("/api/photo-stations/station-1", json={
+        "name": "Phone station",
+        "paper_size": "letter",
+        "corners": [
+            {"x": 5, "y": 6},
+            {"x": 90, "y": 7},
+            {"x": 88, "y": 92},
+            {"x": 4, "y": 91},
+        ],
+    })
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Phone station"
+    assert data["paper_size"] == "letter"
+    assert data["corners"][0] == {"x": 5.0, "y": 6.0}
+    assert station_store.get("station-1").corners[2].x == 88
+
+
+def test_update_station_rejects_wrong_corner_count(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.patch("/api/photo-stations/station-1", json={
+        "corners": [{"x": 5, "y": 6}, {"x": 90, "y": 7}, {"x": 88, "y": 92}],
+    })
+
+    assert resp.status_code == 400
+
+
+def test_delete_station_removes_owned_photo(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    photo = tmp_path / "default" / "station-photos" / "station-1.jpg"
+    _write_image(photo)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        image_path="default/station-photos/station-1.jpg",
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.delete("/api/photo-stations/station-1")
+
+    assert resp.status_code == 200
+    assert station_store.get("station-1") is None
+    assert not photo.exists()
+
+
+def test_station_suggestions_are_backend_owned_and_filter_far(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    station_store = routes.get_photo_station_store("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.jpg",
+        original_image_width=101,
+        original_image_height=122,
+        corners=_corners(101, 122),
+    ))
+    station_store.set("near", PhotoStation(
+        id="near",
+        name="Near station",
+        image_width=100,
+        image_height=120,
+        paper_size="a4",
+        corners=_corners(100, 120),
+    ))
+    station_store.set("far", PhotoStation(
+        id="far",
+        name="Far station",
+        image_width=160,
+        image_height=120,
+        paper_size="a4",
+        corners=_corners(160, 120),
+    ))
+
+    resp = client.get("/api/sessions/session-1/station-suggestions")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["station_count"] == 2
+    assert [s["station"]["id"] for s in data["suggestions"]] == ["near"]
+    assert data["suggestions"][0]["match_status"] == "near"
+    assert data["suggestions"][0]["height_delta_percent"] == pytest.approx(1.667)
+
+
+def test_station_suggestions_return_empty_for_legacy_sessions_without_dimensions(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    station_store = routes.get_photo_station_store("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.jpg",
+        corners=_corners(),
+    ))
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.get("/api/sessions/session-1/station-suggestions")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"suggestions": [], "station_count": 1}
+
+
+def test_upload_with_station_reuses_crop_and_corners(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Cropped station",
+        image_width=100,
+        image_height=100,
+        capture_crop={"x": 0.25, "y": 0, "width": 0.5, "height": 1},
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.post(
+        "/api/upload",
+        data={"station_id": "station-1"},
+        files={"image": ("photo.png", _image_bytes(size=(200, 100)), "image/png")},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["corner_source"] == "station"
+    assert data["station_id"] == "station-1"
+    session_store, _, _ = routes.get_stores("default")
+    session = session_store.get(data["session_id"])
+    assert session.original_image_width == 100
+    assert session.original_image_height == 100
+    assert session.capture_crop.x == 0.25
+    assert session.corners[2].x == 100
+    assert station_store.get("station-1").last_used_at is not None
+    assert station_store.get("station-1").updated_at is None
+
+
+def test_upload_with_station_dimension_mismatch_does_not_orphan_upload(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    station_store = routes.get_photo_station_store("default")
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.post(
+        "/api/upload",
+        data={"station_id": "station-1"},
+        files={"image": ("photo.png", _image_bytes(size=(140, 100)), "image/png")},
+    )
+
+    session_store, _, _ = routes.get_stores("default")
+    assert resp.status_code == 400
+    assert session_store.all() == {}
+    assert list((tmp_path / "default" / "uploads").iterdir()) == []
+
+
+def test_upload_with_capture_crop_detects_on_cropped_image(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+
+    def detect(path):
+        assert Image.open(path).size == (50, 80)
+        return [(0, 0), (50, 0), (50, 80), (0, 80)]
+
+    monkeypatch.setattr(routes.image_processor, "detect_paper_corners", detect)
+
+    resp = client.post(
+        "/api/upload",
+        data={"capture_crop": json.dumps({"x": 0, "y": 0, "width": 0.5, "height": 1})},
+        files={"image": ("photo.png", _image_bytes(size=(100, 80)), "image/png")},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["corner_source"] == "detected"
+    session_store, _, _ = routes.get_stores("default")
+    session = session_store.get(data["session_id"])
+    assert session.original_image_width == 50
+    assert session.original_image_height == 80
+    assert session.capture_crop.width == 0.5
+
+
+def test_upload_rejects_capture_crop_outside_image(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+
+    resp = client.post(
+        "/api/upload",
+        data={"capture_crop": json.dumps({"x": 0.75, "y": 0, "width": 0.5, "height": 1})},
+        files={"image": ("photo.png", _image_bytes(size=(100, 80)), "image/png")},
+    )
+
+    assert resp.status_code == 400
+
+
+def test_reuse_station_scales_near_dimension_match(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    station_store = routes.get_photo_station_store("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.jpg",
+        original_image_width=101,
+        original_image_height=122,
+        corners=_corners(101, 122),
+    ))
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=120,
+        paper_size="a4",
+        corners=_corners(100, 120),
+    ))
+
+    resp = client.post("/api/sessions/session-1/reuse-corners", json={"station_id": "station-1"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["paper_size"] == "a4"
+    assert data["corners"][1]["x"] == 101
+    assert data["corners"][2]["y"] == 122
+    assert data["suggestion"]["match_status"] == "near"
+    assert data["suggestion"]["warnings"]
+    assert session_store.get("session-1").paper_size == "a4"
+    assert station_store.get("station-1").updated_at is None
+
+
+def test_reuse_station_requires_original_upload(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    station_store = routes.get_photo_station_store("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_width=100,
+        original_image_height=100,
+        corners=_corners(),
+    ))
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.post("/api/sessions/session-1/reuse-corners", json={"station_id": "station-1"})
+
+    assert resp.status_code == 404
+
+
+def test_reuse_station_rejects_far_dimension_match(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    session_store, _, _ = routes.get_stores("default")
+    station_store = routes.get_photo_station_store("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.jpg",
+        original_image_width=140,
+        original_image_height=100,
+        corners=_corners(140),
+    ))
+    station_store.set("station-1", PhotoStation(
+        id="station-1",
+        name="Desk station",
+        image_width=100,
+        image_height=100,
+        paper_size="a4",
+        corners=_corners(),
+    ))
+
+    resp = client.post("/api/sessions/session-1/reuse-corners", json={"station_id": "station-1"})
+
+    assert resp.status_code == 400
+
+
+def test_redetect_corners_updates_session_from_original_upload(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    original = tmp_path / "default" / "uploads" / "session-1.png"
+    _write_image(original, size=(120, 160))
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.png",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="letter",
+    ))
+    monkeypatch.setattr(routes.image_processor, "detect_paper_corners", lambda *_: [(1, 2), (100, 3), (98, 120), (2, 118)])
+
+    resp = client.post("/api/sessions/session-1/redetect-corners")
+
+    assert resp.status_code == 200
+    assert resp.json()["corners"][0] == {"x": 1.0, "y": 2.0}
+    session = session_store.get("session-1")
+    assert session.corners[2].x == 98
+    assert session.paper_size == "letter"
+
+
+def test_delete_session_cleans_session_owned_files(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    paths = [
+        tmp_path / "default" / "uploads" / "session-1.png",
+        tmp_path / "default" / "processed" / "session-1_corrected.png",
+        tmp_path / "default" / "processed" / "session-1_mask.png",
+        tmp_path / "default" / "outputs" / "session-1.stl",
+        tmp_path / "default" / "outputs" / "session-1.3mf",
+    ]
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"data")
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.png",
+        corrected_image_path="default/processed/session-1_corrected.png",
+        mask_image_path="default/processed/session-1_mask.png",
+        stl_path="default/outputs/session-1.stl",
+    ))
+
+    resp = client.delete("/api/sessions/session-1")
+
+    assert resp.status_code == 200
+    assert session_store.get("session-1") is None
+    assert all(not path.exists() for path in paths)
+
+
+def test_set_corners_without_station_does_not_copy_station_photo(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    original = tmp_path / "default" / "uploads" / "session-1.png"
+    corrected = tmp_path / "default" / "processed" / "session-1_corrected.png"
+    _write_image(original)
+    _write_image(corrected)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.png",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="a4",
+    ))
+    monkeypatch.setattr(routes.image_processor, "apply_perspective_correction", lambda *_: (str(corrected), 1.0))
+
+    resp = client.post("/api/sessions/session-1/corners", json={
+        "corners": [p.model_dump() for p in _corners()],
+        "paper_size": "a4",
+    })
+
+    assert resp.status_code == 200
+    assert resp.json()["station"] is None
+    assert not (tmp_path / "default" / "station-photos").exists()
+
+
+def test_set_corners_with_station_saves_station_photo(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    original = tmp_path / "default" / "uploads" / "session-1.png"
+    corrected = tmp_path / "default" / "processed" / "session-1_corrected.png"
+    _write_image(original)
+    _write_image(corrected)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.png",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="a4",
+    ))
+    monkeypatch.setattr(routes.image_processor, "apply_perspective_correction", lambda *_: (str(corrected), 1.0))
+
+    resp = client.post("/api/sessions/session-1/corners", json={
+        "corners": [p.model_dump() for p in _corners()],
+        "paper_size": "a4",
+        "save_station_name": "Desk station",
+    })
+
+    assert resp.status_code == 200
+    station = resp.json()["station"]
+    assert station["name"] == "Desk station"
+    assert station["image_path"].startswith("default/station-photos/")
+    assert (tmp_path / station["image_path"]).exists()
+    assert not original.exists()
+
+
+def test_set_corners_station_copy_failure_keeps_original_upload(tmp_path, monkeypatch):
+    client = _api_client(tmp_path, monkeypatch)
+    original = tmp_path / "default" / "uploads" / "session-1.png"
+    corrected = tmp_path / "default" / "processed" / "session-1_corrected.png"
+    _write_image(original)
+    _write_image(corrected)
+    session_store, _, _ = routes.get_stores("default")
+    session_store.set("session-1", Session(
+        id="session-1",
+        original_image_path="default/uploads/session-1.png",
+        original_image_width=120,
+        original_image_height=160,
+        corners=_corners(),
+        paper_size="a4",
+    ))
+    monkeypatch.setattr(routes.image_processor, "apply_perspective_correction", lambda *_: (str(corrected), 1.0))
+
+    def fail_copy(*_args, **_kwargs):
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(routes.shutil, "copy2", fail_copy)
+
+    with pytest.raises(OSError, match="copy failed"):
+        client.post("/api/sessions/session-1/corners", json={
+            "corners": [p.model_dump() for p in _corners()],
+            "paper_size": "a4",
+            "save_station_name": "Desk station",
+        })
+
+    assert original.exists()


### PR DESCRIPTION
## Summary

This adds the backend foundation for reusable photo stations. A photo station stores a known camera/paper setup so later captures from the same setup can reuse or compare against saved paper corners instead of starting from scratch each time.

The PR includes:
- photo station request/response schemas
- a JSON-backed photo station store
- endpoints for listing, creating, updating, deleting, and reusing stations
- station suggestions for an uploaded session
- corner redetection support
- saving a station directly while confirming corners
- focused backend tests for the new station behavior

## Implementation Notes

The station store follows the existing local JSON-store pattern used elsewhere in the backend. Station records include paper size, image dimensions, source image path, saved corners, and timestamps.

The corner confirmation endpoint can now optionally receive `save_station_name`. When present, the backend creates a station from the confirmed session image and corners as part of the same workflow.

This also addresses review feedback from the original larger PR:
- Uses timezone-aware UTC timestamps instead of `datetime.utcnow()`.
- Centralizes station creation logic in a helper instead of duplicating it between routes.
- Copies the original uploaded image into station storage before unlinking the upload source.
- Adds backend coverage for station creation, suggestion behavior, invalid input, corrupt store handling, and the copy-before-unlink path.

## Tests

- `python -m pytest backend/tests/test_photo_stations.py`

Code and PR drafted with Codex
