### PR TITLE
fix: better accessibility for hints and alerts in light mode

### DIFF
--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -15,10 +15,13 @@ import { Alert } from '@/components/Alert'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { useProjectSource } from '@/hooks/useProjectSource'
 import { GRID_UNIT } from '@/lib/constants'
+import { useTheme } from '@/hooks/useTheme'
+import { cn } from '@/lib/utils'
 
 function InfoBanner({ children }: { children: React.ReactNode }) {
+  const { theme } = useTheme()
   return (
-    <div className="text-[10px] text-amber-400 bg-amber-900/20 border border-amber-800/50 rounded px-2 py-1">
+    <div className={cn("text-[10px] rounded px-2 py-1", theme === 'dark' ? 'bg-amber-900/20 border border-amber-800/50 text-amber-400' : 'bg-amber-500/20 border border-amber-400/50 text-amber-600')}>
       {children}
     </div>
   )

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,8 @@ import { GRID_UNIT } from '@/lib/constants'
 import { getDefaultBinDefaults } from '@/lib/binDefaults'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
 import { projectNameMap, projectStatusLabels, toolProjectLabel, toolProjectTitle } from '@/lib/projectSelectors'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/hooks/useTheme'
 
 function thumbnailRotationStyle(transform: AffineMatrix | null): React.CSSProperties | undefined {
   if (!transform) return undefined
@@ -229,6 +231,15 @@ function loadSectionCollapseState(): MainSectionCollapseState {
   } catch {
     return defaultSectionCollapse
   }
+}
+
+function HintBanner({ children }: { children: React.ReactNode }) {
+  const { theme } = useTheme()
+  return (
+    <div className={cn("text-[10px] flex-shrink-0", theme === 'dark' ? 'text-amber-300' : 'text-amber-600')}>
+      {children}
+    </div>
+  )
 }
 
 export default function HomePage() {
@@ -499,7 +510,7 @@ export default function HomePage() {
                               <span className="text-[10px] text-text-muted flex-shrink-0">·</span>
                             )}
                             {project.unplaced_count > 0 && (
-                              <span className="text-[10px] text-amber-300 flex-shrink-0">{project.unplaced_count} need bin</span>
+                              <HintBanner>{project.unplaced_count} need bin</HintBanner>
                             )}
                           </div>
                         )}
@@ -609,7 +620,7 @@ export default function HomePage() {
                                 {projectBinToolIds.has(tool.id) ? (
                                   <span className="text-[10px] text-text-muted flex-shrink-0">Placed</span>
                                 ) : (
-                                  <span className="text-[10px] text-amber-300 flex-shrink-0">Needs bin</span>
+                                  <HintBanner>Needs bin</HintBanner>
                                 )}
                               </>
                             )}

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -36,6 +36,8 @@ import {
   type ProjectToolFilter,
 } from '@/lib/projectSelectors'
 import { AlertTriangle, ArrowLeft, CheckSquare, ChevronDown, ChevronRight, Loader2, Package, Plus, Search, Square, Trash2, Unlink } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/hooks/useTheme'
 
 const PROJECT_SECTION_COLLAPSE_KEY = 'tracefinity.project.collapsedSections'
 type ProjectSectionId = 'binDefaults' | 'projectTools' | 'linkedBins'
@@ -62,6 +64,7 @@ export default function ProjectPage() {
   const params = useParams()
   const router = useRouter()
   const projectId = params.id as string
+  const { theme } = useTheme()
 
   const [project, setProject] = useState<BinProject | null>(null)
   const [projects, setProjects] = useState<BinProjectSummary[]>([])
@@ -478,7 +481,7 @@ export default function ProjectPage() {
         <section className="glass rounded-[8px] px-3 py-2">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="flex items-center gap-2 text-xs text-amber-300">
+              <div className={cn("flex items-center gap-2 text-xs", theme === 'dark' ? 'text-amber-300' : 'text-amber-600')}>
                 <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
                 <span>{healthIssues.length} project health issue{healthIssues.length !== 1 ? 's' : ''}</span>
               </div>
@@ -581,7 +584,7 @@ export default function ProjectPage() {
                       title: binLabel(bin),
                       className: 'text-text-secondary',
                     }))
