### PR TITLE
Require proxy secret for user namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |
 | `TOOL_LABEL_PROVIDER` | `none` | Optional automatic tool naming. Set to `ollama` for local vision naming |
 | `SHOW_APP_VERSION` | `true` | Show the running version in the settings popover. Set to `false` to hide it |
+| `PROXY_SECRET` | | Shared secret for a trusted multi-user reverse proxy. Leave unset for normal standalone use |
 
 ### Docker Compose
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,10 +47,14 @@ def _configure_uvicorn_logging():
 
 
 class ProxySecretMiddleware(BaseHTTPMiddleware):
-    """reject requests with X-User-Id but wrong/missing proxy secret"""
+    """only trust user-scoped headers from an authenticated proxy."""
 
     async def dispatch(self, request: Request, call_next):
         if not settings.proxy_secret:
+            path = request.url.path
+            user_scoped_path = path in ("/api", "/storage") or path.startswith(("/api/", "/storage/"))
+            if user_scoped_path and request.headers.get("x-user-id"):
+                return Response(status_code=403)
             return await call_next(request)
         if request.headers.get("x-user-id"):
             if request.headers.get("x-proxy-secret") != settings.proxy_secret:

--- a/backend/tests/test_proxy_middleware.py
+++ b/backend/tests/test_proxy_middleware.py
@@ -1,6 +1,8 @@
-"""auth middleware: enforced when secret is configured, skipped otherwise."""
+"""trusted proxy headers are enforced without affecting standalone requests."""
 import pytest
 from starlette.testclient import TestClient
+
+FORGED_USER_ID = "forgeduser000000000000000"
 
 
 @pytest.fixture()
@@ -54,6 +56,28 @@ def test_requests_pass_through_without_proxy_secret(client):
     assert resp.status_code == 200
 
 
+def test_rejects_user_namespace_without_proxy_secret(client, tmp_path, monkeypatch):
+    """standalone clients cannot provision arbitrary user namespaces."""
+    import app.api.routes as routes
+
+    monkeypatch.setattr(routes.settings, "storage_path", tmp_path)
+    routes._store_cache.clear()
+    routes._project_store_cache.clear()
+
+    headers = {"x-user-id": FORGED_USER_ID, "x-proxy-secret": "client-supplied"}
+    resp = client.get("/api/bins", headers=headers)
+
+    assert resp.status_code == 403
+    assert client.get(f"/storage/{FORGED_USER_ID}/anything", headers=headers).status_code == 403
+    assert not (tmp_path / FORGED_USER_ID).exists()
+    assert FORGED_USER_ID not in routes._store_cache
+    assert FORGED_USER_ID not in routes._user_locks
+
+    standalone_resp = client.get("/api/bins")
+    assert standalone_resp.status_code == 200
+    assert standalone_resp.json() == {"bins": []}
+
+
 def test_rejects_bad_secret_when_configured(monkeypatch, _restore_secretless_app):
     """wrong secret rejected when auth is configured."""
     monkeypatch.setenv("PROXY_SECRET", "real-secret")
