### PR TITLE
Limit decoded image size during ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ By default, Tracefinity uses [IS-Net](https://github.com/xuebinqin/DIS) for loca
 |-|-|-|
 | `GOOGLE_API_KEY` | | Gemini API key. Uses Gemini instead of local models |
 | `TRACERS` | auto-detected | Comma-separated list of available tracers, e.g. `gemini,birefnet-lite,isnet` |
+| `MAX_UPLOAD_MB` | `20` | Maximum compressed upload size in megabytes |
+| `MAX_IMAGE_PIXELS` | `64000000` | Maximum decoded pixels accepted before downscaling |
 | `STL_GENERATION_CONCURRENCY` | unlimited | Process-wide maximum STL generation jobs; excess jobs wait up to 5 seconds, then receive 503 |
 | `TRACEFINITY_ONNX_PROVIDER` | `auto` | Local ONNX provider: `auto`, `cuda`, or `cpu` |
 | `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Gemini model for mask generation (see below) |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -68,7 +68,7 @@ from app.services.ai_tracer import AITracer
 from app.services.bin_service import sync_placed_tools
 from app.services.bin_store import BinStore
 from app.services.geometry import optimal_rotation_angle as _optimal_rotation_angle
-from app.services.image_ingest import ingest_image
+from app.services.image_ingest import ImageTooLargeError, ingest_image
 from app.services.image_processor import ImageProcessor
 from app.services.image_service import generate_tool_thumbnail
 from app.services.photo_checks import check_photo, extract_focal_length_35mm
@@ -155,6 +155,20 @@ image_processor = ImageProcessor()
 
 # one AITracer per local model so each can cache its loaded model
 _tracers: dict[str, AITracer] = {}
+
+
+def _ingest_with_limits(
+    content: bytes, ext: str, max_dim: int | None = None
+) -> tuple[bytes, str, float]:
+    try:
+        return ingest_image(
+            content,
+            ext,
+            max_dim,
+            max_pixels=settings.max_image_pixels,
+        )
+    except ImageTooLargeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
 
 
 def _remote_token(tracer_id: str) -> str | None:
@@ -614,7 +628,7 @@ async def upload_image(request: Request, image: UploadFile, user_id: str = Depen
     # exif is dropped when the image is re-encoded, so read it first
     focal_length = extract_focal_length_35mm(content)
 
-    content, ext, _ = ingest_image(content, ext, MAX_UPLOAD_DIM)
+    content, ext, _ = _ingest_with_limits(content, ext, MAX_UPLOAD_DIM)
     image_path = up / "uploads" / f"{session_id}{ext}"
     # the awaited read can outlive a concurrent account deletion; refuse
     # to write into the deleted user's tree
@@ -667,7 +681,7 @@ async def set_corners(request: Request, session_id: str, req: CornersRequest, us
     # pixel→mm conversion stays correct after the image shrinks.
     corrected_bytes = Path(output_path).read_bytes()
     ext = Path(output_path).suffix
-    corrected_bytes, _, ds_ratio = ingest_image(corrected_bytes, ext, MAX_UPLOAD_DIM)
+    corrected_bytes, _, ds_ratio = _ingest_with_limits(corrected_bytes, ext, MAX_UPLOAD_DIM)
     Path(output_path).write_bytes(corrected_bytes)
     if ds_ratio < 1.0:
         scale_factor /= ds_ratio
@@ -818,7 +832,7 @@ async def trace_from_mask(
     mask_ext = Path(mask.filename or "mask.png").suffix.lower() or ".png"
     if mask_ext not in ALLOWED_IMAGE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="unsupported image format")
-    content, mask_ext, _ = ingest_image(content, mask_ext)
+    content, mask_ext, _ = _ingest_with_limits(content, mask_ext)
     mask_path = up / "processed" / f"{session_id}_mask.png"
     # the awaited read can outlive a concurrent account deletion; refuse
     # to write into the deleted user's tree

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     gemini_image_model: str = "gemini-3.1-flash-image-preview"
     gemini_label_model: str = "gemini-2.0-flash"
     max_upload_mb: int = 20
+    max_image_pixels: int = Field(default=64_000_000, gt=0)
     stl_generation_concurrency: Optional[int] = Field(default=None, gt=0)
     log_level: str = "INFO"
     proxy_secret: Optional[str] = None

--- a/backend/app/services/image_ingest.py
+++ b/backend/app/services/image_ingest.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 HEIC_EXTENSIONS = {".heic", ".heif"}
 _ORIENTATION_TAG = 0x0112
+DEFAULT_MAX_IMAGE_PIXELS = 64_000_000
+
+
+class ImageTooLargeError(ValueError):
+    """Raised before decoding an image that exceeds the pixel budget."""
+
 
 try:
     import pillow_heif
@@ -23,14 +29,31 @@ except ImportError:
     pass
 
 
-def ingest_image(content: bytes, ext: str, max_dim: int | None = None) -> tuple[bytes, str, float]:
+def ingest_image(
+    content: bytes,
+    ext: str,
+    max_dim: int | None = None,
+    max_pixels: int = DEFAULT_MAX_IMAGE_PIXELS,
+) -> tuple[bytes, str, float]:
     """normalise an uploaded image. returns (bytes, ext, downscale_ratio).
 
     HEIC becomes JPEG, EXIF orientation is applied to the pixels and the tag
     dropped, and the long edge is capped at max_dim. ratio is <1 when shrunk;
     the long edge lands exactly on max_dim so the ratio is exact for it and
     within half a pixel for the short edge (dimensions are rounded)."""
-    img = Image.open(io.BytesIO(content))
+    try:
+        img = Image.open(io.BytesIO(content))
+    except Image.DecompressionBombError as exc:
+        raise ImageTooLargeError("image dimensions exceed the configured limit") from exc
+
+    w, h = img.size
+    pixels = w * h
+    if pixels > max_pixels:
+        img.close()
+        raise ImageTooLargeError(
+            f"image has {pixels:,} pixels; maximum is {max_pixels:,}"
+        )
+
     changed = False
     new_ext = ext.lower()
 

--- a/backend/tests/test_image_ingest.py
+++ b/backend/tests/test_image_ingest.py
@@ -4,7 +4,7 @@ import io
 import pytest
 from PIL import Image
 
-from app.services.image_ingest import ingest_image
+from app.services.image_ingest import ImageTooLargeError, ingest_image
 
 
 def _jpeg(width: int, height: int, orientation: int | None = None) -> bytes:
@@ -59,6 +59,27 @@ class TestOrientation:
 
 
 class TestDownscale:
+    def test_normalises_pillow_decompression_bomb_error(self, monkeypatch):
+        def reject(*args, **kwargs):
+            raise Image.DecompressionBombError("too many pixels")
+
+        monkeypatch.setattr(Image, "open", reject)
+
+        with pytest.raises(
+            ImageTooLargeError,
+            match="image dimensions exceed the configured limit",
+        ):
+            ingest_image(b"not decoded", ".png")
+
+    def test_rejects_image_over_pixel_limit_before_resize(self):
+        content = _jpeg(11, 10)
+
+        with pytest.raises(
+            ImageTooLargeError,
+            match=r"image has 110 pixels; maximum is 100",
+        ):
+            ingest_image(content, ".jpg", max_dim=8, max_pixels=100)
+
     def test_ratio_matches_actual_resize(self):
         content = _jpeg(2402, 3300)
 

--- a/backend/tests/test_routes_photo_warnings.py
+++ b/backend/tests/test_routes_photo_warnings.py
@@ -61,6 +61,19 @@ def test_upload_without_exif_stores_no_focal_length(tmp_path, monkeypatch):
     assert sessions.get(resp.json()["session_id"]).focal_length_35mm is None
 
 
+def test_upload_rejects_image_over_pixel_limit(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes.settings, "max_image_pixels", 100)
+
+    resp = client.post(
+        "/api/upload",
+        files={"image": ("photo.jpg", _jpeg_bytes(11, 10, None), "image/jpeg")},
+    )
+
+    assert resp.status_code == 413
+    assert resp.json() == {"detail": "image has 110 pixels; maximum is 100"}
+
+
 def test_upload_focal_length_survives_downscale(tmp_path, monkeypatch):
     """exif is stripped when the image is re-encoded; extraction must happen first."""
     client = _client(tmp_path, monkeypatch)

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -59,6 +59,10 @@ docker run --memory=10g -p 3000:3000 -v ./data:/app/storage ghcr.io/tracefinity/
 
 Headroom above the model figures accounts for OpenCV image processing, STL generation, and the Node.js frontend server.
 
+Uploaded photos and masks are rejected before decoding when they exceed 64
+megapixels. Set `MAX_IMAGE_PIXELS` to a positive integer to tune this limit for
+the host's available memory.
+
 STL generation is unlimited by default, preserving the fastest behavior for
 well-provisioned hosts. On memory-constrained or shared hosts, set
 `STL_GENERATION_CONCURRENCY` to a positive integer to cap the number of

--- a/docs/usage/uploading-photos.md
+++ b/docs/usage/uploading-photos.md
@@ -27,7 +27,9 @@ Warnings are advisory: you can dismiss them and continue, but retaking the photo
 
 ## Supported formats
 
-JPG, PNG, WebP, and HEIC. There is no hard file size limit, but large photos take longer to upload and process.
+JPG, PNG, WebP, and HEIC. Uploads are limited to 20 MB and 64 megapixels by
+default. Self-hosted instances can tune these limits with `MAX_UPLOAD_MB` and
+`MAX_IMAGE_PIXELS`.
 
 Images are automatically downscaled to a maximum of 2048px on the longest edge. Original uploads are deleted after perspective correction; only the corrected image is retained.
 


### PR DESCRIPTION
## Summary

- Reject photos and masks above a configurable decoded-pixel limit before pixel data is materialized, preventing small compressed images from consuming hundreds of megabytes.
- Return HTTP 413 for oversized images and document the 64-megapixel default for self-hosted operators.

## Test evidence

- `cd backend && venv/bin/pytest -q` — 312 passed.
- `make lint` — passed; frontend reported 9 existing warnings and no errors.
- A 420 KB, 144-megapixel PNG proof case was rejected before decode with about 26 MB maximum RSS, down from about 720 MB before the fix.

Closes #178