### PR TITLE
Show app version in settings popover

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -44,6 +44,10 @@ jobs:
             type=raw,value=dev
             type=sha,prefix=dev-
 
+      - name: Short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -52,5 +56,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=dev-${{ steps.sha.outputs.short }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -53,6 +53,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,6 +58,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Smoke test image version
+        run: |
+          # baked APP_VERSION must match the release tag
+          docker run --rm --entrypoint sh \
+            "$REGISTRY/$IMAGE_NAME:${{ steps.meta.outputs.version }}" \
+            -c 'echo "$APP_VERSION"' | grep -qx "${GITHUB_REF_NAME#v}"
+
   release-helm-chart:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -45,6 +45,26 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      # single-arch build for the smoke check; APP_VERSION is arch-independent
+      # and the push build below reuses the cached layers
+      - name: Build for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: tracefinity-smoke
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test image version
+        run: |
+          # baked APP_VERSION must match the release tag before anything is pushed
+          got=$(docker run --rm --entrypoint sh tracefinity-smoke -c 'echo "$APP_VERSION"')
+          echo "image APP_VERSION='$got' expected '${GITHUB_REF_NAME#v}'"
+          test "$got" = "${GITHUB_REF_NAME#v}"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -57,13 +77,6 @@ jobs:
             APP_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Smoke test image version
-        run: |
-          # baked APP_VERSION must match the release tag
-          docker run --rm --entrypoint sh \
-            "$REGISTRY/$IMAGE_NAME:${{ steps.meta.outputs.version }}" \
-            -c 'echo "$APP_VERSION"' | grep -qx "${GITHUB_REF_NAME#v}"
 
   release-helm-chart:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,10 @@ RUN chmod +x /app/tests/test_entrypoint.sh
 
 EXPOSE 3000
 
+# version baked in by CI (release tag or dev-<sha>); "dev" for local builds
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 ENV GEMINI_IMAGE_MODEL="gemini-3-pro-image-preview"
 ENV STORAGE_PATH=/app/storage
 ENV U2NET_HOME=/app/.u2net

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 | `TRACEFINITY_ONNX_PROVIDER` | `auto` | Local ONNX provider: `auto`, `cuda`, or `cpu` |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |
 | `TOOL_LABEL_PROVIDER` | `none` | Optional automatic tool naming. Set to `ollama` for local vision naming |
+| `SHOW_APP_VERSION` | `true` | Show the running version in the settings popover. Set to `false` to hide it |
 
 ### Docker Compose
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -577,7 +577,12 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
 
 @router.get("/version")
 async def get_version():
-    """return the running app version (baked into the image, "dev" locally)."""
+    """return the running app version (baked into the image, "dev" locally).
+
+    404 when SHOW_APP_VERSION=false so nothing is disclosed.
+    """
+    if not settings.show_app_version:
+        raise HTTPException(status_code=404)
     return {"version": settings.app_version}
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -575,6 +575,12 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
     )
 
 
+@router.get("/version")
+async def get_version():
+    """return the running app version (baked into the image, "dev" locally)."""
+    return {"version": settings.app_version}
+
+
 @router.get("/api-keys")
 async def get_available_keys(request: Request):
     """return available tracers and provider info."""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,7 @@ from app.services.tracer_registry import DEFAULT_LOCAL_TRACERS, validate_tracer_
 
 class Settings(BaseSettings):
     app_version: str = "dev"
+    show_app_version: bool = True
     storage_path: Path = Path("./storage")
     google_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,7 +36,13 @@ class Settings(BaseSettings):
     tool_label_timeout_seconds: float = 30.0
     tool_label_max_crop_px: int = 512
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+        # empty env vars (e.g. docker run -e SHOW_APP_VERSION=) fall back to defaults
+        "env_ignore_empty": True,
+    }
 
     @property
     def available_tracers(self) -> list[str]:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,7 @@ from app.services.tracer_registry import DEFAULT_LOCAL_TRACERS, validate_tracer_
 
 
 class Settings(BaseSettings):
