### PR TITLE
Block store writes racing user deletion

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -87,6 +87,7 @@ from app.services.project_service import (
 from app.services.project_store import ProjectStore
 from app.services.session_store import SessionStore
 from app.services.stl_generator_manifold import ManifoldSTLGenerator
+from app.services.store_errors import StoreClosedError
 from app.services.tool_namer import name_polygons
 from app.services.tool_store import ToolStore
 from app.services.tracer_registry import TRACER_LABELS, tracer_kind, validate_tracer_ids
@@ -419,8 +420,12 @@ def _run_generate(
     user_path: Path,
     input_hash: str,
     user_id: str,
+    store: SessionStore | BinStore,
 ) -> GenerateResponse:
     """shared STL generation with caching, splitting, and zipping"""
+    # in-flight guard: the request captured its store before any awaits or
+    # threadpool hops; refuse to write outputs once the user is deleted
+    store.ensure_open()
     output_path = user_path / "outputs" / f"{entity_id}.stl"
     hash_path = user_path / "outputs" / f"{entity_id}.hash"
     threemf_path = user_path / "outputs" / f"{entity_id}.3mf"
@@ -534,6 +539,9 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
 
     content, ext, _ = ingest_image(content, ext, MAX_UPLOAD_DIM)
     image_path = up / "uploads" / f"{session_id}{ext}"
+    # the awaited read can outlive a concurrent account deletion; refuse
+    # to write into the deleted user's tree
+    user_sessions.ensure_open()
     image_path.write_bytes(content)
 
     corners = image_processor.detect_paper_corners(str(image_path))
@@ -673,7 +681,12 @@ async def trace_tools(
             corrected_image_path,
             api_key,
             mask_output_path,
+            # abort the mask write (and the dir recreation it implies) if
+            # the user was deleted while the model call was in flight
+            before_mask_write=user_sessions.ensure_open,
         )
+    except StoreClosedError:
+        raise
     except TimeoutError:
         label = TRACER_LABELS.get(tracer_id, tracer_id)
         logging.warning("%s timed out", tracer_id)
@@ -730,6 +743,9 @@ async def trace_from_mask(
         raise HTTPException(status_code=400, detail="unsupported image format")
     content, mask_ext, _ = ingest_image(content, mask_ext)
     mask_path = up / "processed" / f"{session_id}_mask.png"
+    # the awaited read can outlive a concurrent account deletion; refuse
+    # to write into the deleted user's tree
+    user_sessions.ensure_open()
     mask_path.write_bytes(content)
 
     corrected_image_path = _abs(session.corrected_image_path)
@@ -790,7 +806,7 @@ def generate_stl(request: Request, session_id: str, req: GenerateRequest, user_i
         for p in scaled
     ]
 
-    response = _run_generate(scaled, req, session_id, up, input_hash, user_id)
+    response = _run_generate(scaled, req, session_id, up, input_hash, user_id, user_sessions)
 
     output_path = up / "outputs" / f"{session_id}.stl"
     fresh_session = user_sessions.get(session_id)
@@ -1650,7 +1666,7 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
         half_grid_base=bc.half_grid_base,
     )
 
-    response = _run_generate(scaled, gen_req, bin_id, up, input_hash, user_id)
+    response = _run_generate(scaled, gen_req, bin_id, up, input_hash, user_id, user_bins)
 
     output_path = up / "outputs" / f"{bin_id}.stl"
     fresh = user_bins.get(bin_id)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 import re
+import threading
 import uuid
 import zipfile
 from datetime import datetime
@@ -102,25 +103,38 @@ validate_tracer_ids(settings.available_tracers)
 _store_cache: dict[str, tuple[SessionStore, ToolStore, BinStore]] = {}
 _project_store_cache: dict[str, ProjectStore] = {}
 
+# serialises store creation against user deletion so a store cannot be
+# built from files that are mid-rmtree (issue #160). locks are never
+# removed; the dict is bounded by the number of user ids seen.
+_user_locks: dict[str, threading.Lock] = {}
+_user_locks_guard = threading.Lock()
+
+
+def user_lock(user_id: str) -> threading.Lock:
+    with _user_locks_guard:
+        return _user_locks.setdefault(user_id, threading.Lock())
+
 
 def get_stores(user_id: str) -> tuple[SessionStore, ToolStore, BinStore]:
-    if user_id not in _store_cache:
-        user_path = settings.storage_path / user_id
-        ensure_user_dirs(user_path)
-        _store_cache[user_id] = (
-            SessionStore(user_path),
-            ToolStore(user_path),
-            BinStore(user_path),
-        )
-    return _store_cache[user_id]
+    with user_lock(user_id):
+        if user_id not in _store_cache:
+            user_path = settings.storage_path / user_id
+            ensure_user_dirs(user_path)
+            _store_cache[user_id] = (
+                SessionStore(user_path),
+                ToolStore(user_path),
+                BinStore(user_path),
+            )
+        return _store_cache[user_id]
 
 
 def get_project_store(user_id: str) -> ProjectStore:
-    if user_id not in _project_store_cache:
-        user_path = settings.storage_path / user_id
-        ensure_user_dirs(user_path)
-        _project_store_cache[user_id] = ProjectStore(user_path)
-    return _project_store_cache[user_id]
+    with user_lock(user_id):
+        if user_id not in _project_store_cache:
+            user_path = settings.storage_path / user_id
+            ensure_user_dirs(user_path)
+            _project_store_cache[user_id] = ProjectStore(user_path)
+        return _project_store_cache[user_id]
 
 
 def _user_path(user_id: str) -> Path:

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -16,15 +16,22 @@ router = APIRouter()
 @router.delete("/users/me")
 async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)):
     """delete all stored data for the authenticated user"""
