### PR TITLE
Add OpenRouter provider for automatic tool naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,21 @@ TRACERS=
 TRACEFINITY_ONNX_PROVIDER=auto
 
 # Automatic tool names after tracing (optional)
-# none disables naming; ollama uses a local vision model through ToolNamer.
+# none disables naming; ollama uses a local vision model through ToolNamer;
+# openrouter uses OpenRouter's chat completions API (see OPENROUTER_API_KEY /
+# OPENROUTER_LABEL_MODEL below).
 TOOL_LABEL_PROVIDER=none
 TOOL_LABEL_MODEL=qwen3-vl:4b
 TOOL_LABEL_OLLAMA_URL=http://localhost:11434
 TOOL_LABEL_TIMEOUT_SECONDS=30
 TOOL_LABEL_MAX_CROP_PX=512
+
+# OpenRouter (optional) -- only needed when TOOL_LABEL_PROVIDER=openrouter
+OPENROUTER_API_KEY=
+# Comma-separated priority list; tried in order, falling through to the next
+# model on HTTP 429 (free-tier ":free" models share a 20 req/min pool per
+# model across all OpenRouter users, so a popular one can rate-limit fast).
+OPENROUTER_LABEL_MODEL=google/gemini-2.0-flash-001
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     storage_path: Path = Path("./storage")
     google_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None
+    openrouter_url: str = "https://openrouter.ai/api/v1/chat/completions"
     openrouter_image_model: str = "google/gemini-3.1-flash-image-preview"
     openrouter_label_model: str = "google/gemini-2.0-flash-001"
     gemini_image_model: str = "gemini-3.1-flash-image-preview"

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from app.config import settings
 from app.models.schemas import Point, Polygon
 from app.services.tracer_registry import (
     GPU_REQUIRED_TRACERS,
@@ -63,8 +64,6 @@ Return labels in the same order as the positions listed above."""
 
 # models that need post-hoc alignment (don't respect output dimensions)
 _NEEDS_ALIGNMENT = {"gemini-2.5-flash-image"}
-
-OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 
 class AITracer:
@@ -381,7 +380,7 @@ class AITracer:
         async def _call():
             async with httpx.AsyncClient(timeout=90) as client:
                 resp = await client.post(
-                    OPENROUTER_URL,
+                    settings.openrouter_url,
                     json=payload,
                     headers={
                         "Authorization": f"Bearer {self.openrouter_key}",
@@ -697,7 +696,7 @@ class AITracer:
         async def _call():
             async with httpx.AsyncClient(timeout=30) as client:
                 resp = await client.post(
-                    OPENROUTER_URL,
+                    settings.openrouter_url,
                     json=payload,
                     headers={
                         "Authorization": f"Bearer {self.openrouter_key}",

--- a/backend/app/services/tool_namer.py
+++ b/backend/app/services/tool_namer.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 import cv2
@@ -12,9 +13,9 @@ import numpy as np
 
 from app.config import settings
 from app.models.schemas import Point, Polygon
+from app.services.ai_tracer import OPENROUTER_URL
 
 logger = logging.getLogger(__name__)
-
 
 LABEL_PROMPT = """Identify the physical tool or object in this image.
 Return only JSON with this shape:
@@ -67,6 +68,8 @@ class ToolNamerConfig:
     ollama_url: str = "http://localhost:11434"
     timeout_seconds: float = 30.0
     max_crop_px: int = 512
+    openrouter_api_key: str | None = field(kw_only=True)
+    openrouter_model: str = field(kw_only=True)
 
     @classmethod
     def from_settings(cls) -> "ToolNamerConfig":
@@ -76,6 +79,8 @@ class ToolNamerConfig:
             ollama_url=settings.tool_label_ollama_url,
             timeout_seconds=settings.tool_label_timeout_seconds,
             max_crop_px=settings.tool_label_max_crop_px,
+            openrouter_api_key=settings.openrouter_api_key,
+            openrouter_model=settings.openrouter_label_model,
         )
 
 
@@ -118,6 +123,83 @@ class OllamaToolNamer:
         return parse_label_response(raw)
 
 