+    app_version: str = "dev"
     storage_path: Path = Path("./storage")
     google_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,12 @@ logging.basicConfig(
 from app.api.routes import router
 from app.api.user_routes import router as user_router
 
-app = FastAPI(title="Tracefinity API", version=settings.app_version)
+# neutral openapi version when the toggle is off, so nothing is disclosed
+# (fastapi rejects an empty version string)
+app = FastAPI(
+    title="Tracefinity API",
+    version=settings.app_version if settings.show_app_version else "hidden",
+)
 
 
 @app.on_event("startup")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ logging.basicConfig(
 from app.api.routes import router
 from app.api.user_routes import router as user_router
 
-app = FastAPI(title="Tracefinity API", version="0.1.0")
+app = FastAPI(title="Tracefinity API", version=settings.app_version)
 
 
 @app.on_event("startup")

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -14,7 +14,7 @@ def client():
 
 def test_version_defaults_to_dev(monkeypatch):
     monkeypatch.delenv("APP_VERSION", raising=False)
-    assert Settings().app_version == "dev"
+    assert Settings(_env_file=None).app_version == "dev"
 
 
 def test_version_endpoint_reflects_settings(client, monkeypatch):
@@ -26,7 +26,7 @@ def test_version_endpoint_reflects_settings(client, monkeypatch):
 
 def test_app_version_read_from_env(monkeypatch):
     monkeypatch.setenv("APP_VERSION", "0.6.0")
-    assert Settings().app_version == "0.6.0"
+    assert Settings(_env_file=None).app_version == "0.6.0"
 
 
 def test_version_endpoint_404_when_disabled(client, monkeypatch):
@@ -37,11 +37,20 @@ def test_version_endpoint_404_when_disabled(client, monkeypatch):
 
 def test_show_app_version_read_from_env(monkeypatch):
     monkeypatch.setenv("SHOW_APP_VERSION", "false")
-    assert Settings().show_app_version is False
+    assert Settings(_env_file=None).show_app_version is False
     monkeypatch.setenv("SHOW_APP_VERSION", "0")
-    assert Settings().show_app_version is False
+    assert Settings(_env_file=None).show_app_version is False
     monkeypatch.delenv("SHOW_APP_VERSION")
-    assert Settings().show_app_version is True
+    assert Settings(_env_file=None).show_app_version is True
+
+
+def test_empty_env_vars_fall_back_to_defaults(monkeypatch):
+    """docker run -e SHOW_APP_VERSION= must not crash the app."""
+    monkeypatch.setenv("SHOW_APP_VERSION", "")
+    monkeypatch.setenv("APP_VERSION", "")
+    s = Settings(_env_file=None)
+    assert s.show_app_version is True
+    assert s.app_version == "dev"
 
 
 def test_openapi_version_hidden_when_disabled(monkeypatch):
@@ -53,9 +62,9 @@ def test_openapi_version_hidden_when_disabled(monkeypatch):
 
     monkeypatch.setenv("SHOW_APP_VERSION", "false")
     monkeypatch.setenv("APP_VERSION", "9.9.9")
-    importlib.reload(config_mod)
-    importlib.reload(main_mod)
     try:
+        importlib.reload(config_mod)
+        importlib.reload(main_mod)
         resp = TestClient(main_mod.app).get("/openapi.json")
         assert resp.json()["info"]["version"] == "hidden"
     finally:

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,26 @@
+"""version endpoint reports the running app version."""
+
+from fastapi.testclient import TestClient
+
+from app.config import Settings, settings
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_version_defaults_to_dev():
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "dev"}
+
+
+def test_version_reflects_settings(monkeypatch):
+    monkeypatch.setattr(settings, "app_version", "1.2.3")
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "1.2.3"}
+
+
+def test_app_version_read_from_env(monkeypatch):
+    monkeypatch.setenv("APP_VERSION", "0.6.0")
+    assert Settings().app_version == "0.6.0"

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -27,3 +27,39 @@ def test_version_endpoint_reflects_settings(client, monkeypatch):
 def test_app_version_read_from_env(monkeypatch):
     monkeypatch.setenv("APP_VERSION", "0.6.0")
     assert Settings().app_version == "0.6.0"