-    # evict store caches before rmtree so a failed/partial delete cannot
-    # leave stale in-memory data that a later write resurrects to disk
-    from app.api.routes import _project_store_cache, _store_cache
-    _store_cache.pop(user_id, None)
-    _project_store_cache.pop(user_id, None)
+    from app.api.routes import _project_store_cache, _store_cache, user_lock
 
-    user_path = settings.storage_path / user_id
-    if user_path.exists():
-        shutil.rmtree(user_path)
-        logger.info("deleted storage for user %s", user_id)
+    # the user lock blocks store creation for this user until rmtree
+    # finishes; closing the evicted stores blocks writes from references
+    # already captured by in-flight requests (issue #160)
+    with user_lock(user_id):
+        stores = _store_cache.pop(user_id, None)
+        project_store = _project_store_cache.pop(user_id, None)
+        for store in (stores or ()):
+            store.close()
+        if project_store is not None:
+            project_store.close()
+
+        user_path = settings.storage_path / user_id
+        if user_path.exists():
+            shutil.rmtree(user_path)
+            logger.info("deleted storage for user %s", user_id)
 
     return Response(status_code=204)

--- a/backend/app/api/user_routes.py
+++ b/backend/app/api/user_routes.py
@@ -14,8 +14,12 @@ router = APIRouter()
 
 
 @router.delete("/users/me")
-async def delete_user_data(request: Request, user_id: str = Depends(get_user_id)):
-    """delete all stored data for the authenticated user"""
+def delete_user_data(request: Request, user_id: str = Depends(get_user_id)):
+    """delete all stored data for the authenticated user.
+
+    sync on purpose: fastapi runs it in the threadpool, so the user lock,
+    store locks and rmtree cannot stall the event loop under contention
+    """
     from app.api.routes import _project_store_cache, _store_cache, user_lock
 
     # the user lock blocks store creation for this user until rmtree

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from app.config import settings
+from app.services.store_errors import StoreClosedError
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 LOG_DATEFMT = "%H:%M:%S"
@@ -28,6 +29,13 @@ app = FastAPI(
     title="Tracefinity API",
     version=settings.app_version if settings.show_app_version else "hidden",
 )
+
+
+@app.exception_handler(StoreClosedError)
+async def _store_closed_handler(request: Request, exc: StoreClosedError):
+    # an in-flight request lost the race against user deletion; the data
+    # it targets is gone for good
+    return JSONResponse(status_code=410, content={"detail": "user data deleted"})
 
 
 @app.on_event("startup")

--- a/backend/app/services/ai_tracer.py
+++ b/backend/app/services/ai_tracer.py
@@ -5,6 +5,7 @@ import json
 import logging
 import tempfile
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import cv2
@@ -106,16 +107,22 @@ class AITracer:
         image_path: str,
         api_key: str,
         mask_output_path: str | None = None,
+        before_mask_write: Callable[[], None] | None = None,
     ) -> tuple[list[Polygon], str | None]:
