### PR TITLE
Add dashboard tool status filters

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,8 @@ import { GRID_UNIT } from '@/lib/constants'
 import { getDefaultBinDefaults } from '@/lib/binDefaults'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
 import { projectNameMap, projectStatusLabels, toolProjectLabel, toolProjectTitle } from '@/lib/projectSelectors'
+import { filterToolsByStatus, getToolQuickFilterCounts } from '@/lib/toolFilters'
+import type { ToolQuickFilter } from '@/lib/toolFilters'
 import { cn } from '@/lib/utils'
 import { useTheme } from '@/hooks/useTheme'
 
@@ -258,6 +260,7 @@ export default function HomePage() {
   const [projectStatusFilter, setProjectStatusFilter] = useState<ProjectStatus | 'all'>('all')
   const [toolSearch, setToolSearch] = useState('')
   const [toolSort, setToolSort] = useState('date')
+  const [toolQuickFilter, setToolQuickFilter] = useState<ToolQuickFilter>('all')
   const [collapsedSections, setCollapsedSections] = useState<MainSectionCollapseState>(loadSectionCollapseState)
 
   const hasData = toolsList.length > 0 || binsList.length > 0 || projectsList.length > 0
@@ -302,7 +305,7 @@ export default function HomePage() {
   }, [binsList])
 
   const filteredTools = useMemo(() => {
-    let list = toolsList
+    let list = filterToolsByStatus(toolsList, toolQuickFilter, projectBinToolIds)
     if (toolSearch.trim()) {
       const q = toolSearch.toLowerCase()
       list = list.filter(t => t.name.toLowerCase().includes(q))
@@ -311,7 +314,16 @@ export default function HomePage() {
       list = [...list].sort((a, b) => a.name.localeCompare(b.name))
     }
     return list
-  }, [toolsList, toolSearch, toolSort])
+  }, [toolsList, projectBinToolIds, toolQuickFilter, toolSearch, toolSort])
+
+  const toolQuickFilterOptions = useMemo(() => {
+    const counts = getToolQuickFilterCounts(toolsList, projectBinToolIds)
+    return [
+      { value: 'all' as const, label: 'All', count: counts.all },
+      { value: 'placed' as const, label: 'Placed', count: counts.placed },
+      { value: 'unassigned' as const, label: 'Unassigned', count: counts.unassigned },
+    ]
+  }, [toolsList, projectBinToolIds])
 
   function setSectionCollapsed(section: MainSectionId, collapsed: boolean) {
     setCollapsedSections(prev => {
@@ -462,10 +474,10 @@ export default function HomePage() {
                       <button
                         key={option.value}
                         onClick={() => setProjectStatusFilter(option.value)}
-                        className={`flex-shrink-0 rounded-[7px] px-2.5 py-1 text-[11px] transition-colors cursor-pointer ${
+                        className={`glass-sm flex-shrink-0 rounded-[7px] px-2.5 py-1 text-[11px] transition-colors cursor-pointer ${
                           isActive
                             ? 'bg-accent-muted text-accent'
-                            : 'glass-sm text-text-secondary hover:bg-glass-hover'
+                            : 'text-text-secondary hover:bg-glass-hover'
                         }`}
                       >
                         {option.label}
@@ -549,15 +561,41 @@ export default function HomePage() {
       {toolsList.length > 0 && (
         <div>
           <SectionHeader
-            title="Tools" count={toolsList.length}
+            title="Tools" count={filteredTools.length}
             search={toolSearch} onSearchChange={setToolSearch}
             sortKey={toolSort} onSortChange={setToolSort}
             collapsed={collapsedSections.tools}
             onToggleCollapsed={() => setSectionCollapsed('tools', !collapsedSections.tools)}
           />
           {!collapsedSections.tools && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-            {filteredTools.map(tool => {
+          <>
+            <div
+              role="group"
+              aria-label="Filter tools by status"
+              className="mb-3 flex min-w-0 items-center gap-1.5 overflow-x-auto pb-0.5"
+            >
+              {toolQuickFilterOptions.map(option => {
+                const isActive = toolQuickFilter === option.value
+                return (
+                  <button
+                    key={option.value}
+                    onClick={() => setToolQuickFilter(option.value)}
+                    aria-pressed={isActive}
+                    className={`glass-sm flex-shrink-0 rounded-[7px] px-2.5 py-1 text-[11px] transition-colors cursor-pointer ${
+                      isActive
+                        ? 'bg-accent-muted text-accent'
+                        : 'text-text-secondary hover:bg-glass-hover'
+                    }`}
+                  >
+                    {option.label}
+                    <span className="ml-1 text-[10px] text-text-muted">{option.count}</span>
+                  </button>
+                )
+              })}
+            </div>
+            {filteredTools.length > 0 ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+              {filteredTools.map(tool => {
                 const projectLabel = toolProjectLabel(tool.project_ids, projectNameById)
                 const projectTitle = toolProjectTitle(tool.project_ids, projectNameById)
                 const primaryProjectId = tool.project_ids[0]
@@ -651,7 +689,13 @@ export default function HomePage() {
                   </div>
                 )
               })}
-          </div>
+              </div>
+            ) : (
+              <div className="glass rounded-[8px] p-6 text-center">
+                <p className="text-xs text-text-muted">No tools match this filter.</p>
+              </div>
+            )}
+          </>
           )}
         </div>
       )}

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -535,10 +535,10 @@ export default function ProjectPage() {
                 <button
                   key={key}
                   onClick={() => setStatusFilter(key as ProjectToolFilter)}
-                  className={`rounded-[7px] px-2 py-1 text-[11px] transition-colors cursor-pointer ${
+                  className={`glass-sm rounded-[7px] px-2 py-1 text-[11px] transition-colors cursor-pointer ${
                     statusFilter === key
                       ? 'bg-accent-muted text-accent'
-                      : 'glass-sm text-text-secondary hover:bg-glass-hover'
+                      : 'text-text-secondary hover:bg-glass-hover'
                   }`}
                 >
                   {label}

--- a/frontend/src/lib/toolFilters.test.ts
+++ b/frontend/src/lib/toolFilters.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterToolsByStatus, getToolQuickFilterCounts } from './toolFilters'
+import type { ToolSummary } from '@/types'
+
+const tool = (id: string, projectIds: string[] = []): ToolSummary => ({
+  id,
+  name: id,
+  created_at: null,
+  point_count: 0,
+  points: [],
+  interior_rings: [],
+  smoothed: false,
+  smooth_level: 0,
+  thumbnail_url: null,
+  image_transform: null,
+  image_context: null,
+  category: null,
+  drawer: null,
+  tags: [],
+  project_ids: projectIds,
+  review_status: null,
+  needs_cleanup: false,
+})
+
+describe('tool quick filters', () => {
+  const tools = [
+    tool('placed', ['project-1']),
+    tool('needs-bin', ['project-1']),
+    tool('unassigned'),
+  ]
+  const placedToolIds = new Set(['placed'])
+
+  it('shows only project tools that have been placed in a project bin', () => {
+    expect(filterToolsByStatus(tools, 'placed', placedToolIds).map(item => item.id))
+      .toEqual(['placed'])
+  })
+
+  it('shows only tools that are not assigned to a project', () => {
+    expect(filterToolsByStatus(tools, 'unassigned', placedToolIds).map(item => item.id))
+      .toEqual(['unassigned'])
+  })
+
+  it('does not classify an outside-project tool as placed', () => {
+    const outsideProjectTool = tool('outside-project')
+
+    expect(filterToolsByStatus([outsideProjectTool], 'placed', new Set(['outside-project'])))
+      .toEqual([])
+  })
+
+  it('returns counts for each quick filter', () => {
+    expect(getToolQuickFilterCounts(tools, placedToolIds)).toEqual({
+      all: 3,
+      placed: 1,
+      unassigned: 1,
+    })
+  })
+})

--- a/frontend/src/lib/toolFilters.ts
+++ b/frontend/src/lib/toolFilters.ts
@@ -1,0 +1,37 @@
+import type { ToolSummary } from '@/types'
+
+export type ToolQuickFilter = 'all' | 'placed' | 'unassigned'
+
+export function matchesToolQuickFilter(
+  tool: ToolSummary,
+  filter: ToolQuickFilter,
+  placedToolIds: ReadonlySet<string>,
+): boolean {
+  if (filter === 'placed') {
+    return tool.project_ids.length > 0 && placedToolIds.has(tool.id)
+  }
+  if (filter === 'unassigned') {
+    return tool.project_ids.length === 0
+  }
+  return true
+}
+
+export function filterToolsByStatus(
+  tools: ToolSummary[],
+  filter: ToolQuickFilter,
+  placedToolIds: ReadonlySet<string>,
+): ToolSummary[] {
+  if (filter === 'all') return tools
+  return tools.filter(tool => matchesToolQuickFilter(tool, filter, placedToolIds))
+}
+
+export function getToolQuickFilterCounts(
+  tools: ToolSummary[],
+  placedToolIds: ReadonlySet<string>,
+): Record<ToolQuickFilter, number> {
+  return {
+    all: tools.length,
+    placed: tools.filter(tool => matchesToolQuickFilter(tool, 'placed', placedToolIds)).length,
+    unassigned: tools.filter(tool => matchesToolQuickFilter(tool, 'unassigned', placedToolIds)).length,
+  }
+}


### PR DESCRIPTION
## Summary

- add All, Placed, and Unassigned quick filters to the dashboard Tools section, with live counts and accessible pressed states
- compose the status filters with the existing search and sort controls, including a clear empty-results state
- centralize tool-status classification in tested selector helpers
- keep the glass border present in active and inactive filter states so the dashboard and project tool filters no longer shift when clicked

## Behavior

Placed includes tools assigned to a project and present in one of that project's bins. Unassigned includes tools that belong to no project. Assigned tools that still need a bin remain available under All.

The filter-button movement was caused by inactive buttons using `glass-sm`, which adds a 1px border, while the active state removed that class. Keeping `glass-sm` in both states preserves the button geometry while allowing the active background and text colors to change.

## Validation

- `pnpm exec vitest run` — 15 test files and 118 tests passed
- `pnpm exec eslint src/app/page.tsx src/app/projects/[id]/page.tsx` — no errors; two existing warnings
- `pnpm exec tsc --noEmit`
- `pnpm exec next build`

Code and PR drafted with Codex
