### PR TITLE
fix: make traced outlines visible on the select tools step

### DIFF
--- a/frontend/src/components/PolygonEditor.tsx
+++ b/frontend/src/components/PolygonEditor.tsx
@@ -6,7 +6,7 @@ import { Undo2, Redo2, Trash2, Plus, Minus, Move } from 'lucide-react'
 import { polygonPathData } from '@/lib/svg'
 import { useHistory } from '@/hooks/useHistory'
 import { ZOOM_FACTOR } from '@/lib/constants'
-import { clampZoom, zoomedViewBox, viewBoxPoint, zoomAtCursor } from '@/lib/viewbox'
+import { clampZoom, zoomedViewBox, viewBoxPoint, zoomAtCursor, uiScaleFor } from '@/lib/viewbox'
 
 interface Props {
   imageUrl: string
@@ -18,8 +18,6 @@ interface Props {
   hovered?: string | null
   onHoveredChange?: (id: string | null) => void
 }
-// fallback only, used until the rendered size has been measured
-const BASE_VIEW_WIDTH = 800
 // dark halo painted under outlines so they stay legible over photographs
 const HALO_STROKE = 'rgba(2, 6, 23, 0.55)'
 
@@ -51,15 +49,9 @@ export function PolygonEditor({
   const panRef = useRef(pan)
   useEffect(() => { zoomRef.current = zoom }, [zoom])
   useEffect(() => { panRef.current = pan }, [pan])
-  // one uiScale unit == one CSS pixel on screen. derived from the rendered size,
-  // not a fixed width: a portrait image is height-constrained, so the canvas is
-  // far narrower than BASE_VIEW_WIDTH and assuming otherwise gives sub-pixel
-  // strokes. divided by zoom so handles and strokes keep a constant size.
-  const uiScale = (
-    fitted.width > 0
-      ? imageSize.width / fitted.width
-      : imageSize.width > 0 ? imageSize.width / BASE_VIEW_WIDTH : 1
-  ) / zoom
+  // fitted is the measured size of the box the viewBox paints into, so one
+  // uiScale unit lands as one CSS pixel regardless of image aspect
+  const uiScale = uiScaleFor(imageSize.width, fitted.width, zoom)
 
   // active polygon for vertex editing (internal)
   const [activeId, setActiveId] = useState<string | null>(null)

--- a/frontend/src/components/PolygonEditor.tsx
+++ b/frontend/src/components/PolygonEditor.tsx
@@ -18,8 +18,10 @@ interface Props {
   hovered?: string | null
   onHoveredChange?: (id: string | null) => void
 }
-// base sizes for SVG UI elements, designed for ~800px viewBox width
+// fallback only, used until the rendered size has been measured
 const BASE_VIEW_WIDTH = 800
+// dark halo painted under outlines so they stay legible over photographs
+const HALO_STROKE = 'rgba(2, 6, 23, 0.55)'
 
 type EditMode = 'select' | 'vertex' | 'add-vertex' | 'delete-vertex'
 type DragState =
@@ -49,9 +51,15 @@ export function PolygonEditor({
   const panRef = useRef(pan)
   useEffect(() => { zoomRef.current = zoom }, [zoom])
   useEffect(() => { panRef.current = pan }, [pan])
-  // scale UI elements relative to image size so they're visible on large photos;
-  // divided by zoom so handles and strokes keep a constant on-screen size
-  const uiScale = (imageSize.width > 0 ? imageSize.width / BASE_VIEW_WIDTH : 1) / zoom
+  // one uiScale unit == one CSS pixel on screen. derived from the rendered size,
+  // not a fixed width: a portrait image is height-constrained, so the canvas is
+  // far narrower than BASE_VIEW_WIDTH and assuming otherwise gives sub-pixel
+  // strokes. divided by zoom so handles and strokes keep a constant size.
+  const uiScale = (
+    fitted.width > 0
+      ? imageSize.width / fitted.width
+      : imageSize.width > 0 ? imageSize.width / BASE_VIEW_WIDTH : 1
+  ) / zoom
 
   // active polygon for vertex editing (internal)
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -507,8 +515,8 @@ export function PolygonEditor({
             const isHovered = hovered === poly.id
             const pathData = polygonPathData(poly.points, poly.interior_rings)
 
-            let fill = 'rgba(90, 180, 222, 0.06)'
-            let stroke = 'rgba(90, 180, 222, 0.4)'
+            let fill = 'rgba(90, 180, 222, 0.08)'
+            let stroke = 'rgba(90, 180, 222, 0.85)'
             let strokeW = uiScale * 1
             if (isActive) {
               fill = 'rgba(90, 180, 222, 0.3)'
@@ -526,6 +534,14 @@ export function PolygonEditor({
 
             return (
               <g key={poly.id}>
+                <path
+                  d={pathData}
+                  fillRule="evenodd"
+                  fill="none"
+                  stroke={HALO_STROKE}
+                  strokeWidth={strokeW + uiScale * 1.5}
+                  className="pointer-events-none"
+                />
                 <path
                   d={pathData}
                   fillRule="evenodd"

--- a/frontend/src/lib/viewbox.test.ts
+++ b/frontend/src/lib/viewbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { clampZoom, zoomedViewBox, viewBoxPoint, zoomAtCursor, MIN_ZOOM, MAX_ZOOM } from './viewbox'
+import { clampZoom, zoomedViewBox, viewBoxPoint, zoomAtCursor, uiScaleFor, MIN_ZOOM, MAX_ZOOM, BASE_VIEW_WIDTH } from './viewbox'
 import { ZOOM_FACTOR } from './constants'
 
 const W = 2048
@@ -86,5 +86,52 @@ describe('zoomAtCursor', () => {
     const newPan = zoomAtCursor(W, H, 2, 4, { x: 15, y: -5 }, 0.5, 0.5)
     expect(newPan.x).toBeCloseTo(15, 8)
     expect(newPan.y).toBeCloseTo(-5, 8)
+  })
+})
+
+describe('uiScaleFor', () => {
+  // the bug: a portrait A4 photo is height-constrained, so the canvas renders
+  // far narrower than BASE_VIEW_WIDTH and a 1px stroke came out at ~0.53px
+  const IMG_W = 1505
+  const RENDERED_W = 426
+
+  function onScreenPx(units: number, imageWidth: number, renderedWidth: number): number {
+    return units * (renderedWidth / imageWidth)
+  }
+
+  it('renders one unit as one CSS pixel at zoom 1', () => {
+    const scale = uiScaleFor(IMG_W, RENDERED_W, 1)
+    expect(onScreenPx(scale * 1, IMG_W, RENDERED_W)).toBeCloseTo(1, 8)
+  })
+
+  it('holds on-screen size across zoom levels', () => {
+    for (const zoom of [0.5, 1, 2.5, 8, 20]) {
+      const scale = uiScaleFor(IMG_W, RENDERED_W, zoom)
+      const visibleWidth = IMG_W / zoom
+      expect(onScreenPx(scale * 1, visibleWidth, RENDERED_W)).toBeCloseTo(1, 8)
+    }
+  })
+
+  it('holds on-screen size regardless of image aspect', () => {
+    const portrait = uiScaleFor(1505, 426, 1)
+    const landscape = uiScaleFor(2048, 1200, 1)
+    expect(onScreenPx(portrait, 1505, 426)).toBeCloseTo(1, 8)
+    expect(onScreenPx(landscape, 2048, 1200)).toBeCloseTo(1, 8)
+  })
+
+  it('beats the old fixed-width assumption for a narrow canvas', () => {
+    const old = IMG_W / BASE_VIEW_WIDTH
+    expect(onScreenPx(old, IMG_W, RENDERED_W)).toBeLessThan(0.6)
+    expect(onScreenPx(uiScaleFor(IMG_W, RENDERED_W, 1), IMG_W, RENDERED_W)).toBeCloseTo(1, 8)
+  })
+
+  it('falls back to the fixed width before the render is measured', () => {
+    expect(uiScaleFor(IMG_W, 0, 1)).toBeCloseTo(IMG_W / BASE_VIEW_WIDTH, 8)
+  })
+
+  it('never returns zero or a negative scale', () => {
+    expect(uiScaleFor(0, 0, 1)).toBe(1)
+    expect(uiScaleFor(IMG_W, RENDERED_W, 0)).toBe(1)
+    expect(uiScaleFor(IMG_W, RENDERED_W, -1)).toBe(1)
   })
 })

--- a/frontend/src/lib/viewbox.ts
+++ b/frontend/src/lib/viewbox.ts
@@ -46,3 +46,18 @@ export function zoomAtCursor(
   const next = viewBoxPoint(zoomedViewBox(width, height, newZoom, pan), fx, fy)
   return { x: pan.x + (cur.x - next.x), y: pan.y + (cur.y - next.y) }
 }
+
+// fallback view width, used only until the rendered size has been measured
+export const BASE_VIEW_WIDTH = 800
+
+// scale factor that makes one SVG user unit render as one CSS pixel.
+// renderedWidth must be the measured width of the element the viewBox is
+// painted into: a portrait image is height-constrained, so assuming a fixed
+// view width gives sub-pixel strokes and handles. divided by zoom so both keep
+// a constant on-screen size as the viewBox shrinks.
+export function uiScaleFor(imageWidth: number, renderedWidth: number, zoom: number): number {
+  if (zoom <= 0) return 1
+  if (renderedWidth > 0 && imageWidth > 0) return imageWidth / renderedWidth / zoom
+  if (imageWidth > 0) return imageWidth / BASE_VIEW_WIDTH / zoom
+  return 1 / zoom
+}


### PR DESCRIPTION
Fixes #185.

## Problem

`uiScale` normalised SVG stroke and handle sizes against a hardcoded 800px view width. That assumption fails for portrait images: the canvas is height-constrained, so it renders far narrower than 800px and everything scaled off `uiScale` came out proportionally too small.

Measured on a 1505x2048 corrected image at a normal laptop viewport:

| | before | after |
|-|-|-|
| rendered canvas | 426 x 580 CSS px | unchanged |
| `uiScale` | 1.88125 | 3.533 |
| `strokeWidth` on screen | 0.53 px | 1.00 px |
| unselected stroke alpha | 0.4 | 0.85 |
| halo | none | 2.5 px at 0.55 |

A 0.53px line at 40% opacity over a photograph is not visible. The Select Tools step tells you to click the outlines and keeps the save button disabled until you do, so the flow dead-ends with no way forward on the canvas.

## Change

- Derive `uiScale` from the measured rendered width (`fitted.width`) instead of `BASE_VIEW_WIDTH`, so one unit is one CSS pixel at zoom 1. `BASE_VIEW_WIDTH` stays as the fallback until the size has been measured.
- Raise unselected stroke opacity from 0.4 to 0.85 and fill from 0.06 to 0.08.
- Paint a dark halo under every outline so it stays legible against arbitrary photographic backgrounds.

## Side effect worth knowing

`uiScale` also drives vertex handles, vertex hit targets and edge hit targets. Those were undersized by the same factor and are now correct, which means they change size on every layout, not just the broken one. Where the canvas currently renders wider than 800px they get slightly smaller than before, because they now hold a true constant on-screen size rather than growing with the image.

## Verification

- `tsc --noEmit` clean.
- `eslint` clean on all three changed files. Repo warning count unchanged.
- `next build` succeeds.
- `vitest run`: 9 files, 105 tests pass, up from 99. The 5 jsdom module-resolution errors reproduce on `main` with these changes stashed, so they are pre-existing and unrelated. They are also why there is no render test here: every jsdom-environment test file in the repo currently fails to load.
- Verified visually by patching the computed values into a rendered editor and screenshotting. All four outlines legible where none were before.

## Tests

The scale calculation was inline in the component with no way to assert it, so the second commit moves it to `viewbox.ts` as `uiScaleFor` and pins the behaviour:

- one unit renders as one CSS pixel at zoom 1
- on-screen size holds across zoom levels (0.5 to 20) and across image aspects
- falls back to the fixed width before the render has been measured
- never returns zero or a negative scale

Plus a direct regression test: the old fixed-width assumption produces under 0.6px for a narrow canvas, which is the bug.