-        """trace tools via local model or gemini mask generation."""
+        """trace tools via local model or gemini mask generation.
+
+        before_mask_write runs just before the mask lands on disk; raising
+        from it aborts the write. the caller uses it to stop the mask being
+        written (and the user dir recreated) when the owning user was
+        deleted while the model call was in flight (issue #160)."""
         import os
         if os.environ.get("E2E_TEST_MODE"):
-            return self._mock_trace(mask_output_path)
+            return self._mock_trace(mask_output_path, before_mask_write)
 
         if self.uses_saliency:
-            mask_path = await self._generate_mask_saliency(image_path, mask_output_path)
+            mask_path = await self._generate_mask_saliency(image_path, mask_output_path, before_mask_write)
         else:
-            mask_path = await self._generate_mask_gemini(image_path, api_key, mask_output_path)
+            mask_path = await self._generate_mask_gemini(image_path, api_key, mask_output_path, before_mask_write)
 
         if not mask_path:
             return [], None
@@ -244,7 +251,12 @@ class AITracer:
         logging.info("generating mask via %s (%s)", cfg.provider, cfg.model)
         return await remote_saliency_mask(cfg, buf.getvalue(), pil_img.size)
 
-    async def _generate_mask_saliency(self, image_path: str, output_path: str | None = None) -> str | None:
+    async def _generate_mask_saliency(
+        self,
+        image_path: str,
+        output_path: str | None = None,
+        before_mask_write: Callable[[], None] | None = None,
+    ) -> str | None:
         """generate a foreground mask using a saliency model (local or remote).
 
         crop to the paper rect before running the model. saliency models pick
@@ -273,6 +285,8 @@ class AITracer:
         mask_out = cv2.bitwise_not(full)
 
         if output_path:
+            if before_mask_write:
+                before_mask_write()
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             cv2.imwrite(output_path, mask_out)
             return output_path
@@ -281,7 +295,11 @@ class AITracer:
             cv2.imencode(".png", mask_out)[1].tofile(f)
             return f.name
 
-    def _mock_trace(self, mask_output_path: str | None) -> tuple[list[Polygon], str | None]:
+    def _mock_trace(
+        self,
+        mask_output_path: str | None,
+        before_mask_write: Callable[[], None] | None = None,
+    ) -> tuple[list[Polygon], str | None]:
         """return pre-recorded fixture data instead of calling Gemini"""
         import shutil
         fixtures = Path(__file__).resolve().parent.parent.parent / "tests" / "fixtures"
@@ -289,6 +307,8 @@ class AITracer:
         mock_json = fixtures / "mock_polygons.json"
 
         if mask_output_path and mock_mask.exists():
+            if before_mask_write:
+                before_mask_write()
             Path(mask_output_path).parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(mock_mask), mask_output_path)
 
@@ -331,7 +351,13 @@ class AITracer:
         mime_type = self._get_media_type(image_path)
         return image_bytes, mime_type, self._mask_prompt(width, height), width, height
 
-    async def _generate_mask_gemini(self, image_path: str, api_key: str, output_path: str | None = None) -> str | None:
+    async def _generate_mask_gemini(
+        self,
+        image_path: str,
+        api_key: str,
+        output_path: str | None = None,
+        before_mask_write: Callable[[], None] | None = None,
+    ) -> str | None:
         """generate a mask via ollama, openrouter, or google sdk."""
         image_bytes, mime_type, prompt, _, _ = self._prepare_image(image_path)
 
@@ -344,6 +370,8 @@ class AITracer:
             return None
 
         if output_path:
+            if before_mask_write:
+                before_mask_write()
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             Path(output_path).write_bytes(mask_data)
             return output_path

--- a/backend/app/services/bin_store.py
+++ b/backend/app/services/bin_store.py
@@ -35,9 +35,11 @@ class BinStore:
                 self._bins = {}
 
     def close(self):
-        """block further disk writes; called when the owning user is deleted"""
+        """block further disk writes and drop cached data; called when the
+        owning user is deleted so captured references cannot read stale data"""
         with self._lock:
             self._closed = True
+            self._bins = {}
 
     def ensure_open(self):
         """raise StoreClosedError if the owning user has been deleted"""

--- a/backend/app/services/bin_store.py
+++ b/backend/app/services/bin_store.py
@@ -17,6 +17,7 @@ class BinStore:
         self.file_path = storage_path / "bins.json"
         self._bins: dict[str, BinModel] = {}
         self._lock = threading.Lock()
+        self._closed = False
         self._load()
 
     def _load(self):
@@ -32,7 +33,16 @@ class BinStore:
                 logger.error(f"Failed to load {self.file_path}: {e}")
                 self._bins = {}
 
+    def close(self):
+        """block further disk writes; called when the owning user is deleted"""
+        with self._lock:
+            self._closed = True
+
     def _save(self):
+        # runs with self._lock held; refuse writes from references
+        # captured before user deletion (issue #160)
+        if self._closed:
+            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
         data = {bid: b.model_dump() for bid, b in self._bins.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,

--- a/backend/app/services/bin_store.py
+++ b/backend/app/services/bin_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import BinModel
+from app.services.store_errors import StoreClosedError
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +39,15 @@ class BinStore:
         with self._lock:
             self._closed = True
 
+    def ensure_open(self):
+        """raise StoreClosedError if the owning user has been deleted"""
+        if self._closed:
+            raise StoreClosedError(f"store closed, refusing write to {self.file_path}")
+
     def _save(self):
         # runs with self._lock held; refuse writes from references
         # captured before user deletion (issue #160)
-        if self._closed:
-            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
+        self.ensure_open()
         data = {bid: b.model_dump() for bid, b in self._bins.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,
@@ -63,11 +68,15 @@ class BinStore:
 
     def set(self, bin_id: str, bin_data: BinModel):
         with self._lock:
+            # check before mutating so a refused write cannot leave a
+            # phantom record in memory
+            self.ensure_open()
             self._bins[bin_id] = bin_data
             self._save()
 
     def delete(self, bin_id: str) -> Optional[BinModel]:
         with self._lock:
+            self.ensure_open()
             bin_data = self._bins.pop(bin_id, None)
             if bin_data:
                 self._save()

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import BinProject
+from app.services.store_errors import StoreClosedError
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +39,15 @@ class ProjectStore:
         with self._lock:
             self._closed = True
 
+    def ensure_open(self):
+        """raise StoreClosedError if the owning user has been deleted"""
+        if self._closed:
+            raise StoreClosedError(f"store closed, refusing write to {self.file_path}")
+
     def _save(self):
         # runs with self._lock held; refuse writes from references
         # captured before user deletion (issue #160)
-        if self._closed:
-            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
+        self.ensure_open()
         data = {pid: p.model_dump() for pid, p in self._projects.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,
@@ -63,11 +68,15 @@ class ProjectStore:
 
     def set(self, project_id: str, project: BinProject):
         with self._lock:
+            # check before mutating so a refused write cannot leave a
+            # phantom record in memory
+            self.ensure_open()
             self._projects[project_id] = project
             self._save()
 
     def delete(self, project_id: str) -> Optional[BinProject]:
         with self._lock:
+            self.ensure_open()
             project = self._projects.pop(project_id, None)
             if project:
                 self._save()

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -35,9 +35,11 @@ class ProjectStore:
                 self._projects = {}
 
     def close(self):
-        """block further disk writes; called when the owning user is deleted"""
+        """block further disk writes and drop cached data; called when the
+        owning user is deleted so captured references cannot read stale data"""
         with self._lock:
             self._closed = True
+            self._projects = {}
 
     def ensure_open(self):
         """raise StoreClosedError if the owning user has been deleted"""

--- a/backend/app/services/project_store.py
+++ b/backend/app/services/project_store.py
@@ -17,6 +17,7 @@ class ProjectStore:
         self.file_path = storage_path / "bin-projects.json"
         self._projects: dict[str, BinProject] = {}
         self._lock = threading.Lock()
+        self._closed = False
         self._load()
 
     def _load(self):
@@ -32,7 +33,16 @@ class ProjectStore:
                 logger.error(f"Failed to load {self.file_path}: {e}")
                 self._projects = {}
 
+    def close(self):
+        """block further disk writes; called when the owning user is deleted"""
+        with self._lock:
+            self._closed = True
+
     def _save(self):
+        # runs with self._lock held; refuse writes from references
+        # captured before user deletion (issue #160)
+        if self._closed:
+            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
         data = {pid: p.model_dump() for pid, p in self._projects.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,

--- a/backend/app/services/session_store.py
+++ b/backend/app/services/session_store.py
@@ -35,9 +35,11 @@ class SessionStore:
                 self._sessions = {}
 
     def close(self):
-        """block further disk writes; called when the owning user is deleted"""
+        """block further disk writes and drop cached data; called when the
+        owning user is deleted so captured references cannot read stale data"""
         with self._lock:
             self._closed = True
+            self._sessions = {}
 
     def ensure_open(self):
         """raise StoreClosedError if the owning user has been deleted"""

--- a/backend/app/services/session_store.py
+++ b/backend/app/services/session_store.py
@@ -17,6 +17,7 @@ class SessionStore:
         self.file_path = storage_path / "sessions.json"
         self._sessions: dict[str, Session] = {}
         self._lock = threading.Lock()
+        self._closed = False
         self._load()
 
     def _load(self):
@@ -32,7 +33,16 @@ class SessionStore:
                 logger.error(f"Failed to load {self.file_path}: {e}")
                 self._sessions = {}
 
+    def close(self):
+        """block further disk writes; called when the owning user is deleted"""
+        with self._lock:
+            self._closed = True
+
     def _save(self):
+        # runs with self._lock held; refuse writes from references
+        # captured before user deletion (issue #160)
+        if self._closed:
+            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
         # atomic write: write to temp file then rename
         data = {sid: s.model_dump() for sid, s in self._sessions.items()}
         temp_fd, temp_path = tempfile.mkstemp(

--- a/backend/app/services/session_store.py
+++ b/backend/app/services/session_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import Session
+from app.services.store_errors import StoreClosedError
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +39,15 @@ class SessionStore:
         with self._lock:
             self._closed = True
 
+    def ensure_open(self):
+        """raise StoreClosedError if the owning user has been deleted"""
+        if self._closed:
+            raise StoreClosedError(f"store closed, refusing write to {self.file_path}")
+
     def _save(self):
         # runs with self._lock held; refuse writes from references
         # captured before user deletion (issue #160)
-        if self._closed:
-            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
+        self.ensure_open()
         # atomic write: write to temp file then rename
         data = {sid: s.model_dump() for sid, s in self._sessions.items()}
         temp_fd, temp_path = tempfile.mkstemp(
@@ -64,11 +69,15 @@ class SessionStore:
 
     def set(self, session_id: str, session: Session):
         with self._lock:
+            # check before mutating so a refused write cannot leave a
+            # phantom record in memory
+            self.ensure_open()
             self._sessions[session_id] = session
             self._save()
 
     def delete(self, session_id: str) -> Optional[Session]:
         with self._lock:
+            self.ensure_open()
             session = self._sessions.pop(session_id, None)
             if session:
                 self._save()

--- a/backend/app/services/store_errors.py
+++ b/backend/app/services/store_errors.py
@@ -1,0 +1,2 @@
+class StoreClosedError(RuntimeError):
+    """write attempted on a store whose owning user has been deleted"""

--- a/backend/app/services/tool_store.py
+++ b/backend/app/services/tool_store.py
@@ -35,9 +35,11 @@ class ToolStore:
                 self._tools = {}
 
     def close(self):
-        """block further disk writes; called when the owning user is deleted"""
+        """block further disk writes and drop cached data; called when the
+        owning user is deleted so captured references cannot read stale data"""
         with self._lock:
             self._closed = True
+            self._tools = {}
 
     def ensure_open(self):
         """raise StoreClosedError if the owning user has been deleted"""

--- a/backend/app/services/tool_store.py
+++ b/backend/app/services/tool_store.py
@@ -17,6 +17,7 @@ class ToolStore:
         self.file_path = storage_path / "tools.json"
         self._tools: dict[str, Tool] = {}
         self._lock = threading.Lock()
+        self._closed = False
         self._load()
 
     def _load(self):
@@ -32,7 +33,16 @@ class ToolStore:
                 logger.error(f"Failed to load {self.file_path}: {e}")
                 self._tools = {}
 
+    def close(self):
+        """block further disk writes; called when the owning user is deleted"""
+        with self._lock:
+            self._closed = True
+
     def _save(self):
+        # runs with self._lock held; refuse writes from references
+        # captured before user deletion (issue #160)
+        if self._closed:
+            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
         data = {tid: t.model_dump() for tid, t in self._tools.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,

--- a/backend/app/services/tool_store.py
+++ b/backend/app/services/tool_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.models.schemas import Tool
+from app.services.store_errors import StoreClosedError
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +39,15 @@ class ToolStore:
         with self._lock:
             self._closed = True
 
+    def ensure_open(self):
+        """raise StoreClosedError if the owning user has been deleted"""
+        if self._closed:
+            raise StoreClosedError(f"store closed, refusing write to {self.file_path}")
+
     def _save(self):
         # runs with self._lock held; refuse writes from references
         # captured before user deletion (issue #160)
-        if self._closed:
-            raise RuntimeError(f"store closed, refusing write to {self.file_path}")
+        self.ensure_open()
         data = {tid: t.model_dump() for tid, t in self._tools.items()}
         temp_fd, temp_path = tempfile.mkstemp(
             dir=self.file_path.parent,
@@ -63,11 +68,15 @@ class ToolStore:
 
     def set(self, tool_id: str, tool: Tool):
         with self._lock:
+            # check before mutating so a refused write cannot leave a
+            # phantom record in memory
+            self.ensure_open()
             self._tools[tool_id] = tool
             self._save()
 
     def delete(self, tool_id: str) -> Optional[Tool]:
         with self._lock:
+            self.ensure_open()
             tool = self._tools.pop(tool_id, None)
             if tool:
                 self._save()

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -11,6 +11,7 @@ import app.main as main_mod
 from app.config import ensure_user_dirs, settings
 from app.main import app
 from app.models.schemas import BinModel, BinProject, Session, Tool
+from app.services.store_errors import StoreClosedError
 
 # valid cuid per auth._USER_ID_RE
 USER_ID = "cjld2cjxh0000qzrmn831i7rn"
@@ -99,7 +100,7 @@ def test_captured_store_write_after_deletion_cannot_recreate_data(client, tmp_pa
     routes.get_project_store(USER_ID)
     assert (tmp_path / USER_ID).exists()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(StoreClosedError):
         captured.set(record.id, make_record())
 
     assert not (tmp_path / USER_ID / filename).exists()

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -1,9 +1,12 @@
+import asyncio
+import io
 import json
 import shutil
 import threading
 
 import pytest
 from fastapi.testclient import TestClient
+from PIL import Image
 
 import app.api.routes as routes
 import app.api.user_routes as user_routes
@@ -11,6 +14,7 @@ import app.main as main_mod
 from app.config import ensure_user_dirs, settings
 from app.main import app
 from app.models.schemas import BinModel, BinProject, Session, Tool
+from app.services.ai_tracer import AITracer
 from app.services.store_errors import StoreClosedError
 
 # valid cuid per auth._USER_ID_RE
@@ -156,3 +160,61 @@ def test_get_stores_during_deletion_waits_for_rmtree_and_sees_empty_state(client
     on_disk = json.loads((tmp_path / USER_ID / "bin-projects.json").read_text())
     assert old_id not in on_disk
     assert "p-new" in on_disk
+
+
+def test_delete_mid_trace_does_not_recreate_user_dir_or_mask(client, tmp_path, monkeypatch):
+    """a trace awaiting its model call must not write the mask (recreating
+    the user dir) after the user is deleted mid-flight (issue #160)"""
+    headers = {"x-user-id": USER_ID}
+    monkeypatch.setattr(settings, "tracers", None)
+    monkeypatch.setattr(settings, "google_api_key", "test-key")
+    monkeypatch.setattr(settings, "openrouter_api_key", None)
+    monkeypatch.setattr(routes, "_tracers", {})
+
+    session_id = "trace-race"
+    user_sessions, _, _ = routes.get_stores(USER_ID)
+    corrected = tmp_path / USER_ID / "processed" / "corrected.png"
+    Image.new("RGB", (64, 64), "white").save(corrected)
+    user_sessions.set(session_id, Session(
+        id=session_id,
+        corrected_image_path=f"{USER_ID}/processed/corrected.png",
+    ))
+
+    buf = io.BytesIO()
+    Image.new("L", (64, 64), 255).save(buf, format="PNG")
+    mask_bytes = buf.getvalue()
+
+    in_model = threading.Event()
+    release_model = threading.Event()
+
+    async def fake_mask(self, image_bytes, mime_type, prompt, api_key):
+        in_model.set()
+        await asyncio.to_thread(release_model.wait, 5)
+        return mask_bytes
+
+    monkeypatch.setattr(AITracer, "_mask_via_google", fake_mask)
+
+    trace_result = {}
+
+    def do_trace():
+        trace_result["resp"] = client.post(
+            f"/api/sessions/{session_id}/trace", json={}, headers=headers
+        )
+
+    tracer_thread = threading.Thread(target=do_trace)
+    tracer_thread.start()
+    assert in_model.wait(5)
+
+    # deletion completes while the model call is still awaited
+    resp = TestClient(app).delete("/api/users/me", headers=headers)
+    assert resp.status_code == 204
+    assert not (tmp_path / USER_ID).exists()
+
+    release_model.set()
+    tracer_thread.join(5)
+    assert not tracer_thread.is_alive()
+
+    # the in-flight trace must abort cleanly, not resurrect the user dir
+    assert trace_result["resp"].status_code == 410
+    assert not (tmp_path / USER_ID / "processed" / f"{session_id}_mask.png").exists()
+    assert not (tmp_path / USER_ID).exists()

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -1,12 +1,16 @@
 import json
+import shutil
+import threading
 
 import pytest
 from fastapi.testclient import TestClient
 
 import app.api.routes as routes
+import app.api.user_routes as user_routes
 import app.main as main_mod
 from app.config import ensure_user_dirs, settings
 from app.main import app
+from app.models.schemas import BinModel, BinProject, Session, Tool
 
 # valid cuid per auth._USER_ID_RE
 USER_ID = "cjld2cjxh0000qzrmn831i7rn"
@@ -58,3 +62,96 @@ def test_deleted_projects_do_not_resurrect_on_next_write(client, tmp_path):
     on_disk = json.loads((tmp_path / USER_ID / "bin-projects.json").read_text())
     assert old_id not in on_disk
     assert new_id in on_disk
+
+
+def _capture_store(kind: str):
+    if kind == "project":
+        return routes.get_project_store(USER_ID)
+    session_store, tool_store, bin_store = routes.get_stores(USER_ID)
+    return {"session": session_store, "tool": tool_store, "bin": bin_store}[kind]
+
+
+_STORE_CASES = {
+    "session": ("sessions.json", lambda: Session(id="s1")),
+    "tool": ("tools.json", lambda: Tool(id="t1", name="Old tool", points=[])),
+    "bin": ("bins.json", lambda: BinModel(id="b1")),
+    "project": ("bin-projects.json", lambda: BinProject(id="p1", name="Old project")),
+}
+
+
+@pytest.mark.parametrize("kind", sorted(_STORE_CASES))
+def test_captured_store_write_after_deletion_cannot_recreate_data(client, tmp_path, kind):
+    headers = {"x-user-id": USER_ID}
+    filename, make_record = _STORE_CASES[kind]
+
+    captured = _capture_store(kind)
+    record = make_record()
+    captured.set(record.id, record)
+    assert (tmp_path / USER_ID / filename).exists()
+
+    resp = client.delete("/api/users/me", headers=headers)
+    assert resp.status_code == 204
+    assert not (tmp_path / USER_ID).exists()
+
+    # any later request recreates the user dirs; the captured reference
+    # must still be unable to write the deleted data back
+    routes.get_stores(USER_ID)
+    routes.get_project_store(USER_ID)
+    assert (tmp_path / USER_ID).exists()
+
+    with pytest.raises(RuntimeError):
+        captured.set(record.id, make_record())
+
+    assert not (tmp_path / USER_ID / filename).exists()
+
+
+def test_get_stores_during_deletion_waits_for_rmtree_and_sees_empty_state(client, tmp_path, monkeypatch):
+    headers = {"x-user-id": USER_ID}
+
+    resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
+    assert resp.status_code == 200
+    old_id = resp.json()["id"]
+
+    in_rmtree = threading.Event()
+    release_rmtree = threading.Event()
+    real_rmtree = shutil.rmtree
+
+    def slow_rmtree(path, *args, **kwargs):
+        in_rmtree.set()
+        assert release_rmtree.wait(5)
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(user_routes.shutil, "rmtree", slow_rmtree)
+
+    delete_result = {}
+
+    def do_delete():
+        delete_result["resp"] = client.delete("/api/users/me", headers=headers)
+
+    deleter = threading.Thread(target=do_delete)
+    deleter.start()
+    assert in_rmtree.wait(5)
+
+    repopulated = {}
+
+    def do_get():
+        repopulated["store"] = routes.get_project_store(USER_ID)
+
+    getter = threading.Thread(target=do_get)
+    getter.start()
+    getter.join(0.3)
+    # store creation must block until deletion finishes, otherwise it
+    # loads the about-to-be-deleted files and caches stale data
+    assert getter.is_alive()
+
+    release_rmtree.set()
+    deleter.join(5)
+    getter.join(5)
+    assert delete_result["resp"].status_code == 204
+    assert repopulated["store"].all() == {}
+
+    new_project = BinProject(id="p-new", name="New drawer")
+    repopulated["store"].set(new_project.id, new_project)
+    on_disk = json.loads((tmp_path / USER_ID / "bin-projects.json").read_text())
+    assert old_id not in on_disk
+    assert "p-new" in on_disk


### PR DESCRIPTION
## Summary

- Deletion now closes the evicted store instances (session/tool/bin/project); a closed store refuses writes and drops its in-memory data, so a store reference captured by an in-flight threadpool request (e.g. `generate_stl`) can no longer rewrite or serve the deleted user's data.
- `get_stores`/`get_project_store` and the deletion sequence (evict, close, rmtree) serialise on a per-user `threading.Lock`, closing the residual #159 window where a store could be built from files mid-rmtree and cached with stale data.
- Non-store file writes are guarded too: the tracer mask write, upload, trace-mask and shared STL output paths check the captured store before writing, so an in-flight request cannot recreate the deleted user's tree.
- Closed-store writes raise a typed `StoreClosedError`, mapped to a 410 at the API layer, so requests losing the race fail cleanly instead of as unhandled 500s.
- Regression tests: captured-store write after deletion for all four stores (asserts `StoreClosedError` and nothing reappears on disk, including after dir recreation), store creation racing an event-gated slow rmtree, and a delete landing mid-trace (asserts the user dir and mask never reappear).

## Approach

The issue offered a per-user lock or a deleted-generation check in `_save`. Neither alone closes the race, so this uses both halves, each for the window only it can cover:

- A closed flag checked in the store write path handles captured references. A lock alone cannot: the offending write happens after deletion has completed and released any lock. The check is atomic with the write because `set()`/`delete()` hold the store's existing lock for check + mutate + save, and `close()` takes the same lock, giving a clean happens-before (write lands before rmtree, or the write sees closed and refuses). `close()` also drops the in-memory dicts, belt and braces with the flag, so a captured reference cannot read stale records either; in-flight reads racing deletion were already best-effort, so nothing meaningful is lost.
- The per-user lock handles cache repopulation during deletion. A closed flag alone cannot: a fresh instance created between eviction and rmtree loads the old files and is not closed.

Non-store file writes get the same treatment, with the captured (now closed) store as the deletion signal. The seconds-long window is a trace awaiting its model call: the tracer used to mkdir + write the mask when the call returned, silently recreating the deleted user's dir before the store `set()` raised, orphaning the mask with no cleanup. `trace_tools` now passes the captured session store's `ensure_open` into the tracer as a `before_mask_write` hook that aborts the write, and the upload, trace-mask and shared STL generation paths check the captured store before writing into the user tree. Fresh requests for a deleted user id still recreate dirs by design.

Refused writes raise `StoreClosedError` (a `RuntimeError` subclass shared in `app/services/store_errors.py`), mapped to a 410 with a terse detail by an app-level exception handler. The delete handler itself is now a sync `def`: it takes threading locks and runs rmtree, which belongs in FastAPI's threadpool, not on the event loop.

Locks are never removed from `_user_locks` (popping reintroduces races); the dict is bounded by user ids seen, fine for the single-process scope here. Multi-process remains #155. `drawer_store.py` is untouched: nothing instantiates it.

## Test evidence

- `pytest` (backend, main checkout venv): 298 passed
- `make lint-backend`: passes (frontend untouched; worktree lacks node_modules for eslint)
- Store tests fail on the base branch: silent resurrection of `sessions.json`/`tools.json`/`bins.json`/`bin-projects.json` reproduced before the fix
- The mid-trace test fails with the `before_mask_write` hook disabled: the orphaned mask and recreated user dir reproduce

Closes #160