-                    : [{ key: 'needs-bin', label: 'Needs bin', title: 'Needs bin', className: 'text-amber-300' }]),
+                    : [{ key: 'needs-bin', label: 'Needs bin', title: 'Needs bin', className: theme === 'dark' ? 'text-amber-300' : 'text-amber-600' }]),
                 ]
                 return (
                 <div key={tool.id} className="glass rounded-[8px] px-3 py-2 min-h-[72px] flex items-start justify-between gap-2">
@@ -829,7 +832,7 @@ export default function ProjectPage() {
                     </button>
                     <div className="flex items-center gap-1 flex-shrink-0">
                       {outsideTools.length > 0 && (
-                        <AlertTriangle className="w-4 h-4 text-amber-300" />
+                        <AlertTriangle className={cn("w-4 h-4", theme === 'dark' ? 'text-amber-300' : 'text-amber-600')} />
                       )}
                       <Package className="w-4 h-4 text-text-muted" />
                       <button
@@ -854,7 +857,7 @@ export default function ProjectPage() {
                     <div className="mt-2 space-y-1 border-t border-border-subtle pt-2">
                       {outsideTools.length > 0 && (
                         <div className="glass-sm rounded-[7px] border border-border-subtle px-2 py-1">
-                          <p className="text-[10px] text-amber-300">{outsideTools.length} outside-project tool{outsideTools.length !== 1 ? 's' : ''} in this bin</p>
+                          <p className={cn("text-[10px]", theme === 'dark' ? 'text-amber-300' : 'text-amber-600')}>{outsideTools.length} outside-project tool{outsideTools.length !== 1 ? 's' : ''} in this bin</p>
                         </div>
                       )}
                       <p className="text-[10px] text-text-muted px-1">In this bin</p>

--- a/frontend/src/components/Alert.tsx
+++ b/frontend/src/components/Alert.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, Info, CheckCircle, XCircle } from 'lucide-react'
 import { ReactNode } from 'react'
+import { useTheme } from '@/hooks/useTheme'
 
 interface Props {
   variant?: 'error' | 'warning' | 'info' | 'success'
@@ -9,7 +10,7 @@ interface Props {
   className?: string
 }
 
-const variants = {
+const variantsDark = {
   error: {
     container: 'bg-red-900/15 border-red-800/40',
     icon: 'text-red-400',
@@ -36,12 +37,41 @@ const variants = {
   },
 }
 
+const variantsLight = {
+  error: {
+    container: 'bg-red-500/15 border-red-400/40',
+    icon: 'text-red-600',
+    text: 'text-red-600',
+    Icon: XCircle,
+  },
+  warning: {
+    container: 'bg-amber-500/15 border-amber-400/40',
+    icon: 'text-amber-600',
+    text: 'text-amber-600',
+    Icon: AlertTriangle,
+  },
+  info: {
+    container: 'bg-blue-500/15 border-blue-400/40',
+    icon: 'text-blue-600',
+    text: 'text-blue-600',
+    Icon: Info,
+  },
+  success: {
+    container: 'bg-green-500/15 border-green-400/40',
+    icon: 'text-green-600',
+    text: 'text-green-600',
+    Icon: CheckCircle,
+  },
+}
+
 export function Alert({ variant = 'info', children, className = '' }: Props) {
+  const { theme } = useTheme()
+  const variants = theme === 'dark' ? variantsDark : variantsLight
   const v = variants[variant]
   const Icon = v.Icon
 
   return (
-    <div className={`flex items-start gap-2.5 p-3 border rounded-[10px] backdrop-blur-sm ${v.container} ${className}`}>
+    <div className={`flex items-center justify-start gap-2.5 p-3 border rounded-[10px] backdrop-blur-sm ${v.container} ${className}`}>
       <Icon className={`w-4 h-4 flex-shrink-0 mt-0.5 ${v.icon}`} />
       <div className={`text-xs ${v.text}`}>{children}</div>
     </div>

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -7,6 +7,7 @@ import { createPartialBinsValues } from '@/lib/binDefaults'
 import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from '@/lib/settings'
 import { cn } from '@/lib/utils'
 import { ClassValue } from 'clsx'
+import { useTheme } from '@/hooks/useTheme'
 
 const GF_HEIGHT_UNIT = 7.0
 const GF_BASE_HEIGHT = 4.75
@@ -150,6 +151,15 @@ function RadioMatrix({ sizeX, sizeY, values, onChange }: { sizeX: number; sizeY:
           ))}
       </div>
   );
+}
+
+function HintBanner({ children }: { children: React.ReactNode }) {
+  const { theme } = useTheme()
+  return (
+    <div className={cn("text-[11px] mt-1 leading-tight", theme === 'dark' ? 'text-amber-400' : 'text-amber-600')}>
+      {children}
+    </div>
+  )
 }
 
 export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }: Props) {
@@ -371,12 +381,12 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
           onChange={(v) => update({ bed_size: v })}
         />
         {needsSplit && (
-          <div className="text-[11px] text-amber-400 mt-1 leading-tight">
+          <HintBanner>
             {binWidth > config.bed_size && `Width ${binWidth}mm exceeds bed`}
             {binWidth > config.bed_size && binDepth > config.bed_size && ' & '}
             {binDepth > config.bed_size && `Depth ${binDepth}mm exceeds bed`}
             {' \u2014 will be split'}
-          </div>
+          </HintBanner>
         )}
       </div>
 
@@ -414,7 +424,7 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
                           help="Keep the bin perimeter wall through disabled cells while still connecting them on the base."
                       />
                   )}
-                  {exportsSeparateParts && <div className="text-[11px] text-amber-400 mt-1 leading-tight">Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part</div>}
+                  {exportsSeparateParts && <HintBanner>Disconnected pieces {"\u2014"} export includes a ZIP with one STL per part</HintBanner>}
               </div>
           )}
       </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,32 +1,14 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Sun, Moon } from 'lucide-react'
 import { IconButton } from '@/components/IconButton'
