### PR TITLE
fix: stop discarding failed bin saves silently, log 422 detail

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
 
       - name: Install backend
         run: cd backend && python -m venv venv && . venv/bin/activate && pip install -r requirements.txt
@@ -27,8 +29,25 @@ jobs:
       - name: Install frontend
         run: cd frontend && pnpm install --frozen-lockfile
 
+      # browsers are re-downloaded every run without this, and --with-deps
+      # shells out to apt, which can stall indefinitely. the step timeout turns
+      # that into an honest failure instead of eating the whole job budget
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+
       - name: Install Playwright
-        run: cd frontend && pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 5
+        run: |
+          cd frontend
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            pnpm exec playwright install chromium
+          else
+            pnpm exec playwright install --with-deps chromium
+          fi
 
       - name: Run tests
         run: cd frontend && pnpm exec playwright test

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,8 @@ import logging
 from posixpath import normpath
 
 from fastapi import FastAPI
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -36,6 +38,21 @@ async def _store_closed_handler(request: Request, exc: StoreClosedError):
     # an in-flight request lost the race against user deletion; the data
     # it targets is gone for good
     return JSONResponse(status_code=410, content={"detail": "user data deleted"})
+
+
+@app.exception_handler(RequestValidationError)
+async def _validation_handler(request: Request, exc: RequestValidationError):
+    # a 422 is otherwise invisible in the access log, which makes a client
+    # sending a bad payload impossible to diagnose after the fact. log where
+    # it failed and why, never the value itself: payloads carry user data
+    where = ", ".join(
+        f"{'.'.join(str(p) for p in e.get('loc', ()))}: {e.get('type', 'unknown')}"
+        for e in exc.errors()
+    )
+    logging.getLogger("app.validation").warning(
+        "422 %s %s -> %s", request.method, request.url.path, where or "no detail"
+    )
+    return await request_validation_exception_handler(request, exc)
 
 
 @app.on_event("startup")

