### PR TITLE
Replace the grid clamp with resource-aware limits

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 from app.auth import get_user_id
 from app.config import ensure_user_dirs, settings
-from app.constants import GF_GRID
+from app.constants import GF_GRID, MAX_BIN_GRID_CELLS, MAX_BIN_GRID_UNITS
 from app.models.schemas import (
     BinConfig,
     BinDefaults,
@@ -409,8 +409,18 @@ def _build_bin_from_tools(
         else:
             grid_x = max(1.0, math.ceil(needed_w / GF_GRID))
             grid_y = max(1.0, math.ceil(needed_h / GF_GRID))
-        bc.grid_x = min(grid_x, 10.0)
-        bc.grid_y = min(grid_y, 10.0)
+        grid_cells = math.ceil(grid_x) * math.ceil(grid_y)
+        if grid_x > MAX_BIN_GRID_UNITS or grid_y > MAX_BIN_GRID_UNITS or grid_cells > MAX_BIN_GRID_CELLS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"selected tools require a {grid_x:g}x{grid_y:g} grid ({grid_cells} cells); "
+                    f"bins support up to {MAX_BIN_GRID_UNITS:g} units per axis and "
+                    f"{MAX_BIN_GRID_CELLS} cells total"
+                ),
+            )
+        bc.grid_x = grid_x
+        bc.grid_y = grid_y
         bc.partial_bins_values = [True] * (math.ceil(bc.grid_x) * math.ceil(bc.grid_y))
 
         bin_w = bc.grid_x * GF_GRID
@@ -1884,4 +1894,3 @@ def storage_stats(request: Request):
             raise HTTPException(status_code=403)
 
     return _storage_stats_snapshot(settings.storage_path)
-

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -2,6 +2,12 @@ from typing import Literal
 
 GF_GRID = 42.0
 
