### PR TITLE
Flag photo problems before tracing

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -69,6 +69,7 @@ from app.services.geometry import optimal_rotation_angle as _optimal_rotation_an
 from app.services.image_ingest import ingest_image
 from app.services.image_processor import ImageProcessor
 from app.services.image_service import generate_tool_thumbnail
+from app.services.photo_checks import check_photo, extract_focal_length_35mm
 from app.services.polygon_scaler import PolygonScaler, ScaledFingerHole, ScaledPolygon
 from app.services.project_service import (
     add_bin_to_project,
@@ -514,6 +515,9 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
     if len(content) > max_bytes:
         raise HTTPException(status_code=413, detail=f"file too large (max {settings.max_upload_mb}MB)")
 
+    # exif is dropped when the image is re-encoded, so read it first
+    focal_length = extract_focal_length_35mm(content)
+
     content, ext, _ = ingest_image(content, ext, MAX_UPLOAD_DIM)
     image_path = up / "uploads" / f"{session_id}{ext}"
     image_path.write_bytes(content)
@@ -526,6 +530,7 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
         created_at=datetime.utcnow().isoformat(),
         original_image_path=_rel(image_path, up),
         corners=corner_points,
+        focal_length_35mm=focal_length,
     ))
 
     return UploadResponse(
@@ -543,6 +548,18 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
         raise HTTPException(status_code=404, detail="session not found")
 
     corners = [(p.x, p.y) for p in req.corners]
+
+    # advisory photo checks run against the original before it is deleted
+    photo_warnings = []
+    try:
+        with Image.open(_abs(session.original_image_path)) as im:
+            img_w, img_h = im.size
+        photo_warnings = check_photo(
+            corners, img_w, img_h, req.paper_size, session.focal_length_35mm
+        )
+    except Exception:
+        logger.exception("photo checks skipped")
+
     output_path, scale_factor = image_processor.apply_perspective_correction(
         _abs(session.original_image_path), corners, req.paper_size
     )
@@ -567,11 +584,13 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
     session.corners = req.corners
     session.paper_size = req.paper_size
     session.scale_factor = scale_factor
+    session.photo_warnings = photo_warnings or None
     user_sessions.set(session_id, session)
 
     return CornersResponse(
         corrected_image_url=f"/storage/{session.corrected_image_path}",
         scale_factor=scale_factor,
+        warnings=photo_warnings,
     )
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -12,6 +12,11 @@ class Point(BaseModel):
     y: float
 
 
+class PhotoWarning(BaseModel):
+    code: str
+    message: str
+
+
 class FingerHole(BaseModel):
     id: str
     x: float  # center position in pixels

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -62,6 +62,7 @@ class CornersRequest(BaseModel):
 class CornersResponse(BaseModel):
     corrected_image_url: str
     scale_factor: float
+    warnings: list[PhotoWarning] = []
 
 
 class TraceRequest(BaseModel):
@@ -225,6 +226,8 @@ class Session(BaseModel):
     corners: list[Point] | None = None
     paper_size: PaperSize | None = None
     scale_factor: float | None = None
+    focal_length_35mm: float | None = None
+    photo_warnings: list[PhotoWarning] | None = None
     polygons: list[Polygon] | None = None
     stl_path: str | None = None
     layout: Layout | None = None

--- a/backend/app/services/photo_checks.py
+++ b/backend/app/services/photo_checks.py
@@ -1,0 +1,167 @@
+"""pre-trace photo quality checks.
+
+flags photo problems that degrade trace accuracy before the user invests in
+tracing and printing. all checks are advisory and degrade to a no-op when
+their inputs are unavailable (e.g. EXIF stripped).
+"""
+from __future__ import annotations
+
+import io
+import logging
+import math
+
+from PIL import ExifTags, Image
+
+from app.constants import PAPER_SIZES, PaperSize
+from app.models.schemas import PhotoWarning
+
+logger = logging.getLogger(__name__)
+
+# 36x24mm full-frame diagonal; FocalLengthIn35mmFilm is defined against it
+FULL_FRAME_DIAG_MM = math.hypot(36.0, 24.0)
+
+# below this height a 15mm-thick tool traces >~3.5% oversized (H/(H-t))
+MIN_CAMERA_HEIGHT_MM = 450.0
+REFERENCE_TOOL_THICKNESS_MM = 15.0
+
+# corners this close to (or beyond) the image edge suggest the paper is cut off
+EDGE_MARGIN_PX = 2.0
+
+# opposite-side length ratio above this indicates a strong keystone
+MAX_OPPOSITE_SIDE_RATIO = 1.35
+
+Corners = list[tuple[float, float]]
+
+
+def extract_focal_length_35mm(content: bytes) -> float | None:
+    """read FocalLengthIn35mmFilm from image bytes; None when absent."""
+    try:
+        img = Image.open(io.BytesIO(content))
+        exif = img.getexif()
+        value = exif.get_ifd(ExifTags.IFD.Exif).get(ExifTags.Base.FocalLengthIn35mmFilm)
+        if value is None:
+            value = exif.get(ExifTags.Base.FocalLengthIn35mmFilm)
+        if value is None:
+            return None
+        focal = float(value)
+        return focal if focal > 0 else None
+    except Exception:
+        return None
+
+
+def estimate_camera_height_mm(
+    corners: Corners,
+    image_w: float,
+    image_h: float,
+    paper_size: PaperSize,
+    focal_length_35mm: float | None,
+) -> float | None:
+    """estimate camera-to-paper distance from the projected paper diagonal.
+
+    pinhole model against the 35mm-equivalent frame: the image diagonal maps
+    to the full-frame diagonal, so the paper's pixel diagonal gives its size
+    on the virtual sensor and D = f35 * real / projected.
+    """
+    if not focal_length_35mm or focal_length_35mm <= 0 or len(corners) != 4:
+        return None
+    tl, tr, br, bl = corners
+    paper_diag_px = (math.dist(tl, br) + math.dist(tr, bl)) / 2
+    image_diag_px = math.hypot(image_w, image_h)
+    if paper_diag_px < 1.0 or image_diag_px <= 0:
+        return None
+    paper_w_mm, paper_h_mm = PAPER_SIZES[paper_size]
+    paper_diag_mm = math.hypot(paper_w_mm, paper_h_mm)
+    sensor_diag_mm = paper_diag_px * FULL_FRAME_DIAG_MM / image_diag_px
+    return focal_length_35mm * paper_diag_mm / sensor_diag_mm
+
+
+def _check_camera_height(
+    corners: Corners,
+    image_w: float,
+    image_h: float,
+    paper_size: PaperSize,
+    focal_length_35mm: float | None,
+) -> PhotoWarning | None:
+    height = estimate_camera_height_mm(corners, image_w, image_h, paper_size, focal_length_35mm)
+    if height is None or height >= MIN_CAMERA_HEIGHT_MM:
+        return None
+    height_cm = round(height / 10)
+    if height > REFERENCE_TOOL_THICKNESS_MM * 2:
+        oversize_pct = (height / (height - REFERENCE_TOOL_THICKNESS_MM) - 1) * 100
+        detail = f"a 15 mm-thick tool would trace roughly {oversize_pct:.1f}% oversized"
+    else:
+        detail = "thick tools will trace well oversized"
+    return PhotoWarning(
+        code="camera_too_close",
+        message=(
+            f"Camera looks about {height_cm} cm from the paper; {detail}. "
+            "Retake from 60 cm or higher for best accuracy."
+        ),
+    )
+
+
+def _check_paper_in_frame(corners: Corners, image_w: float, image_h: float) -> PhotoWarning | None:
+    for x, y in corners:
+        if (
+            x <= EDGE_MARGIN_PX
+            or y <= EDGE_MARGIN_PX
+            or x >= image_w - EDGE_MARGIN_PX
+            or y >= image_h - EDGE_MARGIN_PX
+        ):
+            return PhotoWarning(
+                code="paper_out_of_frame",
+                message=(
+                    "The paper looks cut off at the photo edge. Keep all four "
+                    "corners inside the frame or scale accuracy may suffer."
+                ),
+            )
+    return None
+
+
+def _check_perspective(corners: Corners) -> PhotoWarning | None:
+    if len(corners) != 4:
+        return None
+    tl, tr, br, bl = corners
+    top = math.dist(tl, tr)
+    bottom = math.dist(bl, br)
+    left = math.dist(tl, bl)
+    right = math.dist(tr, br)
+    if min(top, bottom, left, right) < 1.0:
+        return None
+    ratio = max(
+        max(top, bottom) / min(top, bottom),
+        max(left, right) / min(left, right),
+    )
+    if ratio <= MAX_OPPOSITE_SIDE_RATIO:
+        return None
+    return PhotoWarning(
+        code="extreme_perspective",
+        message=(
+            "Strong camera angle detected. Shoot from directly above the "
+            "paper for the most accurate outlines."
+        ),
+    )
+
+
+def check_photo(
+    corners: Corners,
+    image_w: float,
+    image_h: float,
+    paper_size: PaperSize,
+    focal_length_35mm: float | None,
+) -> list[PhotoWarning]:
+    """run all photo checks; each degrades to a no-op if it cannot run."""
+    warnings: list[PhotoWarning] = []
+    for check in (
+        lambda: _check_camera_height(corners, image_w, image_h, paper_size, focal_length_35mm),
+        lambda: _check_paper_in_frame(corners, image_w, image_h),
+        lambda: _check_perspective(corners),
+    ):
+        try:
+            warning = check()
+        except Exception:
+            logger.exception("photo check failed")
+            continue
+        if warning:
+            warnings.append(warning)
+    return warnings

--- a/backend/app/services/photo_checks.py
+++ b/backend/app/services/photo_checks.py
@@ -44,7 +44,8 @@ def extract_focal_length_35mm(content: bytes) -> float | None:
         if value is None:
             return None
         focal = float(value)
-        return focal if focal > 0 else None
+        # crafted exif can yield inf/nan; keep those out of sessions.json
+        return focal if math.isfinite(focal) and focal > 0 else None
     except Exception:
         return None
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,30 @@
 from __future__ import annotations
 
+import math
 import os
 
 os.environ.setdefault("DEVELOPMENT_MODE", "1")
+
+from app.services.photo_checks import FULL_FRAME_DIAG_MM  # noqa: E402
+
+A4_DIAG_MM = math.hypot(210, 297)
+
+
+def rect_corners(cx: float, cy: float, w: float, h: float) -> list[tuple[float, float]]:
+    """axis-aligned rect as TL, TR, BR, BL."""
+    return [
+        (cx - w / 2, cy - h / 2),
+        (cx + w / 2, cy - h / 2),
+        (cx + w / 2, cy + h / 2),
+        (cx - w / 2, cy + h / 2),
+    ]
+
+
+def corners_for_height(height_mm: float, f35: float, img_w: int, img_h: int) -> list[tuple[float, float]]:
+    """synthesise an A4 paper quad whose projected size implies height_mm."""
+    img_diag = math.hypot(img_w, img_h)
+    sensor_diag_mm = f35 * A4_DIAG_MM / height_mm
+    paper_diag_px = sensor_diag_mm * img_diag / FULL_FRAME_DIAG_MM
+    w = paper_diag_px * 210 / A4_DIAG_MM
+    h = paper_diag_px * 297 / A4_DIAG_MM
+    return rect_corners(img_w / 2, img_h / 2, w, h)

--- a/backend/tests/test_photo_checks.py
+++ b/backend/tests/test_photo_checks.py
@@ -1,0 +1,135 @@
+"""Unit tests for pre-trace photo quality checks."""
+
+import io
+import math
+
+import pytest
+from PIL import ExifTags, Image
+
+from app.services.photo_checks import (
+    FULL_FRAME_DIAG_MM,
+    MIN_CAMERA_HEIGHT_MM,
+    check_photo,
+    estimate_camera_height_mm,
+    extract_focal_length_35mm,
+)
+
+A4_DIAG_MM = math.hypot(210, 297)
+
+
+def _rect_corners(cx: float, cy: float, w: float, h: float) -> list[tuple[float, float]]:
+    """axis-aligned rect as TL, TR, BR, BL."""
+    return [
+        (cx - w / 2, cy - h / 2),
+        (cx + w / 2, cy - h / 2),
+        (cx + w / 2, cy + h / 2),
+        (cx - w / 2, cy + h / 2),
+    ]
+
+
+def _corners_for_height(height_mm: float, f35: float, img_w: int, img_h: int) -> list[tuple[float, float]]:
+    """synthesise an A4 paper quad whose projected size implies height_mm."""
+    img_diag = math.hypot(img_w, img_h)
+    sensor_diag_mm = f35 * A4_DIAG_MM / height_mm
+    paper_diag_px = sensor_diag_mm * img_diag / FULL_FRAME_DIAG_MM
+    w = paper_diag_px * 210 / A4_DIAG_MM
+    h = paper_diag_px * 297 / A4_DIAG_MM
+    return _rect_corners(img_w / 2, img_h / 2, w, h)
+
+
+class TestEstimateCameraHeight:
+    def test_recovers_known_height(self):
+        corners = _corners_for_height(500.0, 26.0, 4000, 3000)
+        est = estimate_camera_height_mm(corners, 4000, 3000, "a4", 26.0)
+        assert est == pytest.approx(500.0, rel=0.01)
+
+    def test_none_without_focal_length(self):
+        corners = _corners_for_height(500.0, 26.0, 4000, 3000)
+        assert estimate_camera_height_mm(corners, 4000, 3000, "a4", None) is None
+
+    def test_none_for_degenerate_quad(self):
+        corners = [(100.0, 100.0)] * 4
+        assert estimate_camera_height_mm(corners, 4000, 3000, "a4", 26.0) is None
+
+
+class TestCheckPhoto:
+    def test_warns_when_camera_too_close(self):
+        corners = _corners_for_height(250.0, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
+        codes = [w.code for w in warnings]
+        assert "camera_too_close" in codes
+        msg = next(w.message for w in warnings if w.code == "camera_too_close")
+        # 250/(250-15) - 1 = ~6.4% oversize for a 15mm tool
+        assert "6.4" in msg
+        assert "25 cm" in msg
+
+    def test_no_camera_warning_at_comfortable_height(self):
+        corners = _corners_for_height(600.0, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
+        assert "camera_too_close" not in [w.code for w in warnings]
+
+    def test_no_camera_warning_without_exif(self):
+        corners = _corners_for_height(250.0, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", None)
+        assert "camera_too_close" not in [w.code for w in warnings]
+
+    def test_warns_when_paper_touches_edge(self):
+        corners = [(0.0, 500.0), (1500.0, 480.0), (1520.0, 1600.0), (30.0, 1620.0)]
+        warnings = check_photo(corners, 2048, 1536, "a4", None)
+        assert "paper_out_of_frame" in [w.code for w in warnings]
+
+    def test_warns_when_corner_beyond_edge(self):
+        corners = [(-10.0, 500.0), (1500.0, 480.0), (1520.0, 1600.0), (30.0, 1620.0)]
+        warnings = check_photo(corners, 2048, 1536, "a4", None)
+        assert "paper_out_of_frame" in [w.code for w in warnings]
+
+    def test_no_edge_warning_for_interior_paper(self):
+        corners = _rect_corners(1024, 768, 1200, 900)
+        warnings = check_photo(corners, 2048, 1536, "a4", None)
+        assert "paper_out_of_frame" not in [w.code for w in warnings]
+
+    def test_warns_on_extreme_keystone(self):
+        # top edge half the length of the bottom edge
+        corners = [(700.0, 200.0), (1300.0, 200.0), (1700.0, 1300.0), (500.0, 1300.0)]
+        warnings = check_photo(corners, 2048, 1536, "a4", None)
+        assert "extreme_perspective" in [w.code for w in warnings]
+
+    def test_no_keystone_warning_for_mild_angle(self):
+        corners = [(590.0, 200.0), (1450.0, 210.0), (1500.0, 1300.0), (540.0, 1310.0)]
+        warnings = check_photo(corners, 2048, 1536, "a4", None)
+        assert "extreme_perspective" not in [w.code for w in warnings]
+
+    def test_threshold_is_sane(self):
+        # a 15mm tool at the threshold height should be within ~3.5% oversize
+        factor = MIN_CAMERA_HEIGHT_MM / (MIN_CAMERA_HEIGHT_MM - 15.0)
+        assert factor < 1.036
+
+
+class TestExtractFocalLength:
+    def _jpeg_with_exif(self, exif: Image.Exif | None) -> bytes:
+        img = Image.new("RGB", (64, 48), "white")
+        buf = io.BytesIO()
+        if exif is not None:
+            img.save(buf, format="JPEG", exif=exif)
+        else:
+            img.save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def test_reads_focal_length_from_exif_ifd(self):
+        exif = Image.Exif()
+        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = 26
+        content = self._jpeg_with_exif(exif)
+        assert extract_focal_length_35mm(content) == pytest.approx(26.0)
+
+    def test_none_when_exif_stripped(self):
+        content = self._jpeg_with_exif(None)
+        assert extract_focal_length_35mm(content) is None
+
+    def test_none_for_zero_focal_length(self):
+        exif = Image.Exif()
+        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = 0
+        content = self._jpeg_with_exif(exif)
+        assert extract_focal_length_35mm(content) is None
+
+    def test_none_for_garbage_bytes(self):
+        assert extract_focal_length_35mm(b"not an image") is None

--- a/backend/tests/test_photo_checks.py
+++ b/backend/tests/test_photo_checks.py
@@ -1,50 +1,28 @@
 """Unit tests for pre-trace photo quality checks."""
 
 import io
-import math
 
 import pytest
 from PIL import ExifTags, Image
 
+import app.services.photo_checks as photo_checks
 from app.services.photo_checks import (
-    FULL_FRAME_DIAG_MM,
     MIN_CAMERA_HEIGHT_MM,
     check_photo,
     estimate_camera_height_mm,
     extract_focal_length_35mm,
 )
-
-A4_DIAG_MM = math.hypot(210, 297)
-
-
-def _rect_corners(cx: float, cy: float, w: float, h: float) -> list[tuple[float, float]]:
-    """axis-aligned rect as TL, TR, BR, BL."""
-    return [
-        (cx - w / 2, cy - h / 2),
-        (cx + w / 2, cy - h / 2),
-        (cx + w / 2, cy + h / 2),
-        (cx - w / 2, cy + h / 2),
-    ]
-
-
-def _corners_for_height(height_mm: float, f35: float, img_w: int, img_h: int) -> list[tuple[float, float]]:
-    """synthesise an A4 paper quad whose projected size implies height_mm."""
-    img_diag = math.hypot(img_w, img_h)
-    sensor_diag_mm = f35 * A4_DIAG_MM / height_mm
-    paper_diag_px = sensor_diag_mm * img_diag / FULL_FRAME_DIAG_MM
-    w = paper_diag_px * 210 / A4_DIAG_MM
-    h = paper_diag_px * 297 / A4_DIAG_MM
-    return _rect_corners(img_w / 2, img_h / 2, w, h)
+from tests.conftest import corners_for_height, rect_corners
 
 
 class TestEstimateCameraHeight:
     def test_recovers_known_height(self):
-        corners = _corners_for_height(500.0, 26.0, 4000, 3000)
+        corners = corners_for_height(500.0, 26.0, 4000, 3000)
         est = estimate_camera_height_mm(corners, 4000, 3000, "a4", 26.0)
         assert est == pytest.approx(500.0, rel=0.01)
 
     def test_none_without_focal_length(self):
-        corners = _corners_for_height(500.0, 26.0, 4000, 3000)
+        corners = corners_for_height(500.0, 26.0, 4000, 3000)
         assert estimate_camera_height_mm(corners, 4000, 3000, "a4", None) is None
 
     def test_none_for_degenerate_quad(self):
@@ -54,7 +32,7 @@ class TestEstimateCameraHeight:
 
 class TestCheckPhoto:
     def test_warns_when_camera_too_close(self):
-        corners = _corners_for_height(250.0, 26.0, 4000, 3000)
+        corners = corners_for_height(250.0, 26.0, 4000, 3000)
         warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
         codes = [w.code for w in warnings]
         assert "camera_too_close" in codes
@@ -64,12 +42,22 @@ class TestCheckPhoto:
         assert "25 cm" in msg
 
     def test_no_camera_warning_at_comfortable_height(self):
-        corners = _corners_for_height(600.0, 26.0, 4000, 3000)
+        corners = corners_for_height(600.0, 26.0, 4000, 3000)
         warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
         assert "camera_too_close" not in [w.code for w in warnings]
 
+    def test_no_camera_warning_at_threshold_height(self):
+        corners = corners_for_height(MIN_CAMERA_HEIGHT_MM, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
+        assert "camera_too_close" not in [w.code for w in warnings]
+
+    def test_camera_warning_just_below_threshold(self):
+        corners = corners_for_height(MIN_CAMERA_HEIGHT_MM - 1.0, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
+        assert "camera_too_close" in [w.code for w in warnings]
+
     def test_no_camera_warning_without_exif(self):
-        corners = _corners_for_height(250.0, 26.0, 4000, 3000)
+        corners = corners_for_height(250.0, 26.0, 4000, 3000)
         warnings = check_photo(corners, 4000, 3000, "a4", None)
         assert "camera_too_close" not in [w.code for w in warnings]
 
@@ -84,7 +72,7 @@ class TestCheckPhoto:
         assert "paper_out_of_frame" in [w.code for w in warnings]
 
     def test_no_edge_warning_for_interior_paper(self):
-        corners = _rect_corners(1024, 768, 1200, 900)
+        corners = rect_corners(1024, 768, 1200, 900)
         warnings = check_photo(corners, 2048, 1536, "a4", None)
         assert "paper_out_of_frame" not in [w.code for w in warnings]
 
@@ -99,10 +87,18 @@ class TestCheckPhoto:
         warnings = check_photo(corners, 2048, 1536, "a4", None)
         assert "extreme_perspective" not in [w.code for w in warnings]
 
-    def test_threshold_is_sane(self):
-        # a 15mm tool at the threshold height should be within ~3.5% oversize
-        factor = MIN_CAMERA_HEIGHT_MM / (MIN_CAMERA_HEIGHT_MM - 15.0)
-        assert factor < 1.036
+    def test_degenerate_quad_produces_no_warnings(self):
+        warnings = check_photo([(100.0, 100.0)] * 4, 4000, 3000, "a4", 26.0)
+        assert warnings == []
+
+    def test_failing_check_does_not_break_others(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(photo_checks, "_check_paper_in_frame", boom)
+        corners = corners_for_height(250.0, 26.0, 4000, 3000)
+        warnings = check_photo(corners, 4000, 3000, "a4", 26.0)
+        assert "camera_too_close" in [w.code for w in warnings]
 
 
 class TestExtractFocalLength:
@@ -115,10 +111,13 @@ class TestExtractFocalLength:
             img.save(buf, format="JPEG")
         return buf.getvalue()
 
-    def test_reads_focal_length_from_exif_ifd(self):
+    def _jpeg_with_focal(self, value) -> bytes:
         exif = Image.Exif()
-        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = 26
-        content = self._jpeg_with_exif(exif)
+        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = value
+        return self._jpeg_with_exif(exif)
+
+    def test_reads_focal_length_from_exif_ifd(self):
+        content = self._jpeg_with_focal(26)
         assert extract_focal_length_35mm(content) == pytest.approx(26.0)
 
     def test_none_when_exif_stripped(self):
@@ -126,10 +125,17 @@ class TestExtractFocalLength:
         assert extract_focal_length_35mm(content) is None
 
     def test_none_for_zero_focal_length(self):
-        exif = Image.Exif()
-        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = 0
-        content = self._jpeg_with_exif(exif)
-        assert extract_focal_length_35mm(content) is None
+        assert extract_focal_length_35mm(self._jpeg_with_focal(0)) is None
+
+    def test_none_for_negative_focal_length(self):
+        assert extract_focal_length_35mm(self._jpeg_with_focal(-26)) is None
+
+    def test_none_for_infinite_focal_length(self):
+        # inf round-trips through exif and would break session reads if stored
+        assert extract_focal_length_35mm(self._jpeg_with_focal(float("inf"))) is None
+
+    def test_none_for_nan_focal_length(self):
+        assert extract_focal_length_35mm(self._jpeg_with_focal(float("nan"))) is None
 
     def test_none_for_garbage_bytes(self):
         assert extract_focal_length_35mm(b"not an image") is None

--- a/backend/tests/test_routes_photo_warnings.py
+++ b/backend/tests/test_routes_photo_warnings.py
@@ -1,7 +1,6 @@
 """Route-level tests for photo warnings on upload and corner correction."""
 
 import io
-import math
 
 from fastapi.testclient import TestClient
 from PIL import ExifTags, Image
@@ -10,9 +9,7 @@ import app.api.routes as routes
 from app.config import ensure_user_dirs
 from app.main import app
 from app.models.schemas import Session
-from app.services.photo_checks import FULL_FRAME_DIAG_MM
-
-A4_DIAG_MM = math.hypot(210, 297)
+from tests.conftest import corners_for_height
 
 
 def _client(tmp_path, monkeypatch):
@@ -20,21 +17,6 @@ def _client(tmp_path, monkeypatch):
     routes._store_cache.clear()
     ensure_user_dirs(tmp_path / "default")
     return TestClient(app)
-
-
-def _corners_for_height(height_mm: float, f35: float, img_w: int, img_h: int) -> list[tuple[float, float]]:
-    img_diag = math.hypot(img_w, img_h)
-    sensor_diag_mm = f35 * A4_DIAG_MM / height_mm
-    diag_px = sensor_diag_mm * img_diag / FULL_FRAME_DIAG_MM
-    w = diag_px * 210 / A4_DIAG_MM
-    h = diag_px * 297 / A4_DIAG_MM
-    cx, cy = img_w / 2, img_h / 2
-    return [
-        (cx - w / 2, cy - h / 2),
-        (cx + w / 2, cy - h / 2),
-        (cx + w / 2, cy + h / 2),
-        (cx - w / 2, cy + h / 2),
-    ]
 
 
 def _jpeg_bytes(w: int, h: int, f35: float | None) -> bytes:
@@ -112,7 +94,7 @@ def _seed_session_with_upload(tmp_path, monkeypatch, f35):
 
 def test_corners_returns_and_persists_warnings(tmp_path, monkeypatch):
     client, sessions = _seed_session_with_upload(tmp_path, monkeypatch, f35=26.0)
-    corners = _corners_for_height(250.0, 26.0, 800, 600)
+    corners = corners_for_height(250.0, 26.0, 800, 600)
 
     resp = client.post(
         "/api/sessions/s1/corners",
@@ -129,7 +111,7 @@ def test_corners_returns_and_persists_warnings(tmp_path, monkeypatch):
 
 def test_corners_without_focal_length_is_graceful(tmp_path, monkeypatch):
     client, sessions = _seed_session_with_upload(tmp_path, monkeypatch, f35=None)
-    corners = _corners_for_height(250.0, 26.0, 800, 600)
+    corners = corners_for_height(250.0, 26.0, 800, 600)
 
     resp = client.post(
         "/api/sessions/s1/corners",
@@ -140,3 +122,25 @@ def test_corners_without_focal_length_is_graceful(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert "camera_too_close" not in [w["code"] for w in resp.json()["warnings"]]
+
+
+def test_corners_succeeds_when_photo_checks_raise(tmp_path, monkeypatch):
+    """a broken check must not fail perspective correction."""
+    client, sessions = _seed_session_with_upload(tmp_path, monkeypatch, f35=26.0)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(routes, "check_photo", boom)
+    corners = corners_for_height(250.0, 26.0, 800, 600)
+
+    resp = client.post(
+        "/api/sessions/s1/corners",
+        json={
+            "corners": [{"x": x, "y": y} for x, y in corners],
+            "paper_size": "a4",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["warnings"] == []
+    assert sessions.get("s1").photo_warnings is None

--- a/backend/tests/test_routes_photo_warnings.py
+++ b/backend/tests/test_routes_photo_warnings.py
@@ -1,0 +1,142 @@
+"""Route-level tests for photo warnings on upload and corner correction."""
+
+import io
+import math
+
+from fastapi.testclient import TestClient
+from PIL import ExifTags, Image
+
+import app.api.routes as routes
+from app.config import ensure_user_dirs
+from app.main import app
+from app.models.schemas import Session
+from app.services.photo_checks import FULL_FRAME_DIAG_MM
+
+A4_DIAG_MM = math.hypot(210, 297)
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def _corners_for_height(height_mm: float, f35: float, img_w: int, img_h: int) -> list[tuple[float, float]]:
+    img_diag = math.hypot(img_w, img_h)
+    sensor_diag_mm = f35 * A4_DIAG_MM / height_mm
+    diag_px = sensor_diag_mm * img_diag / FULL_FRAME_DIAG_MM
+    w = diag_px * 210 / A4_DIAG_MM
+    h = diag_px * 297 / A4_DIAG_MM
+    cx, cy = img_w / 2, img_h / 2
+    return [
+        (cx - w / 2, cy - h / 2),
+        (cx + w / 2, cy - h / 2),
+        (cx + w / 2, cy + h / 2),
+        (cx - w / 2, cy + h / 2),
+    ]
+
+
+def _jpeg_bytes(w: int, h: int, f35: float | None) -> bytes:
+    img = Image.new("RGB", (w, h), "white")
+    buf = io.BytesIO()
+    if f35 is not None:
+        exif = Image.Exif()
+        exif.get_ifd(ExifTags.IFD.Exif)[ExifTags.Base.FocalLengthIn35mmFilm] = int(f35)
+        img.save(buf, format="JPEG", exif=exif)
+    else:
+        img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def test_upload_stores_focal_length_from_exif(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        routes.image_processor, "detect_paper_corners", lambda path: None
+    )
+
+    resp = client.post(
+        "/api/upload",
+        files={"image": ("photo.jpg", _jpeg_bytes(800, 600, 26.0), "image/jpeg")},
+    )
+    assert resp.status_code == 200
+    sessions, _, _ = routes.get_stores("default")
+    assert sessions.get(resp.json()["session_id"]).focal_length_35mm == 26.0
+
+
+def test_upload_without_exif_stores_no_focal_length(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        routes.image_processor, "detect_paper_corners", lambda path: None
+    )
+
+    resp = client.post(
+        "/api/upload",
+        files={"image": ("photo.jpg", _jpeg_bytes(800, 600, None), "image/jpeg")},
+    )
+    assert resp.status_code == 200
+    sessions, _, _ = routes.get_stores("default")
+    assert sessions.get(resp.json()["session_id"]).focal_length_35mm is None
+
+
+def test_upload_focal_length_survives_downscale(tmp_path, monkeypatch):
+    """exif is stripped when the image is re-encoded; extraction must happen first."""
+    client = _client(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        routes.image_processor, "detect_paper_corners", lambda path: None
+    )
+    monkeypatch.setattr(routes, "MAX_UPLOAD_DIM", 400)
+
+    resp = client.post(
+        "/api/upload",
+        files={"image": ("photo.jpg", _jpeg_bytes(800, 600, 26.0), "image/jpeg")},
+    )
+    assert resp.status_code == 200
+    sessions, _, _ = routes.get_stores("default")
+    assert sessions.get(resp.json()["session_id"]).focal_length_35mm == 26.0
+
+
+def _seed_session_with_upload(tmp_path, monkeypatch, f35):
+    client = _client(tmp_path, monkeypatch)
+    uploads = tmp_path / "default" / "uploads"
+    uploads.mkdir(parents=True, exist_ok=True)
+    (uploads / "s1.jpg").write_bytes(_jpeg_bytes(800, 600, None))
+    sessions, _, _ = routes.get_stores("default")
+    sessions.set("s1", Session(
+        id="s1",
+        original_image_path="default/uploads/s1.jpg",
+        focal_length_35mm=f35,
+    ))
+    return client, sessions
+
+
+def test_corners_returns_and_persists_warnings(tmp_path, monkeypatch):
+    client, sessions = _seed_session_with_upload(tmp_path, monkeypatch, f35=26.0)
+    corners = _corners_for_height(250.0, 26.0, 800, 600)
+
+    resp = client.post(
+        "/api/sessions/s1/corners",
+        json={
+            "corners": [{"x": x, "y": y} for x, y in corners],
+            "paper_size": "a4",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "camera_too_close" in [w["code"] for w in body["warnings"]]
+    assert "camera_too_close" in [w.code for w in sessions.get("s1").photo_warnings]
+
+
+def test_corners_without_focal_length_is_graceful(tmp_path, monkeypatch):
+    client, sessions = _seed_session_with_upload(tmp_path, monkeypatch, f35=None)
+    corners = _corners_for_height(250.0, 26.0, 800, 600)
+
+    resp = client.post(
+        "/api/sessions/s1/corners",
+        json={
+            "corners": [{"x": x, "y": y} for x, y in corners],
+            "paper_size": "a4",
+        },
+    )
+    assert resp.status_code == 200
+    assert "camera_too_close" not in [w["code"] for w in resp.json()["warnings"]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 ## Sessions (trace workflow)
 - `POST /api/upload` - upload image, auto-detect corners
-- `POST /api/sessions/{id}/corners` - set corners, apply perspective correction
+- `POST /api/sessions/{id}/corners` - set corners, apply perspective correction; returns advisory photo warnings (camera too close, paper cut off, extreme perspective)
 - `POST /api/sessions/{id}/trace` - AI trace tool outlines
 - `POST /api/sessions/{id}/trace-mask` - trace from uploaded mask
 - `PUT /api/sessions/{id}/polygons` - save polygon edits

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,6 +7,7 @@ Reference for AI agents. Check here before suggesting new features or claiming s
 - Image upload (drag-drop or file picker, JPG/PNG/WebP/HEIC)
 - Paper corner detection with draggable handles
 - Paper size presets (A4, Letter, A3, Tabloid)
+- Photo quality warnings before tracing (camera too close via EXIF focal length, paper cut off at the frame edge, extreme perspective)
 - AI tracing (multiple tracer backends: IS-Net, BiRefNet, InSPyReNet)
 - Remote tracing via Replicate (`REPLICATE_API_TOKEN`, model `men1scus/birefnet` by default; `REPLICATE_RESOLUTION` optional)
 - Remote tracing via fal.ai (`FAL_KEY`, model `fal-ai/birefnet/v2` by default; `FAL_OPERATING_RESOLUTION` default `1024x1024`). Uses `sync_mode` so results are not stored in fal request history; Replicate predictions auto-purge after ~1h.

--- a/docs/usage/uploading-photos.md
+++ b/docs/usage/uploading-photos.md
@@ -14,6 +14,16 @@ The paper is for scale only. Tools can overflow the paper edges. The full visibl
 - **No overlap** -- leave a small gap between tools so the AI can separate them.
 - **Shoot from above** -- aim for directly overhead. Perspective correction handles some angle, but straight-down gives the most accurate scale.
 
+## Photo warnings
+
+After you confirm the paper corners, Tracefinity checks the photo and flags problems that reduce trace accuracy:
+
+- **Camera too close** -- estimated from the photo's EXIF data. Close shots exaggerate outlines of thick tools (a 15 mm-thick tool shot from 25 cm traces roughly 6% oversized). Shoot from 60 cm or higher. Skipped when the photo has no EXIF data (e.g. screenshots or edited images).
+- **Paper cut off** -- a paper corner sits at or beyond the photo edge.
+- **Extreme perspective** -- a strong camera angle degrades edge accuracy even after correction.
+
+Warnings are advisory: you can dismiss them and continue, but retaking the photo gives better results.
+
 ## Supported formats
 
 JPG, PNG, WebP, and HEIC. There is no hard file size limit, but large photos take longer to upload and process.

--- a/frontend/src/app/trace/[id]/page.tsx
+++ b/frontend/src/app/trace/[id]/page.tsx
@@ -10,8 +10,9 @@ import { SessionInfo } from '@/components/SessionInfo'
 import { Alert } from '@/components/Alert'
 import { getSession, setCorners, traceTools, updatePolygons, updateSession, getImageUrl, getAvailableKeys, traceFromMask, saveToolsFromSession } from '@/lib/api'
 import { CornersHint, TraceHint, EditHint } from '@/components/OnboardingIllustrations'
+import { PhotoWarningsBanner } from '@/components/PhotoWarningsBanner'
 import { StepBar } from '@/components/StepBar'
-import type { PaperSize, Point, Polygon, Session } from '@/types'
+import type { PaperSize, PhotoWarning, Point, Polygon, Session } from '@/types'
 
 type Step = 'corners' | 'trace' | 'edit'
 
@@ -63,6 +64,8 @@ export default function TracePage() {
   const [imageUrl, setImageUrl] = useState<string>('')
   const [correctedImageUrl, setCorrectedImageUrl] = useState<string>('')
   const [polygons, setPolygons] = useState<Polygon[]>([])
+  const [photoWarnings, setPhotoWarnings] = useState<PhotoWarning[]>([])
+  const [warningsDismissed, setWarningsDismissed] = useState(false)
 
   const [provider, setProvider] = useState<'google' | 'manual'>('google')
   const [apiKey, setApiKey] = useState('')
@@ -123,6 +126,9 @@ export default function TracePage() {
         if (s.corrected_image_path) {
           setCorrectedImageUrl(`/storage/${s.corrected_image_path}`)
         }
+        if (s.photo_warnings?.length) {
+          setPhotoWarnings(s.photo_warnings)
+        }
         if (s.mask_image_path) {
           const maskRel = s.mask_image_path.replace(/^storage\//, '')
           setMaskUrl(`/storage/${maskRel}`)
@@ -167,6 +173,8 @@ export default function TracePage() {
       const result = await setCorners(sessionId, corners, paperSize)
       setCorrectedImageUrl(result.corrected_image_url)
       setImageVersion(Date.now())
+      setPhotoWarnings(result.warnings ?? [])
+      setWarningsDismissed(false)
 
       if (singleTracer && tracers.length === 1) {
         // single tracer: trace immediately without changing step
@@ -646,6 +654,13 @@ export default function TracePage() {
                 className="w-full rounded-lg border border-border-subtle"
               />
             </div>
+          )}
+
+          {!warningsDismissed && (
+            <PhotoWarningsBanner
+              warnings={photoWarnings}
+              onDismiss={() => setWarningsDismissed(true)}
+            />
           )}
 
           {error && <Alert variant="error">{error}</Alert>}

--- a/frontend/src/components/PhotoWarningsBanner.test.tsx
+++ b/frontend/src/components/PhotoWarningsBanner.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { PhotoWarningsBanner, PHOTO_GUIDE_URL } from './PhotoWarningsBanner'
+
+// jsdom has no matchMedia; useTheme needs it during init
+window.matchMedia = vi.fn().mockReturnValue({
+  matches: false,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+}) as unknown as typeof window.matchMedia
+
+const warnings = [
+  { code: 'camera_too_close', message: 'Camera looks about 25 cm from the paper.' },
+  { code: 'paper_out_of_frame', message: 'The paper looks cut off at the photo edge.' },
+]
+
+describe('PhotoWarningsBanner', () => {
+  afterEach(cleanup)
+
+  it('renders every warning message', () => {
+    render(<PhotoWarningsBanner warnings={warnings} onDismiss={() => {}} />)
+
+    expect(screen.getByText(/25 cm from the paper/)).toBeTruthy()
+    expect(screen.getByText(/cut off at the photo edge/)).toBeTruthy()
+  })
+
+  it('links to the photo guide', () => {
+    render(<PhotoWarningsBanner warnings={warnings} onDismiss={() => {}} />)
+
+    const link = screen.getByRole('link', { name: /photo guide/i })
+    expect(link.getAttribute('href')).toBe(PHOTO_GUIDE_URL)
+  })
+
+  it('calls onDismiss when dismissed', () => {
+    const onDismiss = vi.fn()
+    render(<PhotoWarningsBanner warnings={warnings} onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('renders nothing without warnings', () => {
+    const { container } = render(<PhotoWarningsBanner warnings={[]} onDismiss={() => {}} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/frontend/src/components/PhotoWarningsBanner.tsx
+++ b/frontend/src/components/PhotoWarningsBanner.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Alert } from '@/components/Alert'
+import { DOCS_BASE_URL } from '@/lib/constants'
 import type { PhotoWarning } from '@/types'
 
-export const PHOTO_GUIDE_URL =
-  'https://github.com/tracefinity/tracefinity/blob/main/docs/usage/uploading-photos.md'
+export const PHOTO_GUIDE_URL = `${DOCS_BASE_URL}/usage/uploading-photos.md`
 
 interface Props {
   warnings: PhotoWarning[]

--- a/frontend/src/components/PhotoWarningsBanner.tsx
+++ b/frontend/src/components/PhotoWarningsBanner.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Alert } from '@/components/Alert'
+import type { PhotoWarning } from '@/types'
+
+export const PHOTO_GUIDE_URL =
+  'https://github.com/tracefinity/tracefinity/blob/main/docs/usage/uploading-photos.md'
+
+interface Props {
+  warnings: PhotoWarning[]
+  onDismiss: () => void
+}
+
+export function PhotoWarningsBanner({ warnings, onDismiss }: Props) {
+  if (warnings.length === 0) return null
+
+  return (
+    <Alert variant="warning">
+      <div className="space-y-1.5">
+        {warnings.map((w) => (
+          <p key={w.code}>{w.message}</p>
+        ))}
+        <p>
+          <a
+            href={PHOTO_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            See the photo guide
+          </a>
+          {' · '}
+          <button type="button" onClick={onDismiss} className="underline">
+            Dismiss
+          </button>
+        </p>
+      </div>
+    </Alert>
+  )
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -6,3 +6,4 @@ export const SNAP_GRID_MAX = 42
 export const MAX_HISTORY = 50
 export const ZOOM_FACTOR = 1.15
 export const DEFAULT_CUTOUT_DEPTH = 20
+export const DOCS_BASE_URL = 'https://github.com/tracefinity/tracefinity/blob/main/docs'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,6 +44,11 @@ export interface Layout {
   text_labels: TextLabel[]
 }
 
+export interface PhotoWarning {
+  code: string
+  message: string
+}
+
 export interface Session {
   id: string
   name: string | null
@@ -56,6 +61,8 @@ export interface Session {
   corners: Point[] | null
   paper_size: PaperSize | null
   scale_factor: number | null
+  focal_length_35mm?: number | null
+  photo_warnings?: PhotoWarning[] | null
   polygons: Polygon[] | null
   stl_path: string | null
   layout: Layout | null
@@ -81,6 +88,7 @@ export interface UploadResponse {
 export interface CornersResponse {
   corrected_image_url: string
   scale_factor: number
+  warnings: PhotoWarning[]
 }
 
 export interface TraceResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -61,8 +61,8 @@ export interface Session {
   corners: Point[] | null
   paper_size: PaperSize | null
   scale_factor: number | null
-  focal_length_35mm?: number | null
-  photo_warnings?: PhotoWarning[] | null
+  focal_length_35mm: number | null
+  photo_warnings: PhotoWarning[] | null
   polygons: Polygon[] | null
   stl_path: string | null
   layout: Layout | null


### PR DESCRIPTION
## Summary

- Flags photo problems at corner-confirmation time, before the user invests in tracing and printing. Three checks ship: **camera too close** (EXIF `FocalLengthIn35mmFilm` plus the confirmed paper span give camera height; below 45 cm a 15 mm-thick tool traces over ~3.5% oversized via H/(H-t)), **paper cut off** (a corner at or beyond the frame edge), and **extreme perspective** (opposite-side keystone ratio above 1.35). Blur/shadow checks were deliberately left out: variance-of-Laplacian and contrast thresholds are hard to tune without a corpus of real photos and would false-positive too readily.
- Focal length is extracted at upload, before re-encoding strips EXIF, and stored on the session. Checks run in `POST /sessions/{id}/corners` against the original image with the user-confirmed corners and chosen paper size (no guessing from auto-detected corners), so the estimate uses trustworthy inputs. Warnings persist on the session and return in the response.
- Frontend shows a dismissible warning banner in the trace sidebar as soon as correction completes, with the expected oversize magnitude and a link to the photo guide. It persists through the trace and edit steps and on session reload. Non-blocking throughout.
- Graceful no-ops everywhere: stripped EXIF skips only the camera-height check, unreadable images or degenerate quads skip cleanly, and any check failure is logged and swallowed.

Camera height uses the diagonal pinhole model: the image diagonal maps to the 43.27 mm full-frame diagonal that `FocalLengthIn35mmFilm` is defined against, so `H = f35 x paper_diag_mm x image_diag_px / (43.27 x paper_diag_px)`. Diagonal-based, so phone 4:3 vs 3:2 frame conventions don't skew it.

Follow-up (separate issue if pursued): optional tool-thickness input compensating parallax by scaling polygons by (H-t)/H, now that H is stored per session.

## Test evidence

- `backend/venv/bin/python -m pytest tests` -- 283 passed (16 new unit tests for the checks and EXIF extraction, 5 new route tests including EXIF-survives-downscale and graceful no-EXIF paths)
- `pnpm exec vitest run` -- 114 passed (4 new banner component tests)
- `make lint` -- clean (0 errors; pre-existing warnings untouched)

Closes #150
