### PR TITLE
Evict _project_store_cache on user deletion

### DIFF
--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -21,8 +21,9 @@ async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)
         shutil.rmtree(user_path)
         logger.info("deleted storage for user %s", user_id)
 
-    # evict from store cache
-    from app.api.routes import _store_cache
+    # evict from store caches so stale in-memory data cannot be rewritten to disk
+    from app.api.routes import _project_store_cache, _store_cache
     _store_cache.pop(user_id, None)
+    _project_store_cache.pop(user_id, None)
 
     return Response(status_code=204)

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -16,14 +16,15 @@ router = APIRouter()
 @router.delete("/users/me")
 async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)):
     """delete all stored data for the authenticated user"""
+    # evict store caches before rmtree so a failed/partial delete cannot
+    # leave stale in-memory data that a later write resurrects to disk
+    from app.api.routes import _project_store_cache, _store_cache
+    _store_cache.pop(user_id, None)
+    _project_store_cache.pop(user_id, None)
+
     user_path = settings.storage_path / user_id
     if user_path.exists():
         shutil.rmtree(user_path)
         logger.info("deleted storage for user %s", user_id)
-
-    # evict from store caches so stale in-memory data cannot be rewritten to disk
-    from app.api.routes import _project_store_cache, _store_cache
-    _store_cache.pop(user_id, None)
-    _project_store_cache.pop(user_id, None)
 
     return Response(status_code=204)

--- a/backend/tests/test_proxy_middleware.py
+++ b/backend/tests/test_proxy_middleware.py
@@ -25,6 +25,22 @@ def client(app):
     return TestClient(app)
 
 
+@pytest.fixture()
+def _restore_secretless_app():
+    """secret tests bake PROXY_SECRET into reloaded module state; reload
+    app.config/app.main without it afterwards so later tests see clean modules."""
+    yield
+    import importlib
+
+    import app.config as config_mod
+    import app.main as main_mod
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("PROXY_SECRET", raising=False)
+        importlib.reload(config_mod)
+        importlib.reload(main_mod)
+
+
 def test_starts_without_proxy_secret(client):
     """starts without auth configured."""
     resp = client.get("/health")
@@ -38,7 +54,7 @@ def test_requests_pass_through_without_proxy_secret(client):
     assert resp.status_code == 200
 
 
-def test_rejects_bad_secret_when_configured(monkeypatch):
+def test_rejects_bad_secret_when_configured(monkeypatch, _restore_secretless_app):
     """wrong secret rejected when auth is configured."""
     monkeypatch.setenv("PROXY_SECRET", "real-secret")
 
@@ -58,7 +74,7 @@ def test_rejects_bad_secret_when_configured(monkeypatch):
     assert resp.status_code == 403
 
 
-def test_accepts_correct_secret_when_configured(monkeypatch):
+def test_accepts_correct_secret_when_configured(monkeypatch, _restore_secretless_app):
     """correct secret accepted when auth is configured."""
     monkeypatch.setenv("PROXY_SECRET", "real-secret")
 

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from fastapi.testclient import TestClient
 
 import app.api.routes as routes
@@ -11,19 +12,22 @@ from app.main import app
 USER_ID = "cjld2cjxh0000qzrmn831i7rn"
 
 
-def _client(tmp_path, monkeypatch):
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    # routes imports the same settings object, so one patch covers both
     monkeypatch.setattr(settings, "storage_path", tmp_path)
-    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
     # test_proxy_middleware reloads app.main with a secret; pin auth off
     monkeypatch.setattr(main_mod.settings, "proxy_secret", None)
     routes._store_cache.clear()
     routes._project_store_cache.clear()
     ensure_user_dirs(tmp_path / "default")
-    return TestClient(app)
+    yield TestClient(app)
+    # don't leak this test's user id into later tests
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
 
 
-def test_delete_user_evicts_project_store_cache(tmp_path, monkeypatch):
-    client = _client(tmp_path, monkeypatch)
+def test_delete_user_evicts_project_store_cache(client):
     headers = {"x-user-id": USER_ID}
 
     resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
@@ -36,8 +40,7 @@ def test_delete_user_evicts_project_store_cache(tmp_path, monkeypatch):
     assert USER_ID not in routes._project_store_cache
 
 
-def test_deleted_projects_do_not_resurrect_on_next_write(tmp_path, monkeypatch):
-    client = _client(tmp_path, monkeypatch)
+def test_deleted_projects_do_not_resurrect_on_next_write(client, tmp_path):
     headers = {"x-user-id": USER_ID}
 
     resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -1,0 +1,57 @@
+import json
+
+from fastapi.testclient import TestClient
+
+import app.api.routes as routes
+import app.main as main_mod
+from app.config import ensure_user_dirs, settings
+from app.main import app
+
+# valid cuid per auth._USER_ID_RE
+USER_ID = "cjld2cjxh0000qzrmn831i7rn"
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "storage_path", tmp_path)
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    # test_proxy_middleware reloads app.main with a secret; pin auth off
+    monkeypatch.setattr(main_mod.settings, "proxy_secret", None)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+    ensure_user_dirs(tmp_path / "default")
+    return TestClient(app)
+
+
+def test_delete_user_evicts_project_store_cache(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    headers = {"x-user-id": USER_ID}
+
+    resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
+    assert resp.status_code == 200
+
+    resp = client.delete("/api/users/me", headers=headers)
+    assert resp.status_code == 204
+
+    assert USER_ID not in routes._store_cache
+    assert USER_ID not in routes._project_store_cache
+
+
+def test_deleted_projects_do_not_resurrect_on_next_write(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    headers = {"x-user-id": USER_ID}
+
+    resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
+    assert resp.status_code == 200
+    old_id = resp.json()["id"]
+
+    resp = client.delete("/api/users/me", headers=headers)
+    assert resp.status_code == 204
+    assert not (tmp_path / USER_ID).exists()
+
+    resp = client.post("/api/bin-projects", json={"name": "New drawer"}, headers=headers)
+    assert resp.status_code == 200
+    new_id = resp.json()["id"]
+
+    on_disk = json.loads((tmp_path / USER_ID / "bin-projects.json").read_text())
+    assert old_id not in on_disk
+    assert new_id in on_disk


### PR DESCRIPTION
## Summary

- `DELETE /users/me` evicted `_store_cache` but not `_project_store_cache`, so a stale in-memory `ProjectStore` survived deletion; the next project write for that user id rewrote `bin-projects.json` with the deleted user's projects. Both caches are now popped on deletion, before the `rmtree` so a failed or partial delete cannot leave stale caches behind.
- Adds a regression test proving deleted projects do not resurrect: create a project as a user id, delete the user, write a new project as that id, assert only the new project is on disk.
- Fixes the state pollution at source: `test_proxy_middleware.py` now restores secretless `app.config`/`app.main` modules after its reload tests, instead of leaving a configured secret that 403s later tests sending `x-user-id`. The deletion tests keep a `proxy_secret` pin as belt-and-braces.
- Residual race: a request holding a store reference across the deletion can still flush stale data after eviction; tracked in #160, out of scope here.

## Test evidence

`pytest tests/` (backend): 292 passed. New tests fail without the fix (stale cache entry, resurrected project on disk) and pass with it. Proxy pollution fix verified both ways: proxy tests followed by deletion tests pass with the restore fixture alone (pin removed) and fail without it. `ruff check backend/`: clean.

Closes #156
