### PR TITLE
Allow blank bin generation

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1593,8 +1593,6 @@ def generate_bin_stl(request: Request, bin_id: str, user_id: str = Depends(get_u
     bin_data = user_bins.get(bin_id)
     if not bin_data:
         raise HTTPException(status_code=404, detail="bin not found")
-    if not bin_data.placed_tools:
-        raise HTTPException(status_code=400, detail="bin has no tools placed")
 
     bc = bin_data.bin_config
 

--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -546,6 +546,27 @@ def _resolve_pocket_depth(override: float | None, config, max_depth: float) -> f
     return max(5, min(base, max_depth))
 
 
+def _make_blank_bin_cutout(config: GenerateRequest, wall_top_z: float, max_depth: float):
+    """Full-bin interior pocket for bins with no placed tools."""
+    import manifold3d as mf
+
+    outer_w = config.grid_x * GF_GRID - 0.5
+    outer_h = config.grid_y * GF_GRID - 0.5
+    wall = LIP_D0 + LIP_D2
+    inner_w = outer_w - 2 * wall
+    inner_h = outer_h - 2 * wall
+    if inner_w <= 0 or inner_h <= 0:
+        return None, 0
+
+    pocket_depth = _resolve_pocket_depth(None, config, max_depth)
+    inner_r = min(GF_CORNER_R, inner_w / 2, inner_h / 2)
+    cutter = mf.Manifold.extrude(
+        _cs(_rounded_rect_pts(inner_w, inner_h, inner_r)),
+        pocket_depth + 0.01,
+    ).translate((0.0, 0.0, wall_top_z - pocket_depth))
+    return cutter, pocket_depth
+
+
 def _filleted_rect_radius(width: float, pocket_depth: float) -> float:
     """Bottom fillet radius for the filleted-rectangle cutter profile."""
     return max(0.0, min(width / 3.0, pocket_depth / 2.0))
@@ -1379,12 +1400,13 @@ class ManifoldSTLGenerator:
             cutters.append(_make_magnet_holes(config))
 
         pocket_depth = 5
+        floor_z = GF_BASE_HEIGHT
+        lip_deduction = (LIP_D3 + LIP_D4) if config.stacking_lip else 0
+        max_depth = wall_top_z - floor_z - 2 - lip_deduction
         if polygons:
-            floor_z = GF_BASE_HEIGHT
-            lip_deduction = (LIP_D3 + LIP_D4) if config.stacking_lip else 0
-            max_depth = wall_top_z - floor_z - 2 - lip_deduction
-            # Default pocket_depth still tracks the global cutout_depth; per-cutout
-            # overrides are resolved inside the cutter functions.
+            # Default pocket_depth (used by text labels below) still tracks the
+            # global cutout_depth; per-cutout overrides are resolved inside the
+            # cutter functions via _resolve_pocket_depth.
             pocket_depth = _resolve_pocket_depth(None, config, max_depth)
 
             t1 = time.monotonic()
@@ -1409,6 +1431,12 @@ class ManifoldSTLGenerator:
                 if fh_chamfers:
                     cutters.append(fh_chamfers)
                 logger.info("chamfer cutouts: %.2fs", time.monotonic() - t1)
+        else:
+            t1 = time.monotonic()
+            blank_cutout, pocket_depth = _make_blank_bin_cutout(config, wall_top_z, max_depth)
+            if blank_cutout:
+                cutters.append(blank_cutout)
+            logger.info("blank bin cutout: %.2fs", time.monotonic() - t1)
 
         # text labels (recessed cutters + embossed body additions).
         text_body = None

--- a/backend/tests/test_blank_bin_generation.py
+++ b/backend/tests/test_blank_bin_generation.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+
+from app.models.schemas import GenerateRequest
+from app.services.stl_generator_manifold import (
+    GF_BASE_HEIGHT,
+    GF_GRID,
+    GF_HEIGHT_UNIT,
+    LIP_D0,
+    LIP_D2,
+    LIP_D3,
+    LIP_D4,
+    ManifoldSTLGenerator,
+    _make_blank_bin_cutout,
+)
+
+
+def test_generate_blank_bin_writes_full_width_cutout(tmp_path: Path):
+    output_path = tmp_path / "blank_bin.stl"
+    config = GenerateRequest(
+        grid_x=2,
+        grid_y=1,
+        height_units=3,
+        magnets=False,
+        stacking_lip=True,
+        bed_size=0,
+    )
+
+    body, text_body = ManifoldSTLGenerator().generate_bin([], config, str(output_path))
+
+    assert text_body is None
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    assert body.bounding_box()[5] > 0
+
+
+def test_blank_bin_cutout_observes_cutout_depth():
+    shallow = GenerateRequest(
+        grid_x=2,
+        grid_y=1,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        cutout_depth=8,
+    )
+    deep = shallow.model_copy(update={"cutout_depth": 14})
+    wall_top_z = shallow.height_units * GF_HEIGHT_UNIT
+    lip_deduction = (LIP_D3 + LIP_D4) if shallow.stacking_lip else 0
+    max_depth = wall_top_z - GF_BASE_HEIGHT - 2 - lip_deduction
+
+    _, shallow_depth = _make_blank_bin_cutout(shallow, wall_top_z, max_depth)
+    _, deep_depth = _make_blank_bin_cutout(deep, wall_top_z, max_depth)
+
+    assert shallow_depth == 8
+    assert deep_depth == 14
+
+
+def test_blank_bin_cutout_uses_stacking_lip_wall_thickness():
+    config = GenerateRequest(
+        grid_x=2,
+        grid_y=1,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        wall_thickness=5,
+        cutout_depth=8,
+    )
+    wall_top_z = config.height_units * GF_HEIGHT_UNIT
+    max_depth = wall_top_z - GF_BASE_HEIGHT - 2
+
+    cutter, _ = _make_blank_bin_cutout(config, wall_top_z, max_depth)
+    min_x, min_y, _, max_x, max_y, _ = cutter.bounding_box()
+
+    expected_wall = LIP_D0 + LIP_D2
+    assert max_x - min_x == pytest.approx(config.grid_x * GF_GRID - 0.5 - 2 * expected_wall)
+    assert max_y - min_y == pytest.approx(config.grid_y * GF_GRID - 0.5 - 2 * expected_wall)
+
+
+def test_deeper_blank_bin_cutout_removes_more_material(tmp_path: Path):
+    config = GenerateRequest(
+        grid_x=2,
+        grid_y=1,
+        height_units=4,
+        magnets=False,
+        stacking_lip=False,
+        cutout_depth=8,
+        bed_size=0,
+    )
+    generator = ManifoldSTLGenerator()
+
+    shallow_body, _ = generator.generate_bin([], config, str(tmp_path / "shallow.stl"))
+    deep_body, _ = generator.generate_bin([], config.model_copy(update={"cutout_depth": 14}), str(tmp_path / "deep.stl"))
+
+    assert shallow_body.volume() > deep_body.volume()

--- a/backend/tests/test_half_grid.py
+++ b/backend/tests/test_half_grid.py
@@ -123,9 +123,14 @@ def test_half_grid_base_more_cells_than_standard(tmp_path: Path):
     # both should produce valid geometry
     assert s_body.volume() > 0
     assert h_body.volume() > 0
-    # volumes should be very close (same outer dimensions, just different base pattern)
-    ratio = h_body.volume() / s_body.volume()
-    assert 0.95 < ratio < 1.05
+    # Blank bins now generate as container cavities, so the base pattern can
+    # account for more of the remaining material than it did for solid shells.
+    # The invariant for half-grid bases is the shared outer envelope.
+    s_bb = s_body.bounding_box()
+    h_bb = h_body.bounding_box()
+    assert h_bb[3] - h_bb[0] == pytest.approx(s_bb[3] - s_bb[0])
+    assert h_bb[4] - h_bb[1] == pytest.approx(s_bb[4] - s_bb[1])
+    assert h_bb[5] - h_bb[2] == pytest.approx(s_bb[5] - s_bb[2])
 
 
 def test_half_unit_bin_correct_outer_dimensions(tmp_path: Path):

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -117,8 +117,6 @@ export default function BinPage() {
   }, [binId])
 
   const doGenerate = useCallback(async () => {
-    if (placedTools.length === 0) return
-
     const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] })
     if (key === lastGenerateRef.current) return
 
