### PR TITLE
Add optional STL generation concurrency limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 |-|-|-|
 | `GOOGLE_API_KEY` | | Gemini API key. Uses Gemini instead of local models |
 | `TRACERS` | auto-detected | Comma-separated list of available tracers, e.g. `gemini,birefnet-lite,isnet` |
+| `STL_GENERATION_CONCURRENCY` | unlimited | Process-wide maximum STL generation jobs; excess jobs wait up to 5 seconds, then receive 503 |
 | `TRACEFINITY_ONNX_PROVIDER` | `auto` | Local ONNX provider: `auto`, `cuda`, or `cpu` |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |
 | `TOOL_LABEL_PROVIDER` | `none` | Optional automatic tool naming. Set to `ollama` for local vision naming |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -188,6 +188,12 @@ def _get_tracer(tracer_id: str | None = None) -> AITracer:
 
 polygon_scaler = PolygonScaler()
 stl_generator = ManifoldSTLGenerator()
+STL_GENERATION_QUEUE_TIMEOUT_SECONDS = 5.0
+_stl_generation_semaphore = (
+    threading.BoundedSemaphore(settings.stl_generation_concurrency)
+    if settings.stl_generation_concurrency is not None
+    else None
+)
 
 
 def _rel(abs_path: str | Path, user_path: Path) -> str:
