### PR TITLE
Fix label row indexing for fractional grid_y in partial bins

### DIFF
--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -1200,7 +1200,6 @@ def _make_text_labels(
     offset_y: float,
     pocket_depth: float = 0,
     polygons: list[ScaledPolygon] | None = None,
-    max_depth: float = 0,
 ):
     """Build manifold solids for text labels. Returns (recessed_cutter, embossed_body).
 
@@ -1380,10 +1379,10 @@ class ManifoldSTLGenerator:
             cutters.append(_make_magnet_holes(config))
 
         pocket_depth = 5
-        floor_z = GF_BASE_HEIGHT
-        lip_deduction = (LIP_D3 + LIP_D4) if config.stacking_lip else 0
-        max_depth = wall_top_z - floor_z - 2 - lip_deduction
         if polygons:
+            floor_z = GF_BASE_HEIGHT
+            lip_deduction = (LIP_D3 + LIP_D4) if config.stacking_lip else 0
+            max_depth = wall_top_z - floor_z - 2 - lip_deduction
             # Default pocket_depth still tracks the global cutout_depth; per-cutout
             # overrides are resolved inside the cutter functions.
             pocket_depth = _resolve_pocket_depth(None, config, max_depth)
@@ -1428,7 +1427,6 @@ class ManifoldSTLGenerator:
                 offset_y,
                 pocket_depth,
                 polygons=poly_dicts,
-                max_depth=max_depth,
             )
             if recessed:
                 cutters.append(recessed)

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -314,8 +314,9 @@ def _label_layout_cell(config: GenerateRequest, x_mm: float, y_mm: float) -> tup
     """Map a text label position (bin layout mm, origin top-left) to grid cell indices."""
     grid_x, grid_y = _grid_cell_counts(config)
     ix = min(max(int(x_mm // GF_GRID), 0), grid_x - 1)
-    iy_ui = min(max(int(y_mm // GF_GRID), 0), grid_y - 1)
-    return ix, grid_y - 1 - iy_ui
+    # rows pitch from the bottom; fractional remainder band is the top row
+    iy = min(max(int((config.grid_y * GF_GRID - y_mm) // GF_GRID), 0), grid_y - 1)
+    return ix, iy
 
 
 def _label_in_enabled_cell(config: GenerateRequest, x_mm: float, y_mm: float) -> bool:

--- a/backend/tests/test_partial_bins.py
+++ b/backend/tests/test_partial_bins.py
@@ -330,4 +330,42 @@ def test_text_label_in_disabled_cell_excluded_from_stl(tmp_path: Path):
     assert text_span is None
 
 
+def test_label_layout_cell_fractional_grid_indexes_rows_from_bottom():
+    # 63mm layout: fractional 21mm band is the top row (iy=1),
+    # full 42mm row pitches from the bottom (iy=0)
+    config = _base_config(grid_y=1.5)
 
+    assert _label_layout_cell(config, 21, 30) == (0, 0)
+    assert _label_layout_cell(config, 21, 10) == (0, 1)
+    # centre exactly on a gridline goes to the higher-index cell, matching x
+    assert _label_layout_cell(config, 21, 21) == (0, 1)
+
+
+def test_text_label_fractional_grid_bottom_row_disabled_skips_label(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    # label at y=30 sits in the bottom 42mm row, which is disabled
+    config = _base_config(
+        grid_y=1.5,
+        partial_bins=True,
+        partial_bins_values=[True, True, False, False],
+        text_labels=[TextLabel(id="lbl", text="HELLO", x=21, y=30, emboss=True)],
+    )
+
+    _, text_body = generator.generate_bin([], config, str(tmp_path / "bottom.stl"))
+
+    assert text_body is None
+
+
+def test_text_label_fractional_grid_top_row_disabled_keeps_label(tmp_path: Path):
+    generator = ManifoldSTLGenerator()
+    # same label, but only the top 21mm band is disabled
+    config = _base_config(
+        grid_y=1.5,
+        partial_bins=True,
+        partial_bins_values=[False, False, True, True],
+        text_labels=[TextLabel(id="lbl", text="HELLO", x=21, y=30, emboss=True)],
+    )
+
+    _, text_body = generator.generate_bin([], config, str(tmp_path / "top.stl"))
+
+    assert text_body is not None and not text_body.is_empty()


### PR DESCRIPTION
## Summary

- index label rows from the bottom in `_label_layout_cell`: shell geometry pitches rows from the bottom, so the fractional remainder band is the top UI row; the old top-down `int(y_mm // GF_GRID)` mapped fractional-grid labels to the wrong cell (floating label if the bottom row was disabled, silently dropped label if the top row was)
- remove the unused `max_depth` param left behind by the reverted clipping approach in #127, restoring the pre-#127 `generate_bin` shape

## Test evidence

`backend/venv/bin/python -m pytest` (full backend): 241 passed. New fractional-grid tests fail on main, pass on this branch. `make lint-backend`: clean.

Closes #141