@@ -536,8 +534,10 @@ export default function BinPage() {
               <div className="flex items-center gap-2 text-[11px] text-text-muted">
                 {generating && <Loader2 className="w-3 h-3 animate-spin text-accent" />}
                 <span>{config.grid_x}x{config.grid_y} Grid ({binW} x {binH} mm)</span>
-                {placedTools.length > 0 && (
+                {placedTools.length > 0 ? (
                   <span>· {placedTools.length} tool{placedTools.length !== 1 ? 's' : ''} placed</span>
+                ) : (
+                  <span>· blank bin</span>
                 )}
               </div>
             </div>
@@ -571,8 +571,6 @@ export default function BinPage() {
                       <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
                       <span>Generating...</span>
                     </>
-                  ) : placedTools.length === 0 ? (
-                    <span>Add tools to see preview</span>
                   ) : (
                     <span>Preview will appear here</span>
                   )}

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -294,7 +294,7 @@ export default function ProjectPage() {
   }
 
   async function handleCreateBin() {
-    if (!project || selectedBinToolIds.size === 0) return
+    if (!project) return
     setCreatingBin(true)
     setError(null)
     try {
@@ -423,11 +423,11 @@ export default function ProjectPage() {
           </select>
           <button
             onClick={handleCreateBin}
-            disabled={creatingBin || selectedBinToolIds.size === 0}
+            disabled={creatingBin}
             className="btn-primary px-3 py-2 text-xs flex items-center gap-1.5"
           >
             {creatingBin ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Package className="w-3.5 h-3.5" />}
-            Create bin{selectedBinToolIds.size > 0 ? ` (${selectedBinToolIds.size})` : ''}
+            {selectedBinToolIds.size > 0 ? `Create bin (${selectedBinToolIds.size})` : 'Create blank bin'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Blank bins are useful when a drawer layout needs an empty container, spacer, or catch-all bin alongside traced tool bins. Previously, empty bins could be created in the UI but could not be generated, and the generator behavior did not let the cutout depth define the usable interior cavity. This makes blank bins behave like intentional printable containers instead of requiring a placeholder tool shape.

## Summary
- allow bins with no placed tools to generate STL previews/exports
- enable project-level creation of intentionally blank bins
- generate blank bins as container-style cavities using the configured cutout depth
- keep blank-bin side walls aligned with the stacking-lip wall inset

## Testing
- `python -m pytest backend/tests/test_blank_bin_generation.py`

Code and PR drafted with Codex