### PR TITLE
ci: fail on next-env.d.ts drift via next typegen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,7 @@ jobs:
         with:
           version: 10
       - run: cd frontend && pnpm install --frozen-lockfile
+      - run: cd frontend && pnpm exec next typegen
+      - run: git diff --exit-code -- frontend/next-env.d.ts
       - run: cd frontend && pnpm run lint
       - run: cd frontend && pnpm exec tsc --noEmit


### PR DESCRIPTION
The frontend build regenerates next-env.d.ts inside the runner, so a stale committed copy never surfaced in CI (as happened after the next 16.3.1 bump in #182).

Adds two steps to the frontend lint job: run `next typegen` (generates route types without a full build) then `git diff --exit-code -- frontend/next-env.d.ts`. Fails the PR if the committed generated file drifts.

Validated locally: typegen on clean main reproduces the committed file exactly (gate passes); on the pre-fix drift it fails.