+class OpenRouterToolNamer:
+    """Names an isolated tool crop via an OpenRouter vision model.
+
+    Not part of upstream tracefinity -- tool_namer.py only ships an Ollama
+    branch. Reuses the same OPENROUTER_URL/api-key/model settings already
+    used for the gemini contour-labeling path in
+    ai_tracer.py, and the existing per-crop LABEL_PROMPT in this file, which
+    is already scoped to one isolated tool.
+    """
+
+    def __init__(self, config: ToolNamerConfig):
+        self.config = config
+
+    async def name(self, image_png: bytes) -> str | None:
+        import httpx
+
+        if not self.config.openrouter_api_key:
+            logger.warning("tool naming provider=openrouter but no OPENROUTER_API_KEY set")
+            return None
+
+        image_b64 = base64.b64encode(image_png).decode("ascii")
+        data_url = f"data:image/png;base64,{image_b64}"
+        headers = {"Authorization": f"Bearer {self.config.openrouter_api_key}"}
+
+        # openrouter_model may be a comma-separated priority list. Free-tier
+        # (":free") models share a 20 req/min pool per model across all
+        # OpenRouter users -- a popular model can 429 well before any
+        # per-account cap is involved. Retry each model briefly, then fall
+        # through to the next one rather than failing the whole trace.
+        models = [m.strip() for m in self.config.openrouter_model.split(",") if m.strip()]
+        max_attempts_per_model = 2
+
+        async with httpx.AsyncClient(timeout=self.config.timeout_seconds) as client:
+            for model_index, model in enumerate(models):
+                payload = {
+                    "model": model,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": LABEL_PROMPT},
+                                {"type": "image_url", "image_url": {"url": data_url}},
+                            ],
+                        }
+                    ],
+                    "temperature": 0,
+                }
+
+                response = None
+                for attempt in range(max_attempts_per_model):
+                    response = await client.post(OPENROUTER_URL, json=payload, headers=headers)
+                    if response.status_code != 429:
+                        break
+                    if attempt < max_attempts_per_model - 1:
+                        retry_after = response.headers.get("retry-after")
+                        delay = float(retry_after) if retry_after else 2.0 * (attempt + 1)
+                        logger.info(
+                            "openrouter 429 on %s, retrying in %.1fs (attempt %d/%d)",
+                            model, delay, attempt + 1, max_attempts_per_model,
+                        )
+                        await asyncio.sleep(delay)
+
+                if response.status_code == 429:
+                    if model_index < len(models) - 1:
+                        logger.info("openrouter %s exhausted retries, falling back to %s", model, models[model_index + 1])
+                        continue
+                    logger.warning("openrouter 429 on all configured models: %s", models)
+                    return None
+
+                response.raise_for_status()
+                result = response.json()
+                raw = result["choices"][0]["message"]["content"]
+                return parse_label_response(raw)
+
+        return None
+
+
 def create_tool_namer(config: ToolNamerConfig | None = None) -> ToolNamer:
     config = config or ToolNamerConfig.from_settings()
     provider = config.provider.strip().lower()
@@ -125,6 +207,8 @@ def create_tool_namer(config: ToolNamerConfig | None = None) -> ToolNamer:
         return FallbackToolNamer()
     if provider == "ollama":
         return OllamaToolNamer(config)
+    if provider == "openrouter":
+        return OpenRouterToolNamer(config)
 
     logger.warning("unsupported tool naming provider '%s'; using fallback labels", provider)
     return FallbackToolNamer()

--- a/backend/app/services/tool_namer.py
+++ b/backend/app/services/tool_namer.py
@@ -5,7 +5,7 @@ import base64
 import json
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Protocol
 
 import cv2
@@ -13,9 +13,9 @@ import numpy as np
 
 from app.config import settings
 from app.models.schemas import Point, Polygon
-from app.services.ai_tracer import OPENROUTER_URL
 
 logger = logging.getLogger(__name__)
+
 
 LABEL_PROMPT = """Identify the physical tool or object in this image.
 Return only JSON with this shape:
@@ -55,6 +55,10 @@ _BAD_NAME_FRAGMENTS = (
     "contact sheet",
 )
 
+# Per-model retry budget for OpenRouterToolNamer before falling through to
+# the next model in the priority list.
+_OPENROUTER_MAX_ATTEMPTS_PER_MODEL = 2
+
 
 class ToolNamer(Protocol):
     async def name(self, image_png: bytes) -> str | None:
@@ -68,8 +72,8 @@ class ToolNamerConfig:
     ollama_url: str = "http://localhost:11434"
     timeout_seconds: float = 30.0
     max_crop_px: int = 512
-    openrouter_api_key: str | None = field(kw_only=True)
-    openrouter_model: str = field(kw_only=True)
+    openrouter_api_key: str | None = settings.openrouter_api_key
+    openrouter_model: str = settings.openrouter_label_model
 
     @classmethod
     def from_settings(cls) -> "ToolNamerConfig":
@@ -125,12 +129,6 @@ class OllamaToolNamer:
 
 class OpenRouterToolNamer:
     """Names an isolated tool crop via an OpenRouter vision model.