--- a/backend/tests/test_validation_logging.py
+++ b/backend/tests/test_validation_logging.py
@@ -1,0 +1,48 @@
+"""a 422 is invisible in the access log unless the detail is recorded."""
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+def test_validation_failure_logs_field_and_type(client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.validation"):
+        resp = client.put(
+            "/api/bins/does-not-exist",
+            json={"bin_config": {"wall_thickness": None}},
+        )
+
+    assert resp.status_code == 422
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "422 PUT /api/bins/does-not-exist" in logged
+    assert "wall_thickness" in logged
+    assert "float_type" in logged
+
+
+def test_validation_log_does_not_record_the_value(client, caplog):
+    # payloads carry user data, so the offending value must never be logged
+    with caplog.at_level(logging.WARNING, logger="app.validation"):
+        client.put(
+            "/api/bins/does-not-exist",
+            json={"name": {"secret": "do-not-log-me"}},
+        )
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "do-not-log-me" not in logged
+    assert "name" in logged
+
+
+def test_valid_payload_logs_nothing(client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.validation"):
+        resp = client.put("/api/bins/does-not-exist", json={"name": "fine"})
+
+    assert resp.status_code != 422
+    assert [r for r in caplog.records if r.name == "app.validation"] == []

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -9,7 +9,7 @@ import { ToolBrowser } from '@/components/ToolBrowser'
 import { getBin, updateBin, generateBinStl, getBinStlUrl, getBinZipUrl, getBinThreemfUrl, getBinInsertUrl, getImageUrl, listTools, updateTool } from '@/lib/api'
 import { buildBinConfig, createPartialBinsValues, getDefaultBinConfig, resetDefaultBinConfig, saveDefaultBinConfig } from '@/lib/binDefaults'
 import type { BinConfig, BinData, PlacedTool, TextLabel } from '@/types'
-import { Download, Loader2, Package, ChevronDown, Check } from 'lucide-react'
+import { Download, Loader2, Package, ChevronDown, Check, TriangleAlert } from 'lucide-react'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { Alert } from '@/components/Alert'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
@@ -166,15 +166,15 @@ export default function BinPage() {
     doGenerateRef.current = doGenerate
   }, [doGenerate])
 
-  const { saving, saved } = useDebouncedSave(
-    () => {
+  const { saving, saved, error: saveError } = useDebouncedSave(
+    async () => {
       if (!binData) return
-      updateBin(binId, {
+      await updateBin(binId, {
         name: name || undefined,
         bin_config: config,
         placed_tools: placedTools,
         text_labels: textLabels,
-      }).catch(() => {})
+      })
     },
     [binData, binId, name, config, placedTools, textLabels],
     150,
@@ -389,8 +389,19 @@ export default function BinPage() {
                 { label: name || 'Untitled', editable: true, onEdit: (v) => setName(v) },
               ]} />
               {saving && <Loader2 className="w-3 h-3 animate-spin text-text-muted flex-shrink-0" />}
-              {saved && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
+              {saved && !saveError && <Check className="w-3 h-3 text-green-400 flex-shrink-0" />}
+              {saveError && !saving && (
+                <TriangleAlert
+                  className="w-3 h-3 text-red-400 flex-shrink-0"
+                  aria-label="Changes not saved"
+                />
+              )}
             </div>
+            {saveError && (
+              <div role="alert" className="mb-3 rounded-[8px] border border-red-800 bg-red-900/20 px-2 py-1.5 text-[11px] text-red-300">
+                Changes are not being saved. Recent edits to this bin will be lost if you leave the page.
+              </div>
+            )}
             <BinConfigurator config={config} onChange={setConfig} autoSize={autoSize} onAutoSizeChange={setAutoSize} />
             <div className="mt-3 border-t border-border pt-3 space-y-1.5">
               <div className="flex gap-1.5">

--- a/frontend/src/hooks/__tests__/useDebouncedSave.test.ts
+++ b/frontend/src/hooks/__tests__/useDebouncedSave.test.ts
@@ -69,4 +69,56 @@ describe('useDebouncedSave', () => {
 
     vi.useRealTimers()
   })
+
+  it('surfaces a failed save instead of swallowing it', async () => {
+    const saveFn = vi.fn().mockRejectedValue(new Error('422 bin_config.wall_thickness'))
+    let dep = 0
+    const { result, rerender } = renderHook(() => useDebouncedSave(saveFn, [dep], 50))
+
+    dep = 1
+    rerender()
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 80))
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error?.message).toContain('wall_thickness')
+    expect(result.current.saved).toBe(false)
+    expect(result.current.saving).toBe(false)
+  })
+
+  it('does not count a failed save as saved', async () => {
+    const saveFn = vi.fn().mockRejectedValue(new Error('nope'))
+    let dep = 0
+    const { result, rerender } = renderHook(() => useDebouncedSave(saveFn, [dep], 50))
+
+    dep = 1
+    rerender()
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 80))
+    })
+
+    expect(result.current.saveCount).toBe(0)
+  })
+
+  it('clears the error once a later save succeeds', async () => {
+    const saveFn = vi.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce(undefined)
+    let dep = 0
+    const { result, rerender } = renderHook(() => useDebouncedSave(saveFn, [dep], 50))
+
+    dep = 1
+    rerender()
+    await act(async () => { await new Promise(r => setTimeout(r, 80)) })
+    expect(result.current.error).not.toBeNull()
+
+    dep = 2
+    rerender()
+    await act(async () => { await new Promise(r => setTimeout(r, 80)) })
+    expect(result.current.error).toBeNull()
+    expect(result.current.saveCount).toBe(1)
+  })
 })

--- a/frontend/src/hooks/useDebouncedSave.ts
+++ b/frontend/src/hooks/useDebouncedSave.ts
@@ -5,10 +5,11 @@ export function useDebouncedSave(
   deps: unknown[],
   delay: number = 150,
   options?: { skipInitial?: boolean }
-): { saving: boolean; saved: boolean; saveCount: number } {
+): { saving: boolean; saved: boolean; saveCount: number; error: Error | null } {
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [saveCount, setSaveCount] = useState(0)
+  const [error, setError] = useState<Error | null>(null)
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const pendingSaveRef = useRef<(() => void) | null>(null)
   const savedTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -34,10 +35,12 @@ export function useDebouncedSave(
         await saveFnRef.current()
         setSaveCount(c => c + 1)
         setSaved(true)
+        setError(null)
         if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
         savedTimerRef.current = setTimeout(() => setSaved(false), 2000)
-      } catch {
-        // ignore
+      } catch (err) {
+        // surfaced to the caller: a silent failure looks identical to a save
+        setError(err instanceof Error ? err : new Error('save failed'))
       } finally {
         setSaving(false)
       }
@@ -61,5 +64,5 @@ export function useDebouncedSave(
     return () => window.removeEventListener('beforeunload', flush)
   }, [])
 
-  return { saving, saved, saveCount }
+  return { saving, saved, saveCount, error }
 }


### PR DESCRIPTION
Re #186.

Adds additional logging: a 422 now records the failing field and error type rather than just a status code. Never the value.

Also stops the bin editor discarding failed saves. The page dropped the promise and the hook swallowed the rejection, so a failed autosave showed the same green tick as a success.

Does not identify the 422 trigger.