@@ -432,7 +438,9 @@ def _run_generate(
     zip_path = user_path / "outputs" / f"{entity_id}_parts.zip"
     insert_path = user_path / "outputs" / f"{entity_id}_insert.stl"
 
-    if output_path.exists() and hash_path.exists() and hash_path.read_text() == input_hash:
+    def cached_response() -> GenerateResponse | None:
+        if not (output_path.exists() and hash_path.exists() and hash_path.read_text() == input_hash):
+            return None
         part_paths = sorted(user_path.glob(f"outputs/{entity_id}_part*.stl"))
         stl_urls = [f"/storage/{user_id}/outputs/{p.name}" for p in part_paths]
         insert_stl_url = (
@@ -452,6 +460,74 @@ def _run_generate(
             warning=cached_warning,
         )
 
+    cached = cached_response()
+    if cached is not None:
+        return cached
+
+    # generation is CPU- and memory-intensive. When configured, briefly wait
+    # for a process-wide slot instead of tying up a threadpool worker forever.
+    if _stl_generation_semaphore is not None:
+        acquired = _stl_generation_semaphore.acquire(
+            timeout=STL_GENERATION_QUEUE_TIMEOUT_SECONDS
+        )
+        if not acquired:
+            raise HTTPException(
+                status_code=503,
+                detail="STL generation is busy; try again shortly.",
+                headers={"Retry-After": str(int(STL_GENERATION_QUEUE_TIMEOUT_SECONDS))},
+            )
+        try:
+            # the store may have been closed while this request waited.
+            store.ensure_open()
+            # an identical request may also have populated the cache.
+            cached = cached_response()
+            if cached is not None:
+                return cached
+            return _generate_uncached(
+                scaled,
+                gen_req,
+                entity_id,
+                user_path,
+                input_hash,
+                user_id,
+                output_path,
+                hash_path,
+                threemf_path,
+                zip_path,
+                insert_path,
+            )
+        finally:
+            _stl_generation_semaphore.release()
+
+    return _generate_uncached(
+        scaled,
+        gen_req,
+        entity_id,
+        user_path,
+        input_hash,
+        user_id,
+        output_path,
+        hash_path,
+        threemf_path,
+        zip_path,
+        insert_path,
+    )
+
+
+def _generate_uncached(
+    scaled: list[ScaledPolygon],
+    gen_req: GenerateRequest,
+    entity_id: str,
+    user_path: Path,
+    input_hash: str,
+    user_id: str,
+    output_path: Path,
+    hash_path: Path,
+    threemf_path: Path,
+    zip_path: Path,
+    insert_path: Path,
+) -> GenerateResponse:
+    """Generate and persist an STL after cache and concurrency checks."""
     threemf_path.unlink(missing_ok=True)
     for old in user_path.glob(f"outputs/{entity_id}_part*.stl"):
         old.unlink(missing_ok=True)
@@ -1774,6 +1850,5 @@ async def storage_stats(request: Request):
         per_user.append({"userId": user_dir.name, "bytes": size})
 
     return {"totalBytes": total, "users": per_user}
-
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 from app.services.tracer_registry import DEFAULT_LOCAL_TRACERS, validate_tracer_ids
@@ -20,6 +21,7 @@ class Settings(BaseSettings):
     gemini_image_model: str = "gemini-3.1-flash-image-preview"
     gemini_label_model: str = "gemini-2.0-flash"
     max_upload_mb: int = 20
+    stl_generation_concurrency: Optional[int] = Field(default=None, gt=0)
     log_level: str = "INFO"
     proxy_secret: Optional[str] = None
     cors_origins: list[str] = ["http://localhost:3000", "http://localhost:4001"]

--- a/backend/tests/test_stl_generation_concurrency.py
+++ b/backend/tests/test_stl_generation_concurrency.py
@@ -1,0 +1,186 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.api import routes
+from app.config import Settings
+from app.models.schemas import GenerateRequest
+
+
+class _OpenStore:
+    def ensure_open(self):
+        pass
+
+
+def test_stl_generation_concurrency_defaults_to_unlimited(monkeypatch):
+    monkeypatch.delenv("STL_GENERATION_CONCURRENCY", raising=False)
+    assert Settings(_env_file=None).stl_generation_concurrency is None
+
+
+def test_stl_generation_concurrency_reads_positive_env_value(monkeypatch):
+    monkeypatch.setenv("STL_GENERATION_CONCURRENCY", "2")
+    assert Settings(_env_file=None).stl_generation_concurrency == 2
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_stl_generation_concurrency_rejects_non_positive_values(monkeypatch, value):
+    monkeypatch.setenv("STL_GENERATION_CONCURRENCY", value)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)
+
+
+def test_generation_jobs_wait_for_a_concurrency_slot(monkeypatch, tmp_path):
+    (tmp_path / "outputs").mkdir()
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", threading.BoundedSemaphore(1))
+
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_count = 0
+    call_lock = threading.Lock()
+
+    def fake_generate(*args):
+        nonlocal call_count
+        with call_lock:
+            call_count += 1
+            current_call = call_count
+        if current_call == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+        else:
+            second_entered.set()
+        return current_call
+
+    monkeypatch.setattr(routes, "_generate_uncached", fake_generate)
+    request = GenerateRequest()
+
+    def run(entity_id):
+        return routes._run_generate(
+            [], request, entity_id, tmp_path, entity_id, "default", _OpenStore()
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(run, "first")
+        assert first_entered.wait(timeout=2)
+        second = executor.submit(run, "second")
+        assert not second_entered.wait(timeout=0.1)
+        release_first.set()
+        assert first.result(timeout=2) == 1
+        assert second.result(timeout=2) == 2
+        assert second_entered.is_set()
+
+
+def test_unlimited_generation_jobs_run_concurrently(monkeypatch, tmp_path):
+    (tmp_path / "outputs").mkdir()
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", None)
+    both_entered = threading.Barrier(2, timeout=2)
+
+    def fake_generate(*args):
+        both_entered.wait()
+        return "generated"
+
+    monkeypatch.setattr(routes, "_generate_uncached", fake_generate)
+    request = GenerateRequest()
+
+    def run(entity_id):
+        return routes._run_generate(
+            [], request, entity_id, tmp_path, entity_id, "default", _OpenStore()
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [executor.submit(run, entity_id) for entity_id in ("first", "second")]
+        assert [result.result(timeout=2) for result in results] == ["generated", "generated"]
+
+
+def test_cached_request_bypasses_saturated_queue(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    (outputs / "cached.stl").write_bytes(b"stl")
+    (outputs / "cached.hash").write_text("same")
+
+    class QueueMustNotBeUsed:
+        def acquire(self, **kwargs):
+            raise AssertionError("cached request entered the queue")
+
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", QueueMustNotBeUsed())
+    response = routes._run_generate(
+        [], GenerateRequest(), "cached", tmp_path, "same", "default", _OpenStore()
+    )
+
+    assert response.stl_url.endswith("/cached.stl")
+
+
+def test_request_uses_cache_populated_while_waiting(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+
+    class CachePopulatingQueue:
+        def acquire(self, **kwargs):
+            (outputs / "queued.stl").write_bytes(b"stl")
+            (outputs / "queued.hash").write_text("same")
+            return True
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", CachePopulatingQueue())
+    monkeypatch.setattr(
+        routes,
+        "_generate_uncached",
+        lambda *args: pytest.fail("cache should prevent duplicate generation"),
+    )
+
+    response = routes._run_generate(
+        [], GenerateRequest(), "queued", tmp_path, "same", "default", _OpenStore()
+    )
+    assert response.stl_url.endswith("/queued.stl")
+
+
+def test_saturated_queue_returns_busy_response(monkeypatch, tmp_path):
+    (tmp_path / "outputs").mkdir()
+
+    class SaturatedQueue:
+        def acquire(self, *, timeout):
+            assert timeout == routes.STL_GENERATION_QUEUE_TIMEOUT_SECONDS
+            return False
+
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", SaturatedQueue())
+
+    with pytest.raises(HTTPException) as exc_info:
+        routes._run_generate(
+            [], GenerateRequest(), "busy", tmp_path, "hash", "default", _OpenStore()
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.headers == {"Retry-After": "5"}
+
+
+def test_uncached_generation_writes_output_and_hash(monkeypatch, tmp_path):
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    monkeypatch.setattr(routes, "_stl_generation_semaphore", None)
+
+    class FakeGenerator:
+        def generate_bin(self, scaled, request, output_path, threemf_path):
+            assert scaled == []
+            assert request == GenerateRequest()
+            assert threemf_path.endswith("generated.3mf")
+            Path(output_path).write_bytes(b"stl")
+            return object(), None
+
+        def export_split_parts(self, *args):
+            return []
+
+    monkeypatch.setattr(routes, "stl_generator", FakeGenerator())
+
+    response = routes._run_generate(
+        [], GenerateRequest(), "generated", tmp_path, "input-hash", "default", _OpenStore()
+    )
+
+    assert response.stl_url.endswith("/generated.stl")
+    assert (outputs / "generated.stl").read_bytes() == b"stl"
+    assert (outputs / "generated.hash").read_text() == "input-hash"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,7 @@ image:
 env:
   GOOGLE_API_KEY: "" # Google API key for Gemini. Leave blank to disable.
   TRACERS: "" # Comma-separated list of available tracers, e.g. gemini,birefnet-lite,isnet
+  STL_GENERATION_CONCURRENCY: "" # Positive integer; empty means unlimited
   TRACEFINITY_ONNX_PROVIDER: "" # Local ONNX provider: auto, cuda, or cpu
   GEMINI_IMAGE_MODEL: "" # Gemini model for mask generation
 

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -59,6 +59,14 @@ docker run --memory=10g -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/
 
 Headroom above the model figures accounts for OpenCV image processing, STL generation, and the Node.js frontend server.
 
+STL generation is unlimited by default, preserving the fastest behavior for
+well-provisioned hosts. On memory-constrained or shared hosts, set
+`STL_GENERATION_CONCURRENCY` to a positive integer to cap the number of
+simultaneous generation jobs. Excess requests wait up to 5 seconds for a slot
+and then receive a 503 busy response; for example,
+`-e STL_GENERATION_CONCURRENCY=1` serializes generation and minimizes peak
+memory use. The limit is process-wide.
+
 ### Kubernetes / Helm
 
 Set `resources.requests.memory` to match the tracer. Example for IS-Net:


### PR DESCRIPTION
## Summary

- add `STL_GENERATION_CONCURRENCY` as an optional positive-integer limit
- queue excess STL generation jobs while keeping cached responses outside the queue
- expose the setting in Helm values and document Docker/resource usage
- test default, validation, and serialization behavior

## Testing

- `uvx ruff check backend/app/config.py backend/app/api/routes.py backend/tests/test_stl_generation_concurrency.py`
- `backend/venv/bin/python -m pytest backend/tests -q` (303 passed)
- `helm template tracefinity chart --set-string env.STL_GENERATION_CONCURRENCY=2`

Closes #174