+
+
+def test_version_endpoint_404_when_disabled(client, monkeypatch):
+    monkeypatch.setattr(settings, "show_app_version", False)
+    resp = client.get("/api/version")
+    assert resp.status_code == 404
+
+
+def test_show_app_version_read_from_env(monkeypatch):
+    monkeypatch.setenv("SHOW_APP_VERSION", "false")
+    assert Settings().show_app_version is False
+    monkeypatch.setenv("SHOW_APP_VERSION", "0")
+    assert Settings().show_app_version is False
+    monkeypatch.delenv("SHOW_APP_VERSION")
+    assert Settings().show_app_version is True
+
+
+def test_openapi_version_hidden_when_disabled(monkeypatch):
+    """reload app with the toggle off; openapi must not carry the version."""
+    import importlib
+
+    import app.config as config_mod
+    import app.main as main_mod
+
+    monkeypatch.setenv("SHOW_APP_VERSION", "false")
+    monkeypatch.setenv("APP_VERSION", "9.9.9")
+    importlib.reload(config_mod)
+    importlib.reload(main_mod)
+    try:
+        resp = TestClient(main_mod.app).get("/openapi.json")
+        assert resp.json()["info"]["version"] == "hidden"
+    finally:
+        monkeypatch.delenv("SHOW_APP_VERSION")
+        monkeypatch.delenv("APP_VERSION")
+        importlib.reload(config_mod)
+        importlib.reload(main_mod)

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,20 +1,23 @@
 """version endpoint reports the running app version."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.config import Settings, settings
 from app.main import app
 
-client = TestClient(app)
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
 
 
-def test_version_defaults_to_dev():
-    resp = client.get("/api/version")
-    assert resp.status_code == 200
-    assert resp.json() == {"version": "dev"}
+def test_version_defaults_to_dev(monkeypatch):
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    assert Settings().app_version == "dev"
 
 
-def test_version_reflects_settings(monkeypatch):
+def test_version_endpoint_reflects_settings(client, monkeypatch):
     monkeypatch.setattr(settings, "app_version", "1.2.3")
     resp = client.get("/api/version")
     assert resp.status_code == 200

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ Response fields:
 - `tracers` (array): `{id, label}` entries. Remote tracers include `{"id":"replicate","label":"Replicate"}` and `{"id":"fal","label":"fal.ai"}` when the respective tokens are configured.
 
 ## Meta
-- `GET /api/version` - running app version. Release images report the release tag (e.g. `0.6.0`), dev images `dev-<sha>`, local runs `dev`.
+- `GET /api/version` - running app version. Release images report the release tag (e.g. `0.6.0`), dev images `dev-<sha>`, local runs `dev`. Returns 404 when `SHOW_APP_VERSION=false`.
 
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,9 @@ Response fields:
 - `provider_label` (string|null): human label for the primary tracer, e.g. `Replicate`.
 - `tracers` (array): `{id, label}` entries. Remote tracers include `{"id":"replicate","label":"Replicate"}` and `{"id":"fal","label":"fal.ai"}` when the respective tokens are configured.
 
+## Meta
+- `GET /api/version` - running app version. Release images report the release tag (e.g. `0.6.0`), dev images `dev-<sha>`, local runs `dev`.
+
 ## File serving
 - `GET /api/files/{session_id}/bin.stl` - session STL
 - `GET /api/files/{session_id}/bin.3mf` - session 3MF

--- a/frontend/src/components/SettingsPopover.test.tsx
+++ b/frontend/src/components/SettingsPopover.test.tsx
@@ -33,4 +33,15 @@ describe('SettingsPopover version display', () => {
     expect(await screen.findByText('Settings')).toBeTruthy()
     expect(screen.queryByText(/^Version /)).toBeNull()
   })
+
+  it('omits the version line when version reporting is disabled', async () => {
+    // SHOW_APP_VERSION=false makes /api/version return 404
+    getAppVersion.mockRejectedValue(new Error('not found'))
+    render(<SettingsPopover />)
+
+    fireEvent.click(screen.getByTitle('Settings'))
+
+    expect(await screen.findByText('Settings')).toBeTruthy()
+    expect(screen.queryByText(/^Version /)).toBeNull()
+  })
 })

--- a/frontend/src/components/SettingsPopover.test.tsx
+++ b/frontend/src/components/SettingsPopover.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SettingsPopover } from './SettingsPopover'
+
+const getAppVersion = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  getAppVersion: () => getAppVersion(),
+}))
+
+describe('SettingsPopover version display', () => {
+  afterEach(() => {
+    cleanup()
+    getAppVersion.mockReset()
+  })
+
+  it('shows the app version when the popover opens', async () => {
+    getAppVersion.mockResolvedValue('0.6.0')
+    render(<SettingsPopover />)
+
+    fireEvent.click(screen.getByTitle('Settings'))
+
+    expect(await screen.findByText('Version 0.6.0')).toBeTruthy()
+  })
+
+  it('omits the version line when the fetch fails', async () => {
+    getAppVersion.mockRejectedValue(new Error('offline'))
+    render(<SettingsPopover />)
+
+    fireEvent.click(screen.getByTitle('Settings'))
+
+    expect(await screen.findByText('Settings')).toBeTruthy()
+    expect(screen.queryByText(/^Version /)).toBeNull()
+  })
+})

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Settings } from 'lucide-react'
+import { getAppVersion } from '@/lib/api'
 import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM, getSettings, saveSettings } from '@/lib/settings'
 import { IconButton } from '@/components/IconButton'
 import { NumericInput } from '@/components/NumericInput'
@@ -9,11 +10,17 @@ import { NumericInput } from '@/components/NumericInput'
 export function SettingsPopover() {
   const [open, setOpen] = useState(false)
   const [bedSize, setBedSize] = useState(256)
+  const [version, setVersion] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setBedSize(getSettings().bedSize)
   }, [])
+
+  useEffect(() => {
+    if (!open || version !== null) return
+    getAppVersion().then(setVersion).catch(() => {})
+  }, [open, version])
 
   useEffect(() => {
     if (!open) return
@@ -74,6 +81,12 @@ export function SettingsPopover() {
               Bins wider than this are automatically split into printable pieces.
             </p>
           </div>
+
+          {version && (
+            <p className="text-[10px] text-text-muted mt-4 pt-3 border-t border-border">
+              Version {version}
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -91,6 +91,11 @@ export async function getAvailableKeys(): Promise<{ google: boolean; provider: s
   return fetchApi('/api/api-keys')
 }
 
+export async function getAppVersion(): Promise<string> {
+  const res = await fetchApi<{ version: string }>('/api/version')
+  return res.version
+}
+
 export async function traceTools(
   sessionId: string,
   provider: 'google',


### PR DESCRIPTION
## Summary

- Self-hosters could not tell which release they were running (#144). The release workflow now bakes the tag into the image as `APP_VERSION`, the backend serves it at `GET /api/version`, and the settings popover shows it. Local runs fall back to `dev`; dev images report `dev-<sha>` matching their image tag.
- `SHOW_APP_VERSION=false` turns it off 
- The release workflow now smoke-tests the baked version against the release tag on a single-arch build before the multi-arch push, so a wrong version cannot ship silently. Empty env vars (`SHOW_APP_VERSION=`, `MAX_UPLOAD_MB=`) no longer crash Settings at boot.

## Test evidence

Backend pytest 260 passed, frontend vitest 95 passed, `make lint` clean. Live-verified with uvicorn and a real browser: `/api/version` returns the env value, 404 when disabled, popover shows "Version 0.7.0-preview", line hidden when disabled.

Closes #144