@@ -74,21 +98,26 @@ def test_rejects_bad_secret_when_configured(monkeypatch, _restore_secretless_app
     assert resp.status_code == 403
 
 
-def test_accepts_correct_secret_when_configured(monkeypatch, _restore_secretless_app):
+def test_accepts_correct_secret_when_configured(monkeypatch, tmp_path, _restore_secretless_app):
     """correct secret accepted when auth is configured."""
     monkeypatch.setenv("PROXY_SECRET", "real-secret")
 
     import importlib
 
+    import app.api.routes as routes_mod
     import app.config as config_mod
     import app.main as main_mod
 
     importlib.reload(config_mod)
     importlib.reload(main_mod)
+    monkeypatch.setattr(routes_mod.settings, "storage_path", tmp_path)
+    routes_mod._store_cache.clear()
+    routes_mod._project_store_cache.clear()
 
     client = TestClient(main_mod.app)
     resp = client.get(
-        "/health",
-        headers={"x-user-id": "u1", "x-proxy-secret": "real-secret"},
+        "/api/bins",
+        headers={"x-user-id": FORGED_USER_ID, "x-proxy-secret": "real-secret"},
     )
     assert resp.status_code == 200
+    assert (tmp_path / FORGED_USER_ID).is_dir()

--- a/backend/tests/test_user_deletion.py
+++ b/backend/tests/test_user_deletion.py
@@ -19,14 +19,16 @@ from app.services.store_errors import StoreClosedError
 
 # valid cuid per auth._USER_ID_RE
 USER_ID = "cjld2cjxh0000qzrmn831i7rn"
+PROXY_SECRET = "test-proxy-secret"
+USER_HEADERS = {"x-user-id": USER_ID, "x-proxy-secret": PROXY_SECRET}
 
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
     # routes imports the same settings object, so one patch covers both
     monkeypatch.setattr(settings, "storage_path", tmp_path)
-    # test_proxy_middleware reloads app.main with a secret; pin auth off
-    monkeypatch.setattr(main_mod.settings, "proxy_secret", None)
+    # Exercise per-user behavior through the same trusted-proxy contract as production.
+    monkeypatch.setattr(main_mod.settings, "proxy_secret", PROXY_SECRET)
     routes._store_cache.clear()
     routes._project_store_cache.clear()
     ensure_user_dirs(tmp_path / "default")
@@ -37,7 +39,7 @@ def client(tmp_path, monkeypatch):
 
 
 def test_delete_user_evicts_project_store_cache(client):
-    headers = {"x-user-id": USER_ID}
+    headers = USER_HEADERS
 
     resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
     assert resp.status_code == 200
@@ -50,7 +52,7 @@ def test_delete_user_evicts_project_store_cache(client):
 
 
 def test_deleted_projects_do_not_resurrect_on_next_write(client, tmp_path):
-    headers = {"x-user-id": USER_ID}
+    headers = USER_HEADERS
 
     resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
     assert resp.status_code == 200
@@ -86,7 +88,7 @@ _STORE_CASES = {
 
 @pytest.mark.parametrize("kind", sorted(_STORE_CASES))
 def test_captured_store_write_after_deletion_cannot_recreate_data(client, tmp_path, kind):
-    headers = {"x-user-id": USER_ID}
+    headers = USER_HEADERS
     filename, make_record = _STORE_CASES[kind]
 
     captured = _capture_store(kind)
@@ -111,7 +113,7 @@ def test_captured_store_write_after_deletion_cannot_recreate_data(client, tmp_pa
 
 
 def test_get_stores_during_deletion_waits_for_rmtree_and_sees_empty_state(client, tmp_path, monkeypatch):
-    headers = {"x-user-id": USER_ID}
+    headers = USER_HEADERS
 
     resp = client.post("/api/bin-projects", json={"name": "Old drawer"}, headers=headers)
     assert resp.status_code == 200
@@ -165,7 +167,7 @@ def test_get_stores_during_deletion_waits_for_rmtree_and_sees_empty_state(client
 def test_delete_mid_trace_does_not_recreate_user_dir_or_mask(client, tmp_path, monkeypatch):
     """a trace awaiting its model call must not write the mask (recreating
     the user dir) after the user is deleted mid-flight (issue #160)"""
-    headers = {"x-user-id": USER_ID}
+    headers = USER_HEADERS
     monkeypatch.setattr(settings, "tracers", None)
     monkeypatch.setattr(settings, "google_api_key", "test-key")
     monkeypatch.setattr(settings, "openrouter_api_key", None)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,13 @@
 # API Endpoints
 
+## User namespaces
+
+Standalone installations do not need authentication headers and store data in
+the `default` namespace. Multi-user reverse proxies can set `X-User-Id` only
+when the backend has `PROXY_SECRET` configured and the request includes the
+matching value in `X-Proxy-Secret`. API and storage requests that try to select
+a user namespace without a configured proxy secret receive `403 Forbidden`.
+
 ## Sessions (trace workflow)
 - `POST /api/upload` - upload image, auto-detect corners
 - `POST /api/sessions/{id}/corners` - set corners, apply perspective correction; returns advisory photo warnings (camera too close, paper cut off, extreme perspective)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,11 @@ tracefinity/
 - **BinProject**: a planning group of tool ids and linked bin ids. Placement status is derived from linked bins (`projects.json`). Projects can carry default bin settings used when creating project bins.
 - **Session**: ephemeral, used only for upload/trace workflow. Output is tools saved to library via `save-tools`.
 
+Each record and generated file belongs to a storage namespace. Standalone
+installations always use `default`; trusted multi-user proxies configure
+`PROXY_SECRET` and send both `X-User-Id` and the matching `X-Proxy-Secret`.
+Untrusted clients cannot select arbitrary namespaces when the secret is unset.
+
 PlacedTools sync with their library source on bin load (`GET /bins/{id}`) via `bin_service.sync_placed_tools()`. Edits to a tool's points, finger holes, or name propagate to all bins that use it. The position offset is preserved.
 
 Projects do not own tools or bins. Tools keep `project_ids`, bins keep `project_id`, and project health/repair endpoints keep those links consistent when records are renamed, deleted, or manually edited.


### PR DESCRIPTION
> [!IMPORTANT]
> Standard standalone and configured trusted-proxy deployments are unchanged. Custom proxies that send `X-User-Id` without configuring `PROXY_SECRET` will now receive 403.

## Summary

- reject user namespace selection on API and storage paths unless a trusted proxy secret is configured
- preserve header-free standalone requests, health checks, and authenticated multi-user proxy behavior
- document the namespace contract and exercise existing multi-user tests through it

## Test evidence

- `backend/venv/bin/pytest -q backend/tests/test_proxy_middleware.py backend/tests/test_user_deletion.py` — 13 passed
- `backend/venv/bin/pytest -q backend/tests` — 310 passed
- `make lint` — passed; frontend ESLint reported 9 existing warnings and no errors

Closes #177