### PR TITLE
Weld boolean-seam vertices to fix non-manifold STL exports

### DIFF
--- a/backend/app/services/stl_generator_manifold.py
+++ b/backend/app/services/stl_generator_manifold.py
@@ -1295,8 +1295,15 @@ def _manifold_to_trimesh(m):
     faces = mesh.tri_verts.astype(np.int64)
     tm = trimesh.Trimesh(vertices=verts, faces=faces, process=False)
     # merge near-duplicate vertices and drop degenerate faces that manifold
-    # boolean ops can introduce at intersection seams
-    tm.merge_vertices()
+    # boolean ops can introduce at intersection seams. trimesh's default merge
+    # tolerance is tighter than the ~1e-4mm gaps manifold3d leaves at some
+    # seams, so nondegenerate_faces() below would strip the resulting sliver
+    # triangle without first welding its vertices into their neighbors,
+    # opening a boundary hole where the sliver used to be (reproduced on a
+    # real export: three vertices ~2e-4mm apart, one dropped triangle, three
+    # boundary edges -- exactly what a slicer reports as non-manifold).
+    # 1e-3mm is far below FDM resolution, so this can't affect print fidelity.
+    tm.merge_vertices(digits_vertex=3)
     # drop zero-area faces, then clean up orphaned vertices
     mask = tm.nondegenerate_faces()
     tm.update_faces(mask)

--- a/backend/tests/test_mesh_watertightness.py
+++ b/backend/tests/test_mesh_watertightness.py
@@ -1,0 +1,37 @@
+"""manifold3d's booleans can leave a seam where two near-identical vertices
+land ~1e-4mm apart instead of exactly coincident. trimesh's default
+merge_vertices() tolerance is tighter than that gap, so the later
+nondegenerate_faces() pass drops the resulting sliver triangle without first
+welding its vertices into their neighbors -- opening a small boundary hole
+that slicers report as non-manifold geometry.
+
+Reproduced on a real customer export (grid_x=6, grid_y=9, stacking_lip off,
+real tool cutouts) and, deterministically without any tool data, on a plain
+stacking-lip bin at grid_y=6 -- see test below.
+"""
+from pathlib import Path
+
+import numpy as np
+
+from app.models.schemas import GenerateRequest
+from app.services.stl_generator_manifold import ManifoldSTLGenerator, _manifold_to_trimesh
+
+
+def _boundary_edge_count(mesh) -> int:
+    _, counts = np.unique(mesh.edges_sorted, axis=0, return_counts=True)
+    return int((counts == 1).sum())
+
+
+def test_a_stacking_lip_bin_at_six_grid_units_has_no_boundary_holes(tmp_path: Path):
+    """Below grid_y=6 (252mm) this config exports clean; at and above it, the
+    unpatched merge tolerance used to leave a 3-edge hole in the lip notch
+    seam. No tool polygons needed -- the defect is in the shell/lip geometry
+    itself."""
+    config = GenerateRequest(
+        grid_x=2, grid_y=6, height_units=4, magnets=False, stacking_lip=True,
+    )
+    body, _ = ManifoldSTLGenerator().generate_bin([], config, str(tmp_path / "bin.stl"))
+    tm = _manifold_to_trimesh(body)
+
+    assert _boundary_edge_count(tm) == 0
+    assert tm.is_watertight


### PR DESCRIPTION
## Summary

- manifold3d's boolean ops can leave a seam where two near-identical vertices land ~1e-4mm apart instead of exactly coincident. trimesh's default `merge_vertices()` tolerance is tighter than that gap, so the later `nondegenerate_faces()` pass drops the resulting sliver triangle without first welding its vertices into their neighbors, opening a small boundary hole that slicers report as non-manifold geometry.
- Widen the merge tolerance to `digits_vertex=3` (1e-3mm) before dropping degenerate faces. That's far below FDM print resolution, so it can't affect print fidelity.
- Add a regression test that reproduces the hole deterministically on a plain stacking-lip bin at `grid_y=6` — no tool polygons needed, the defect is in the shell/lip geometry itself.

Originally reproduced on a real customer export (`grid_x=6, grid_y=9`, stacking lip off, real tool cutouts).

## Test evidence

- `pytest backend/tests/test_mesh_watertightness.py` — 1 passed
- `pytest backend/tests -k "stl or mesh or manifold or split"` — 7 passed
- `ruff check backend/app/services/stl_generator_manifold.py backend/tests/test_mesh_watertightness.py` — clean
- Full backend suite: 289 passed. The remaining 10 failures (`test_store_load_errors.py` permission tests, `test_tracer_config.py` env-based tracer selection) are pre-existing on `main` too — Windows `chmod` semantics and a local `FAL_KEY` env var, unrelated to this change.