+import { useTheme } from '@/hooks/useTheme'
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<'dark' | 'light'>('dark')
-
-  useEffect(() => {
-    const stored = localStorage.getItem('theme')
-    if (stored === 'light' || stored === 'dark') {
-      setTheme(stored)
-      document.documentElement.setAttribute('data-theme', stored)
-    } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      setTheme('light')
-      document.documentElement.setAttribute('data-theme', 'light')
-    }
-  }, [])
-
-  function toggle() {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-    document.documentElement.setAttribute('data-theme', next)
-    localStorage.setItem('theme', next)
-  }
+  const { theme, toggleTheme } = useTheme()
 
   return (
-    <IconButton onClick={toggle} title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}>
+    <IconButton onClick={toggleTheme} title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}>
       {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
     </IconButton>
   )

--- a/frontend/src/components/ToolEditor.tsx
+++ b/frontend/src/components/ToolEditor.tsx
@@ -17,6 +17,8 @@ import { useHistory } from '@/hooks/useHistory'
 import { ToolEditorToolbar } from '@/components/ToolEditorToolbar'
 import { ToolEditorCanvas } from '@/components/ToolEditorCanvas'
 import type { EditMode, Selection } from '@/components/ToolEditorToolbar'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/hooks/useTheme'
 
 interface Props {
   points: Point[]
@@ -90,6 +92,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
 
   const imageTransformRef = useRef<AffineMatrix | null>(sourceImageContext?.transform ?? null)
   const onImageTransformRef = useRef(onImageTransformChange)
+  const { theme } = useTheme()
 
   // undo/redo
   const historyOnChange = useCallback((entry: HistoryEntry) => {
@@ -889,7 +892,7 @@ export function ToolEditor({ points, fingerHoles, interiorRings, smoothed, smoot
       </div>
 
       {mirrorNote && (
-        <div className="absolute top-[58px] left-1/2 -translate-x-1/2 z-20 glass-toolbar px-3 py-1.5 text-[11px] text-amber-300 max-w-[320px] text-center pointer-events-none">
+        <div className={cn("absolute top-[58px] left-1/2 -translate-x-1/2 z-20 glass-toolbar px-3 py-1.5 text-[11px] max-w-[320px] text-center pointer-events-none", theme === 'dark' ? 'text-amber-300' : 'text-amber-600')}>
           {mirrorNote}
         </div>
       )}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useCallback, useSyncExternalStore } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+const listeners = new Set<() => void>()
+let observer: MutationObserver | null = null
+let initialized = false
+
+function readTheme(): Theme {
+  if (typeof document === 'undefined') return 'dark'
+  return document.documentElement.getAttribute('data-theme') === 'light'
+    ? 'light'
+    : 'dark'
+}
+
+function emit() {
+  for (const listener of listeners) listener()
+}
+
+function ensureObserver() {
+  if (observer || typeof document === 'undefined') return
+  observer = new MutationObserver(emit)
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  })
+}
+
+/** Resolve theme from localStorage / system preference once on the client. */
+export function initTheme() {
+  if (initialized || typeof window === 'undefined') return
+  initialized = true
+
+  const stored = localStorage.getItem('theme')
+  if (stored === 'light' || stored === 'dark') {
+    document.documentElement.setAttribute('data-theme', stored)
+  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+    document.documentElement.setAttribute('data-theme', 'light')
+  } else {
+    document.documentElement.setAttribute('data-theme', 'dark')
+  }
+}
+
+function subscribe(listener: () => void) {
+  initTheme()
+  listeners.add(listener)
+  ensureObserver()
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && observer) {
+      observer.disconnect()
+      observer = null
+    }
+  }
+}
+
+function getSnapshot(): Theme {
+  return readTheme()
+}
+
+function getServerSnapshot(): Theme {
+  return 'dark'
+}
+
+export function setTheme(next: Theme) {
+  if (typeof document === 'undefined') return
+  document.documentElement.setAttribute('data-theme', next)
+  localStorage.setItem('theme', next)
+  emit()
+}
+
+export function toggleTheme() {
+  setTheme(readTheme() === 'dark' ? 'light' : 'dark')
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  const set = useCallback((next: Theme) => setTheme(next), [])
+  const toggle = useCallback(() => toggleTheme(), [])
+
+  return { theme, setTheme: set, toggleTheme: toggle }
+}