-
-    Not part of upstream tracefinity -- tool_namer.py only ships an Ollama
-    branch. Reuses the same OPENROUTER_URL/api-key/model settings already
-    used for the gemini contour-labeling path in
-    ai_tracer.py, and the existing per-crop LABEL_PROMPT in this file, which
-    is already scoped to one isolated tool.
     """
 
     def __init__(self, config: ToolNamerConfig):
@@ -145,59 +143,67 @@ class OpenRouterToolNamer:
 
         image_b64 = base64.b64encode(image_png).decode("ascii")
         data_url = f"data:image/png;base64,{image_b64}"
-        headers = {"Authorization": f"Bearer {self.config.openrouter_api_key}"}
 
         # openrouter_model may be a comma-separated priority list. Free-tier
         # (":free") models share a 20 req/min pool per model across all
-        # OpenRouter users -- a popular model can 429 well before any
-        # per-account cap is involved. Retry each model briefly, then fall
-        # through to the next one rather than failing the whole trace.
+        # OpenRouter users, so any single model can fail under load that has
+        # nothing to do with this account. Try each model in order and fall
+        # through to the next on any error, not just 429.
         models = [m.strip() for m in self.config.openrouter_model.split(",") if m.strip()]
-        max_attempts_per_model = 2
 
         async with httpx.AsyncClient(timeout=self.config.timeout_seconds) as client:
-            for model_index, model in enumerate(models):
-                payload = {
-                    "model": model,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": LABEL_PROMPT},
-                                {"type": "image_url", "image_url": {"url": data_url}},
-                            ],
-                        }
-                    ],
-                    "temperature": 0,
-                }
+            for model in models:
+                response = await self._post_with_retry(client, model, data_url)
+                if response.status_code >= 400:
+                    logger.info("openrouter %s failed (%d)", model, response.status_code)
+                    continue
 
-                response = None
-                for attempt in range(max_attempts_per_model):
-                    response = await client.post(OPENROUTER_URL, json=payload, headers=headers)
-                    if response.status_code != 429:
-                        break
-                    if attempt < max_attempts_per_model - 1:
-                        retry_after = response.headers.get("retry-after")
-                        delay = float(retry_after) if retry_after else 2.0 * (attempt + 1)
-                        logger.info(
-                            "openrouter 429 on %s, retrying in %.1fs (attempt %d/%d)",
-                            model, delay, attempt + 1, max_attempts_per_model,
-                        )
-                        await asyncio.sleep(delay)
-
-                if response.status_code == 429:
-                    if model_index < len(models) - 1:
-                        logger.info("openrouter %s exhausted retries, falling back to %s", model, models[model_index + 1])
-                        continue
-                    logger.warning("openrouter 429 on all configured models: %s", models)
-                    return None
-
-                response.raise_for_status()
+                # A 200 can still carry no usable content (e.g. reasoning
+                # models may return null content); treat that as "no name".
                 result = response.json()
-                raw = result["choices"][0]["message"]["content"]
+                choices = result.get("choices") or [{}]
+                message = choices[0].get("message") or {}
+                raw = message.get("content")
+                if not raw:
+                    return None
                 return parse_label_response(raw)
 
+        logger.warning("openrouter failed on all configured models: %s", models)
         return None
+
+    async def _post_with_retry(self, client, model: str, data_url: str):
+        """POST one naming request for one model, retrying briefly on 429."""
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": LABEL_PROMPT},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                }
+            ],
+            "temperature": 0,
+        }
+        headers = {"Authorization": f"Bearer {self.config.openrouter_api_key}"}
+
+        for attempt in range(_OPENROUTER_MAX_ATTEMPTS_PER_MODEL):
+            response = await client.post(settings.openrouter_url, json=payload, headers=headers)
+            if response.status_code != 429 or attempt == _OPENROUTER_MAX_ATTEMPTS_PER_MODEL - 1:
+                return response
+
+            # Retry-After is server-controlled; cap it to the namer's own
+            # TOOL_LABEL_TIMEOUT_SECONDS budget so a large value can't stall
+            # the whole trace request. The HTTP-date form isn't a float and
+            # falls back to the default backoff.
+            try:
+                delay = float(response.headers["retry-after"])
+            except (KeyError, ValueError):
+                delay = 2.0 * (attempt + 1)
+            delay = min(delay, self.config.timeout_seconds)
+            logger.info("openrouter 429 on %s, retrying in %.1fs", model, delay)
+            await asyncio.sleep(delay)
 
 
 def create_tool_namer(config: ToolNamerConfig | None = None) -> ToolNamer:

--- a/backend/tests/test_tool_namer.py
+++ b/backend/tests/test_tool_namer.py
@@ -15,6 +15,7 @@ from app.models.schemas import Point, Polygon, Session
 from app.services.tool_namer import (
     FallbackToolNamer,
     OllamaToolNamer,
+    OpenRouterToolNamer,
     ToolNamerConfig,
     create_tool_namer,
     name_polygons,
@@ -62,7 +63,7 @@ def test_disabled_provider_keeps_fallback_labels(tmp_path):
     assert result[0].label == "tool 1"
 
 
-def test_create_tool_namer_supports_only_ollama_and_fallback():
+def test_create_tool_namer_dispatches_by_provider():
     assert isinstance(
         create_tool_namer(ToolNamerConfig(provider="none")),
         FallbackToolNamer,
@@ -72,9 +73,61 @@ def test_create_tool_namer_supports_only_ollama_and_fallback():
         OllamaToolNamer,
     )
     assert isinstance(
+        create_tool_namer(ToolNamerConfig(provider="openrouter")),
+        OpenRouterToolNamer,
+    )
+    assert isinstance(
         create_tool_namer(ToolNamerConfig(provider="unsupported")),
         FallbackToolNamer,
     )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, json_body: dict | None = None, headers: dict | None = None):
+        self.status_code = status_code
+        self._json_body = json_body or {}
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json_body
+
+
+def test_openrouter_namer_falls_through_to_next_model_on_429(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_post(_self, _url, json, headers):
+        calls.append(json["model"])
+        if json["model"] == "model-a":
+            return _FakeResponse(429, headers={"retry-after": "0"})
+        return _FakeResponse(200, {"choices": [{"message": {"content": '{"name":"hacksaw"}'}}]})
+
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+
+    namer = OpenRouterToolNamer(
+        ToolNamerConfig(
+            provider="openrouter",
+            openrouter_api_key="key",
+            openrouter_model="model-a,model-b",
+        )
+    )
+
+    label = asyncio.run(namer.name(b"\x89PNG"))
+
+    assert label == "hacksaw"
+    assert calls == ["model-a", "model-a", "model-b"]
+
+
+def test_openrouter_namer_returns_none_when_content_missing(monkeypatch):
+    async def fake_post(_self, _url, json, headers):
+        return _FakeResponse(200, {"choices": [{"message": {}}]})
+
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+
+    namer = OpenRouterToolNamer(
+        ToolNamerConfig(provider="openrouter", openrouter_api_key="key", openrouter_model="model-a")
+    )
+
+    assert asyncio.run(namer.name(b"\x89PNG")) is None
 
 
 def test_parse_valid_ollama_json_label():

--- a/docs/tool-naming.md
+++ b/docs/tool-naming.md
@@ -17,7 +17,7 @@ TOOL_LABEL_MAX_CROP_PX=512
 
 ## OpenRouter naming
 
-For setups without a local Ollama server (or without GPU headroom to run one), naming can go through OpenRouter's chat completions API instead. Same per-crop flow as Ollama: one cropped image per still-generic polygon, same JSON label parsing and validation, generic label kept on failure.
+For setups without a local Ollama server (or without GPU headroom to run one), naming can go through OpenRouter's chat completions API instead. Same per-crop flow as Ollama: one cropped image per still-generic polygon, same JSON label parsing and validation, generic label kept on failure. As with the remote (`gemini`) tracer, each cropped tool image is sent to OpenRouter's API to be named.
 
 ```bash
 TOOL_LABEL_PROVIDER=openrouter

--- a/docs/tool-naming.md
+++ b/docs/tool-naming.md
@@ -4,7 +4,7 @@ Tracefinity can optionally name traced polygons before you save them to the tool
 
 ## Local Ollama naming
 
-Automatic naming currently supports a local Ollama vision model. It sends one cropped image per still-generic traced polygon to Ollama, validates the returned short JSON name, and keeps the generic `tool N` label when Ollama is unavailable or returns an unusable name.
+Automatic naming supports a local Ollama vision model. It sends one cropped image per still-generic traced polygon to Ollama, validates the returned short JSON name, and keeps the generic `tool N` label when Ollama is unavailable or returns an unusable name.
 
 ```bash
 ollama pull qwen3-vl:4b
@@ -15,15 +15,35 @@ TOOL_LABEL_TIMEOUT_SECONDS=30
 TOOL_LABEL_MAX_CROP_PX=512
 ```
 
+## OpenRouter naming
+
+For setups without a local Ollama server (or without GPU headroom to run one), naming can go through OpenRouter's chat completions API instead. Same per-crop flow as Ollama: one cropped image per still-generic polygon, same JSON label parsing and validation, generic label kept on failure.
+
+```bash
+TOOL_LABEL_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_LABEL_MODEL=google/gemini-2.0-flash-001
+```
+
+`OPENROUTER_LABEL_MODEL` accepts a **comma-separated list** of models, tried in order:
+
+```bash
+OPENROUTER_LABEL_MODEL=google/gemma-4-31b-it:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+```
+
+This is aimed at OpenRouter's free-tier (`:free` suffix) models, which share a 20 req/min pool *per model, across all OpenRouter users* — not a per-account limit. A popular free model can return `429 Too Many Requests` under third-party load that has nothing to do with your own usage. Each model in the list gets a couple of quick retries (honoring `Retry-After` when present) before falling through to the next one, so a congested first choice doesn't fail the whole trace's naming pass. A single model (no comma) works the same as before.
+
 ## Configuration
 
 | Variable | Default | Description |
 |-|-|-|
-| `TOOL_LABEL_PROVIDER` | `none` | Set to `ollama` to enable local automatic naming |
-| `TOOL_LABEL_MODEL` | `qwen3-vl:4b` | Ollama vision model used for naming |
-| `TOOL_LABEL_OLLAMA_URL` | `http://localhost:11434` | Ollama server URL |
-| `TOOL_LABEL_TIMEOUT_SECONDS` | `30` | Timeout for each naming request |
-| `TOOL_LABEL_MAX_CROP_PX` | `512` | Maximum long edge for each isolated tool crop |
+| `TOOL_LABEL_PROVIDER` | `none` | Set to `ollama` or `openrouter` to enable automatic naming |
+| `TOOL_LABEL_MODEL` | `qwen3-vl:4b` | Ollama vision model used for naming (`ollama` provider only) |
+| `TOOL_LABEL_OLLAMA_URL` | `http://localhost:11434` | Ollama server URL (`ollama` provider only) |
+| `TOOL_LABEL_TIMEOUT_SECONDS` | `30` | Timeout for each naming request (both providers) |
+| `TOOL_LABEL_MAX_CROP_PX` | `512` | Maximum long edge for each isolated tool crop (both providers) |
+| `OPENROUTER_API_KEY` | unset | Required for the `openrouter` provider |
+| `OPENROUTER_LABEL_MODEL` | `google/gemini-2.0-flash-001` | Model, or comma-separated fallback list, for the `openrouter` provider |
 
 ## Behavior
 


### PR DESCRIPTION
## Summary

`TOOL_LABEL_PROVIDER` currently only supports `ollama` or off (`create_tool_namer` in `tool_namer.py`). This adds an `openrouter` option for setups that don't want to run a local Ollama server (or don't have GPU headroom for one), reusing the OpenRouter URL/API-key/model settings already present in `app/config.py` and used elsewhere for gemini mask generation.

- New `OpenRouterToolNamer`, wired into `create_tool_namer()` for `provider == "openrouter"`.
- `OPENROUTER_LABEL_MODEL` now accepts a **comma-separated priority list** of models, e.g.:
  ```
  OPENROUTER_LABEL_MODEL=google/gemma-4-31b-it:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
  ```
  Each model gets a couple of quick retries (honoring `Retry-After`) on `HTTP 429` before falling through to the next one in the list. This is aimed at OpenRouter's free-tier (`:free`) models, which share a 20 req/min pool *per model, across all OpenRouter users* — a popular free model can 429 under load that has nothing to do with the caller's own account or credit balance. A single model (no comma) behaves exactly as before.
- Updated `docs/tool-naming.md` and `.env.example` to document the new provider and the fallback-list behavior.

Tested end-to-end against a self-hosted deployment: traced tools with `TOOL_LABEL_PROVIDER=openrouter` and a two-model fallback list, including forcing a 429 on the first model and confirming fallthrough to the second.

## Test plan

- [x] `TOOL_LABEL_PROVIDER=openrouter` + single model names traced tools correctly
- [x] `TOOL_LABEL_PROVIDER=openrouter` + comma-separated model list falls through to the second model on 429
- [x] `TOOL_LABEL_PROVIDER=ollama` still works unaffected (openrouter fields are `kw_only`, always populated by `from_settings()` but unused by `OllamaToolNamer`)
- [ ] `TOOL_LABEL_PROVIDER=none`/unset still falls back to generic `tool N` labels