+# Bin geometry is generated in full before bed-size splitting. Keep the
+# resource ceiling tied to total grid cells while allowing long, narrow bins.
+MIN_BIN_GRID_UNITS = 1.0
+MAX_BIN_GRID_UNITS = 25.0
+MAX_BIN_GRID_CELLS = 100
+
 PaperSize = Literal["a4", "letter", "a3", "tabloid"]
 
 PAPER_SIZES: dict[PaperSize, tuple[float, float]] = {

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,7 +46,8 @@ async def _validation_handler(request: Request, exc: RequestValidationError):
     # sending a bad payload impossible to diagnose after the fact. log where
     # it failed and why, never the value itself: payloads carry user data
     where = ", ".join(
-        f"{'.'.join(str(p) for p in e.get('loc', ()))}: {e.get('type', 'unknown')}"
+        f"{'.'.join(str(p) for p in e.get('loc', ()))}: "
+        f"{e.get('type', 'unknown')} ({e.get('msg', 'no message')})"
         for e in exc.errors()
     )
     logging.getLogger("app.validation").warning(

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import math
 from typing import Literal
 
 from pydantic import BaseModel, field_validator, model_validator
 
-from app.constants import PaperSize
+from app.constants import (
+    MAX_BIN_GRID_CELLS,
+    MAX_BIN_GRID_UNITS,
+    MIN_BIN_GRID_UNITS,
+    PaperSize,
+)
 
 
 class Point(BaseModel):
@@ -105,9 +111,11 @@ class BinParams(BaseModel):
 
     @model_validator(mode="after")
     def normalize_partial_bins_values(self) -> "BinParams":
-        import math
-
         expected = math.ceil(self.grid_x) * math.ceil(self.grid_y)
+        if expected > MAX_BIN_GRID_CELLS:
+            raise ValueError(
+                f"grid footprint must not exceed {MAX_BIN_GRID_CELLS} cells"
+            )
         if len(self.partial_bins_values) != expected:
             self.partial_bins_values = [True] * expected
         if not self.partial_bins_connect:
@@ -119,9 +127,10 @@ class BinParams(BaseModel):
     @field_validator("grid_x", "grid_y")
     @classmethod
     def validate_grid(cls, v: float) -> float:
-        if v < 1 or v > 10:
-            raise ValueError("grid size must be between 1 and 10")
-        # must be a multiple of 0.5
+        if v < MIN_BIN_GRID_UNITS:
+            raise ValueError(f"grid size must be at least {MIN_BIN_GRID_UNITS:g} unit")
+        if v > MAX_BIN_GRID_UNITS:
+            raise ValueError(f"grid size must not exceed {MAX_BIN_GRID_UNITS:g} units per axis")
         if v * 2 != int(v * 2):
             raise ValueError("grid size must be a multiple of 0.5")
         return v

--- a/backend/app/services/drawer_service.py
+++ b/backend/app/services/drawer_service.py
@@ -32,7 +32,7 @@ def _min_grid_for_size(
     else:
         gx = max(1.0, math.ceil(needed_w / GF_GRID))
         gy = max(1.0, math.ceil(needed_h / GF_GRID))
-    return min(gx, 10.0), min(gy, 10.0)
+    return gx, gy
 
 
 def _min_grid_bbox(

--- a/backend/tests/test_build_bin_centering.py
+++ b/backend/tests/test_build_bin_centering.py
@@ -10,6 +10,7 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 
 from app.constants import GF_GRID
 from app.models.schemas import FingerHole, Point, Tool
@@ -80,6 +81,30 @@ class TestBuildBinCentering:
 
         assert placed_cx == pytest.approx(bin_cx, abs=0.1)
         assert placed_cy == pytest.approx(bin_cy, abs=0.1)
+
+    def test_long_narrow_tool_uses_more_than_ten_grid_units(self):
+        from app.api.routes import _build_bin_from_tools
+
+        tool = _make_tool([(0, 0), (600, 0), (600, 20), (0, 20)])
+        store = _mock_tool_store({tool.id: tool})
+
+        result = _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+
+        assert result.bin_config.grid_x == 15
+        assert result.bin_config.grid_y == 1
+
+    def test_tool_layout_over_resource_limit_is_rejected_instead_of_clipped(self):
+        from app.api.routes import _build_bin_from_tools
+
+        tool = _make_tool([(0, 0), (1050, 0), (1050, 20), (0, 20)])
+        store = _mock_tool_store({tool.id: tool})
+
+        with pytest.raises(HTTPException) as exc_info:
+            _build_bin_from_tools("bin1", "test", None, [tool.id], store)
+
+        assert exc_info.value.status_code == 422
+        assert "require a 26x1 grid" in exc_info.value.detail
+        assert "25 units per axis" in exc_info.value.detail
 
     def test_rotated_tool_is_centred_in_bin(self):
         """tool rotated around centroid (bbox no longer at origin) -> still centred."""

--- a/backend/tests/test_half_grid.py
+++ b/backend/tests/test_half_grid.py
@@ -34,13 +34,26 @@ def test_grid_rejects_non_half_increment():
 
 
 def test_grid_rejects_below_minimum():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="at least 1 unit"):
         BinParams(grid_x=0.5)
 
 
 def test_grid_rejects_above_maximum():
-    with pytest.raises(ValidationError):
-        BinParams(grid_x=10.5)
+    with pytest.raises(ValidationError, match="not exceed 25 units per axis"):
+        BinParams(grid_x=25.5)
+
+
+@pytest.mark.parametrize(("grid_x", "grid_y"), [(20, 5), (25, 4), (10.5, 9)])
+def test_grid_accepts_long_narrow_footprints(grid_x: float, grid_y: float):
+    params = BinParams(grid_x=grid_x, grid_y=grid_y)
+    assert params.grid_x == grid_x
+    assert params.grid_y == grid_y
+
+
+@pytest.mark.parametrize(("grid_x", "grid_y"), [(20, 5.5), (10.5, 10), (25, 4.5)])
+def test_grid_rejects_footprints_over_100_cells(grid_x: float, grid_y: float):
+    with pytest.raises(ValidationError, match="footprint must not exceed 100 cells"):
+        BinParams(grid_x=grid_x, grid_y=grid_y)
 
 
 # ── cell layout ──────────────────────────────────────────────────────────────

--- a/backend/tests/test_validation_logging.py
+++ b/backend/tests/test_validation_logging.py
@@ -27,6 +27,19 @@ def test_validation_failure_logs_field_and_type(client, caplog):
     assert "float_type" in logged
 
 
+def test_validation_failure_logs_the_specific_rule(client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.validation"):
+        resp = client.put(
+            "/api/bins/does-not-exist",
+            json={"bin_config": {"grid_x": 25.5}},
+        )
+
+    assert resp.status_code == 422
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "grid_x" in logged
+    assert "grid size must not exceed 25 units per axis" in logged
+
+
 def test_validation_log_does_not_record_the_value(client, caplog):
     # payloads carry user data, so the offending value must never be logged
     with caplog.at_level(logging.WARNING, logger="app.validation"):

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,7 +48,7 @@ Reference for AI agents. Check here before suggesting new features or claiming s
 
 ## Bin Configuration
 
-- Grid sizing (width/depth in gridfinity units, 1-10, 0.5-unit increments for 21mm half-grid)
+- Grid sizing (width/depth in gridfinity units, 1-25 per axis and 100 cells total, with 0.5-unit increments for 21mm half-grid)
 - Bin height in units (7mm each + 4.75mm base)
 - Cutout depth (5mm to max)
 - Clearance (0-5mm extra space around tools)

--- a/docs/resource-requirements.md
+++ b/docs/resource-requirements.md
@@ -71,6 +71,10 @@ and then receive a 503 busy response; for example,
 `-e STL_GENERATION_CONCURRENCY=1` serializes generation and minimizes peak
 memory use. The limit is process-wide.
 
+Bin geometry is limited to a 100-cell grid footprint and 25 units per axis. The
+full manifold is generated before bed-size splitting, so printer bed size does
+not reduce peak generation memory.
+
 ### Kubernetes / Helm
 
 Set `resources.requests.memory` to match the tracer. Example for IS-Net:

--- a/docs/stl-generation.md
+++ b/docs/stl-generation.md
@@ -103,9 +103,19 @@ For NxM bins multiply grid centres by `(ix - (N-1)/2) * 42`.
 grid_units = ceil((tool_dimension + 2*wall + 2*clearance + 0.5) / 42)
 ```
 
+Each axis is limited to 25 grid units and the footprint to
+`ceil(grid_x) * ceil(grid_y) <= 100`. The footprint limit bounds geometry
+generation cost while still allowing long, narrow bins. Auto-size reports the
+required dimensions rather than silently shrinking layouts that exceed either
+limit.
+
 ## Bin Splitting
 
 Large bins are split along grid boundaries using manifold3d `split_by_plane`. Diagonal fit check: `(W + H) / sqrt(2) <= bed_size`. Split parts exported as ZIP.
+
+The full bin manifold is generated before splitting, so bed size controls the
+exported piece size rather than the maximum logical bin size or generation
+resource use.
 
 With partial bins in cut mode, separated islands are exported via `decompose` instead of plane cuts when connect mode is off. With connect mode on, bed splitting measures against the full grid size. See **Partial bins** above.
 

--- a/docs/usage/bin-configuration.md
+++ b/docs/usage/bin-configuration.md
@@ -6,8 +6,8 @@ Gridfinity is a modular storage system where bins snap into a baseplate grid. Ea
 
 | Setting | Range | Default | Notes |
 |-|-|-|-|
-| Grid width | 1-10 u | 2 | Each unit is 42mm |
-| Grid depth | 1-10 u | 2 | |
+| Grid width | 1-25 u | 2 | Each unit is 42mm; the grid footprint is limited to 100 cells |
+| Grid depth | 1-25 u | 2 | The available maximum adjusts with the width |
 | Height | 1-20 u | 4 | Each unit is 7mm + 4.75mm base |
 | Cutout depth | 5mm-max | 20mm | Max depends on height and stacking lip |
 | Clearance | 0-5mm | 1.0mm | Gap around tool outlines |
@@ -39,6 +39,8 @@ Gridfinity is a modular storage system where bins snap into a baseplate grid. Ea
 ## Auto grid sizing
 
 On by default. When enabled, grid width and depth automatically adjust to fit all placed tools, and the grid width/depth sliders are disabled. Toggle it off to set grid size manually; the sliders become active again.
+
+Bins can be up to 25 units on either axis with a 100-cell grid footprint. Long, narrow bins are supported and are split according to the configured bed size. If an auto-sized layout exceeds either safety limit, Tracefinity keeps saving the tool placement but pauses preview and export until the tools are reduced or rearranged.
 
 ## Default bin settings
 

--- a/docs/usage/bin-layout.md
+++ b/docs/usage/bin-layout.md
@@ -70,7 +70,7 @@ The sidebar controls all bin parameters:
 
 | Setting | Description |
 |-|-|
-| Grid Width / Depth | Bin size in gridfinity units (42mm each). 1-10. |
+| Grid Width / Depth | Bin size in gridfinity units (42mm each). 1-25 per axis, up to a 100-cell footprint. |
 | Height | Bin height in units (7mm each + 4.75mm base). |
 | Cutout Depth | How deep tool pockets are cut. |
 | Clearance | Extra space around tool outlines. |

--- a/frontend/src/app/bins/[id]/page.tsx
+++ b/frontend/src/app/bins/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { BinEditor } from '@/components/BinEditor'
 import { BinConfigurator, calcMaxCutoutDepth } from '@/components/BinConfigurator'
@@ -14,7 +14,14 @@ import { Breadcrumb } from '@/components/Breadcrumb'
 import { Alert } from '@/components/Alert'
 import { useDebouncedSave } from '@/hooks/useDebouncedSave'
 import { useProjectSource } from '@/hooks/useProjectSource'
-import { GRID_UNIT, clampGridSize } from '@/lib/constants'
+import {
+  getGridSizeError,
+  gridCellCount,
+  GRID_UNIT,
+  MAX_GRID_CELLS,
+  MAX_GRID_UNITS,
+  requiredGridUnits,
+} from '@/lib/constants'
 import { useTheme } from '@/hooks/useTheme'
 import { cn } from '@/lib/utils'
 
@@ -64,6 +71,38 @@ export default function BinPage() {
   const [defaultsStatus, setDefaultsStatus] = useState<string | null>(null)
   const defaultsStatusTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const exportRef = useRef<HTMLDivElement>(null)
+
+  const requiredGridSize = useMemo(() => {
+    if (!autoSize || placedTools.length === 0) return null
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const tool of placedTools) {
+      for (const point of tool.points) {
+        minX = Math.min(minX, point.x)
+        minY = Math.min(minY, point.y)
+        maxX = Math.max(maxX, point.x)
+        maxY = Math.max(maxY, point.y)
+      }
+    }
+
+    const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25
+    const totalMargin = 2 * halfMargin
+    return {
+      x: requiredGridUnits(maxX - minX, totalMargin, config.half_grid_base),
+      y: requiredGridUnits(maxY - minY, totalMargin, config.half_grid_base),
+      minX,
+      minY,
+      maxX,
+      maxY,
+    }
+  }, [autoSize, placedTools, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
+
+  const requiredGridError = requiredGridSize
+    ? getGridSizeError(requiredGridSize.x, requiredGridSize.y)
+    : null
+  const gridLimitError = requiredGridSize && requiredGridError
+    ? `Layout requires ${requiredGridSize.x}×${requiredGridSize.y} grid units (${gridCellCount(requiredGridSize.x, requiredGridSize.y)} cells). The maximum is ${MAX_GRID_UNITS} units per axis and ${MAX_GRID_CELLS} cells total. Reduce or rearrange the tools; preview and export are paused, but edits continue to save.`
+    : null
 
   useEffect(() => {
     if (!exportOpen) return
@@ -117,7 +156,7 @@ export default function BinPage() {
   }, [binId])
 
   const doGenerate = useCallback(async () => {
-    if (placedTools.length === 0) return
+    if (placedTools.length === 0 || gridLimitError) return
 
     const key = JSON.stringify({ placedTools, config, textLabels, smoothed: [...smoothedToolIds], levels: [...smoothLevels] })
     if (key === lastGenerateRef.current) return
@@ -160,11 +199,27 @@ export default function BinPage() {
         abortRef.current = null
       }
     }
-  }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels])
+  }, [binId, placedTools, config, textLabels, smoothedToolIds, smoothLevels, gridLimitError])
 
   useEffect(() => {
     doGenerateRef.current = doGenerate
   }, [doGenerate])
+
+  useEffect(() => {
+    if (!gridLimitError) return
+    abortRef.current?.abort()
+    abortRef.current = null
+    generatingRef.current = false
+    lastGenerateRef.current = ''
+    setGenerating(false)
+    setError(null)
+    setWarning(null)
+    setStlUrl(null)
+    setStlUrls([])
+    setThreemfUrl(null)
+    setZipUrl(null)
+    setInsertStlUrl(null)
+  }, [gridLimitError])
 
   const { saving, saved, error: saveError } = useDebouncedSave(
     async () => {
@@ -205,23 +260,8 @@ export default function BinPage() {
 
   // auto-size: fit grid to bounding box of all placed tools, recentre if grid changes
   useEffect(() => {
-    if (!autoSize || isDragging || placedTools.length === 0) return
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    for (const tool of placedTools) {
-      for (const p of tool.points) {
-        minX = Math.min(minX, p.x)
-        minY = Math.min(minY, p.y)
-        maxX = Math.max(maxX, p.x)
-        maxY = Math.max(maxY, p.y)
-      }
-    }
-    const halfMargin = config.wall_thickness + config.cutout_clearance + 0.25
-    const toolW = maxX - minX
-    const toolH = maxY - minY
-    const snap = config.half_grid_base ? 0.5 : 1.0;
-    const snapUnit = GRID_UNIT * snap;
-    const needX = clampGridSize(Math.ceil((toolW + 2 * halfMargin) / snapUnit) * snap);
-    const needY = clampGridSize(Math.ceil((toolH + 2 * halfMargin) / snapUnit) * snap);
+    if (isDragging || !requiredGridSize || requiredGridError) return
+    const { x: needX, y: needY, minX, minY, maxX, maxY } = requiredGridSize
 
     const gridChanged = config.grid_x !== needX || config.grid_y !== needY
     if (gridChanged) {
@@ -250,7 +290,7 @@ export default function BinPage() {
         ),
       })))
     }
-  }, [autoSize, isDragging, placedTools, config.grid_x, config.grid_y, config.wall_thickness, config.cutout_clearance, config.half_grid_base])
+  }, [isDragging, requiredGridSize, requiredGridError, placedTools, config.grid_x, config.grid_y])
 
   const handleToggleSmoothed = useCallback(async (toolId: string, smoothed: boolean) => {
     try {
@@ -284,12 +324,11 @@ export default function BinPage() {
     const toolH = maxY - minY
 
     const margin = 2 * config.wall_thickness + 2 * config.cutout_clearance + 0.5;
-    const snap = config.half_grid_base ? 0.5 : 1.0;
-    const snapUnit = GRID_UNIT * snap;
-    const needX = clampGridSize(Math.max(config.grid_x, Math.ceil((toolW + margin) / snapUnit) * snap));
-    const needY = clampGridSize(Math.max(config.grid_y, Math.ceil((toolH + margin) / snapUnit) * snap));
+    const needX = Math.max(config.grid_x, requiredGridUnits(toolW, margin, config.half_grid_base));
+    const needY = Math.max(config.grid_y, requiredGridUnits(toolH, margin, config.half_grid_base));
+    const candidateIsValid = getGridSizeError(needX, needY) === null
 
-    if (needX !== config.grid_x || needY !== config.grid_y) {
+    if (candidateIsValid && (needX !== config.grid_x || needY !== config.grid_y)) {
         setConfig((prev) => ({
             ...prev,
             grid_x: needX,
@@ -299,8 +338,8 @@ export default function BinPage() {
     }
 
     // always centre the tool in the bin
-    const binW = needX * GRID_UNIT
-    const binH = needY * GRID_UNIT
+    const binW = (candidateIsValid ? needX : config.grid_x) * GRID_UNIT
+    const binH = (candidateIsValid ? needY : config.grid_y) * GRID_UNIT
     const toolCx = (minX + maxX) / 2
     const toolCy = (minY + maxY) / 2
     const dx = binW / 2 - toolCx
@@ -369,13 +408,13 @@ export default function BinPage() {
     )
   }
 
-  const stlUrlWithVersion = stlUrl ? `${stlUrl}?v=${stlVersion}` : null
-  const splitUrlsWithVersion = stlUrls.length > 0 ? stlUrls.map(u => `${u}?v=${stlVersion}`) : null
-  const insertUrlWithVersion = insertStlUrl ? `${insertStlUrl}?v=${stlVersion}` : null
+  const stlUrlWithVersion = stlUrl && !gridLimitError ? `${stlUrl}?v=${stlVersion}` : null
+  const splitUrlsWithVersion = stlUrls.length > 0 && !gridLimitError ? stlUrls.map(u => `${u}?v=${stlVersion}`) : null
+  const insertUrlWithVersion = insertStlUrl && !gridLimitError ? `${insertStlUrl}?v=${stlVersion}` : null
   const binW = config.grid_x * GRID_UNIT
   const binH = config.grid_y * GRID_UNIT
   const effectiveRimUnits = config.stacking_lip ? config.rim_units : 0
-  const hasExports = stlUrl || zipUrl || threemfUrl || insertStlUrl
+  const hasExports = !gridLimitError && (stlUrl || zipUrl || threemfUrl || insertStlUrl)
 
   return (
     <div className="h-[calc(100vh-44px)] flex">
@@ -439,6 +478,7 @@ export default function BinPage() {
 
         {/* export buttons */}
         <div className="p-3 flex-shrink-0 space-y-1.5">
+          {gridLimitError && <Alert variant="warning">{gridLimitError}</Alert>}
           {error && <Alert variant="error">{error}</Alert>}
           {warning && (
             <InfoBanner>{warning}</InfoBanner>
@@ -582,6 +622,8 @@ export default function BinPage() {
                       <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
                       <span>Generating...</span>
                     </>
+                  ) : gridLimitError ? (
+                    <span className="max-w-xs px-4 text-center">Layout is too large to generate. Your edits are still saved.</span>
                   ) : placedTools.length === 0 ? (
                     <span>Add tools to see preview</span>
                   ) : (

--- a/frontend/src/components/BinConfigurator.tsx
+++ b/frontend/src/components/BinConfigurator.tsx
@@ -4,6 +4,7 @@ import { Info } from 'lucide-react'
 import type { BinConfig } from '@/types'
 import { NumericInput } from '@/components/NumericInput'
 import { createPartialBinsValues } from '@/lib/binDefaults'
+import { maxGridUnitsForOtherAxis } from '@/lib/constants'
 import { BED_SIZE_MAX_MM, BED_SIZE_MIN_MM } from '@/lib/settings'
 import { cn } from '@/lib/utils'
 import { ClassValue } from 'clsx'
@@ -189,7 +190,7 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
         help="Bin width in gridfinity units (42mm each). Half-unit increments (21mm) supported."
         value={config.grid_x}
         min={1}
-        max={10}
+        max={maxGridUnitsForOtherAxis(config.grid_y)}
         step={0.5}
         unit="u"
         onChange={(v) =>
@@ -206,7 +207,7 @@ export function BinConfigurator({ config, onChange, autoSize, onAutoSizeChange }
         help="Bin depth in gridfinity units (42mm each). Half-unit increments (21mm) supported."
         value={config.grid_y}
         min={1}
-        max={10}
+        max={maxGridUnitsForOtherAxis(config.grid_x)}
         step={0.5}
         unit="u"
         onChange={(v) =>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -8,14 +8,46 @@ export const ZOOM_FACTOR = 1.15
 export const DEFAULT_CUTOUT_DEPTH = 20
 export const DOCS_BASE_URL = 'https://github.com/tracefinity/tracefinity/blob/main/docs'
 
-// grid bounds enforced by the backend validator on bin_config.grid_x/grid_y.
-// exceeding them rejects the whole bin update, so clamp before building a payload
+// Bin geometry is generated in full before bed-size splitting. Keep the
+// resource ceiling tied to total grid cells while allowing long, narrow bins.
 export const MIN_GRID_UNITS = 1
-export const MAX_GRID_UNITS = 10
+export const MAX_GRID_UNITS = 25
+export const MAX_GRID_CELLS = 100
 
-// snap to the nearest 0.5 and hold inside the valid range
-export function clampGridSize(v: number): number {
-  if (Number.isNaN(v)) return MIN_GRID_UNITS
-  const snapped = Math.round(v * 2) / 2
-  return Math.min(MAX_GRID_UNITS, Math.max(MIN_GRID_UNITS, snapped))
+export function gridCellCount(gridX: number, gridY: number): number {
+  return Math.ceil(gridX) * Math.ceil(gridY)
+}
+
+export function requiredGridUnits(
+  spanMm: number,
+  totalMarginMm: number,
+  halfGridBase: boolean,
+): number {
+  const snap = halfGridBase ? 0.5 : 1
+  const snapUnitMm = GRID_UNIT * snap
+  return Math.max(MIN_GRID_UNITS, Math.ceil((spanMm + totalMarginMm) / snapUnitMm) * snap)
+}
+
+export function getGridSizeError(gridX: number, gridY: number): string | null {
+  if (!Number.isFinite(gridX) || !Number.isFinite(gridY)) {
+    return 'Grid dimensions must be finite numbers'
+  }
+  if (gridX < MIN_GRID_UNITS || gridY < MIN_GRID_UNITS) {
+    return `Grid dimensions must be at least ${MIN_GRID_UNITS} unit`
+  }
+  if (gridX > MAX_GRID_UNITS || gridY > MAX_GRID_UNITS) {
+    return `Grid dimensions must not exceed ${MAX_GRID_UNITS} units per axis`
+  }
+  if (gridX * 2 !== Math.trunc(gridX * 2) || gridY * 2 !== Math.trunc(gridY * 2)) {
+    return 'Grid dimensions must use 0.5-unit increments'
+  }
+  if (gridCellCount(gridX, gridY) > MAX_GRID_CELLS) {
+    return `Grid footprint must not exceed ${MAX_GRID_CELLS} cells`
+  }
+  return null
+}
+
+export function maxGridUnitsForOtherAxis(otherAxis: number): number {
+  const otherCells = Math.max(1, Math.ceil(otherAxis))
+  return Math.min(MAX_GRID_UNITS, Math.floor(MAX_GRID_CELLS / otherCells))
 }

--- a/frontend/src/lib/gridSize.test.ts
+++ b/frontend/src/lib/gridSize.test.ts
@@ -1,46 +1,58 @@
 import { describe, it, expect } from 'vitest'
-import { clampGridSize, MIN_GRID_UNITS, MAX_GRID_UNITS } from './constants'
+import {
+  getGridSizeError,
+  gridCellCount,
+  MAX_GRID_CELLS,
+  MAX_GRID_UNITS,
+  MIN_GRID_UNITS,
+  maxGridUnitsForOtherAxis,
+  requiredGridUnits,
+} from './constants'
 
-// the backend validator rejects grid_x/grid_y outside 1..10 or off the 0.5
-// step, and rejects the whole bin update with it
-describe('clampGridSize', () => {
-  it('holds the backend bounds', () => {
+describe('grid size limits', () => {
+  it('matches the backend resource bounds', () => {
     expect(MIN_GRID_UNITS).toBe(1)
-    expect(MAX_GRID_UNITS).toBe(10)
+    expect(MAX_GRID_UNITS).toBe(25)
+    expect(MAX_GRID_CELLS).toBe(100)
   })
 
-  it('clamps above the maximum, which is what rejected saves', () => {
-    expect(clampGridSize(10.5)).toBe(10)
-    expect(clampGridSize(14)).toBe(10)
-    expect(clampGridSize(999)).toBe(10)
+  it('accepts long, narrow bins at the existing resource ceiling', () => {
+    expect(getGridSizeError(20, 5)).toBeNull()
+    expect(getGridSizeError(25, 4)).toBeNull()
+    expect(getGridSizeError(10.5, 9)).toBeNull()
   })
 
-  it('clamps below the minimum', () => {
-    expect(clampGridSize(0)).toBe(1)
-    expect(clampGridSize(-3)).toBe(1)
+  it('rejects a dimension above the sanity ceiling', () => {
+    expect(getGridSizeError(25.5, 2)).toContain('25 units per axis')
   })
 
-  it('snaps to the nearest half unit', () => {
-    expect(clampGridSize(3.4)).toBe(3.5)
-    expect(clampGridSize(3.24)).toBe(3)
-    expect(clampGridSize(7.75)).toBe(8)
+  it('rejects footprints above 100 cells instead of silently shrinking them', () => {
+    expect(getGridSizeError(10.5, 10)).toContain('100 cells')
+    expect(getGridSizeError(20, 5.5)).toContain('100 cells')
+    expect(getGridSizeError(25, 4.5)).toContain('100 cells')
   })
 
-  it('leaves valid values alone', () => {
-    for (const v of [1, 1.5, 4, 6.5, 10]) expect(clampGridSize(v)).toBe(v)
+  it('reports the actual auto-sized requirement instead of clamping to ten', () => {
+    const defaultMargin = 2 * 1.6 + 2 * 1 + 0.5
+    expect(requiredGridUnits(414, defaultMargin, false)).toBe(10)
+    expect(requiredGridUnits(415, defaultMargin, false)).toBe(11)
+    expect(requiredGridUnits(415, defaultMargin, true)).toBe(10.5)
   })
 
-  it('never returns a value the validator would reject', () => {
-    for (let raw = -5; raw <= 20; raw += 0.13) {
-      const v = clampGridSize(raw)
-      expect(v).toBeGreaterThanOrEqual(1)
-      expect(v).toBeLessThanOrEqual(10)
-      expect(v * 2).toBe(Math.trunc(v * 2))
-    }
+  it('counts fractional dimensions by the cells they occupy', () => {
+    expect(gridCellCount(10.5, 9)).toBe(99)
+    expect(gridCellCount(10.5, 10)).toBe(110)
   })
 
-  it('survives non-finite input', () => {
-    expect(clampGridSize(NaN)).toBe(1)
-    expect(clampGridSize(Infinity)).toBe(10)
+  it('rejects invalid lower bounds and increments', () => {
+    expect(getGridSizeError(0.5, 2)).toContain('at least 1 unit')
+    expect(getGridSizeError(2.25, 2)).toContain('0.5-unit increments')
+  })
+
+  it('constrains manual controls using the other dimension', () => {
+    expect(maxGridUnitsForOtherAxis(4)).toBe(25)
+    expect(maxGridUnitsForOtherAxis(5)).toBe(20)
+    expect(maxGridUnitsForOtherAxis(9)).toBe(11)
+    expect(maxGridUnitsForOtherAxis(10.5)).toBe(9)
   })
 })


### PR DESCRIPTION
## Summary

- Replace the arbitrary 10-unit-per-axis clamp with a 25-unit sanity ceiling and a 100-cell resource limit, allowing long split bins without increasing the existing worst-case geometry footprint.
- Keep oversized layouts saved while pausing preview and export with an explicit warning, instead of silently clipping tool cutouts.
- Apply the same rules across API-created bins, editor controls, validation diagnostics, and user documentation.

## Test evidence

- `backend/venv/bin/pytest backend/tests -q` — 325 passed.
- `make lint` — passed (ruff, ESLint with 9 pre-existing warnings, and `tsc --noEmit`).
- `pnpm exec vitest run src/lib/gridSize.test.ts src/components/BinConfigurator.test.ts --reporter=verbose` — 13 passed.
- Full frontend Vitest reached 117 passing tests, but exited non-zero because five jsdom workers could not start: installed `undici@8.10.0` lacks `undici/lib/handler/wrap-handler.js`. This dependency/runtime issue is present independently of this patch.

Closes #186