### PR DESCRIPTION
## Changes
This PR improves the readability of hints and alerts in light mode, since they currently have the same color as in dark mode, which sometimes makes them very hard to read.

The `useTheme` hook was created for this purpose. This hook allows you to access, toggle, or set the theme in other client components.

```TypeScript
'use client'
import { useTheme } from '@/hooks/useTheme'
const { theme, setTheme, toggleTheme } = useTheme()

console.log(theme) // -> "dark" or "light"
setTheme("dark")   // sets the theme to a specific value
toggleTheme()      // toggles the theme to the opposite value
```

## Few examples

| Site / Component | Old | New |
|---|---|---|
| Alert Component | <img width="471" height="222" alt="CleanShot 2026-07-18 at 14 36 54" src="https://github.com/user-attachments/assets/2d28f080-1305-40c0-baa3-6c02616083e3" /> | <img width="470" height="219" alt="CleanShot 2026-07-18 at 14 36 24" src="https://github.com/user-attachments/assets/701f173c-0fd5-4c13-ab24-503e66bb73a9" /> |
| Tool Editor (mirroring) | <img width="315" height="45" alt="CleanShot 2026-07-18 at 15 26 27" src="https://github.com/user-attachments/assets/974126d7-43ee-48de-a9e6-fdc5204da26f" /> | <img width="336" height="59" alt="CleanShot 2026-07-18 at 15 14 48" src="https://github.com/user-attachments/assets/196ee34c-b0bf-4f8a-9ed9-fd8223103724" /> |
| Bin Editor | <img width="164" height="556" alt="CleanShot 2026-07-18 at 15 26 40" src="https://github.com/user-attachments/assets/5b9127eb-e245-4d39-957c-c6f38215e184" /> | <img width="161" height="553" alt="CleanShot 2026-07-18 at 15 35 59" src="https://github.com/user-attachments/assets/78e7c2d8-f2fa-4ff6-83ad-92e85d74b3d7" /> |
| Bin Editor | <img width="190" height="80" alt="CleanShot 2026-06-28 at 00 35 09" src="https://github.com/user-attachments/assets/60cee3d3-bcbe-4d9a-a307-f1e5556a4491" /> | <img width="186" height="84" alt="CleanShot 2026-07-18 at 15 38 25" src="https://github.com/user-attachments/assets/65b573c6-d520-4f83-887d-7672ca3eb21a" /> |
| Main page (projects) | <img width="234" height="107" alt="CleanShot 2026-07-18 at 15 24 56" src="https://github.com/user-attachments/assets/e3e8218f-ba04-4134-aea4-dd01959c8304" /> | <img width="238" height="112" alt="CleanShot 2026-07-18 at 15 44 39" src="https://github.com/user-attachments/assets/b92d01ab-7463-46c5-ad4e-c16b7a6033bc" /> |
