### PR TITLE
Preserve straight edges during outline smoothing

### DIFF
--- a/backend/app/services/polygon_scaler.py
+++ b/backend/app/services/polygon_scaler.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.validation import make_valid
@@ -6,6 +7,10 @@ from shapely.validation import make_valid
 from app.models.schemas import FingerHole, Point, Polygon
 
 logger = logging.getLogger(__name__)
+
+# Two millimetres keeps a smoothed right-angle corner within about 0.4mm.
+# Mirrored in frontend lib/svg.ts; keep preview and generation in lockstep.
+CHAIKIN_CORNER_SPAN_MM = 2.0
 
 
 def smooth_epsilon(level: float) -> float:
@@ -30,6 +35,31 @@ def _chaikin_smooth(
             new.append((0.75 * p0[0] + 0.25 * p1[0], 0.75 * p0[1] + 0.25 * p1[1]))
             new.append((0.25 * p0[0] + 0.75 * p1[0], 0.25 * p0[1] + 0.75 * p1[1]))
         result = new
+    return result
+
+
+def _add_chaikin_support_points(
+    pts: list[tuple[float, float]], corner_span_mm: float = CHAIKIN_CORNER_SPAN_MM
+) -> list[tuple[float, float]]:
+    """Bound Chaikin's corner influence without sampling straight interiors."""
+    result: list[tuple[float, float]] = []
+    n = len(pts)
+    for i in range(n):
+        p0 = pts[i]
+        p1 = pts[(i + 1) % n]
+        result.append(p0)
+        length = math.dist(p0, p1)
+        if length <= corner_span_mm:
+            continue
+        support_positions = (
+            [0.5]
+            if length <= 2 * corner_span_mm
+            else [corner_span_mm / length, 1 - corner_span_mm / length]
+        )
+        for t in support_positions:
+            result.append(
+                (p0[0] + (p1[0] - p0[0]) * t, p0[1] + (p1[1] - p0[1]) * t)
+            )
     return result
 
 
@@ -194,14 +224,19 @@ class PolygonScaler:
         return polygon
 
     def smooth(self, polygon: ScaledPolygon, level: float = 0.5) -> ScaledPolygon:
-        """simplify, chaikin subdivide, then clean near-collinear points.
-        level 0..1 controls simplification aggressiveness before subdivision."""
+        """simplify, bound corner influence, then subdivide and clean.
+        level 0..1 controls simplification aggressiveness before smoothing."""
         pts = polygon.points_mm
         if len(pts) < 4:
             return polygon
         simplified = self.simplify(polygon, tolerance_mm=smooth_epsilon(level))
-        smoothed_pts = _chaikin_smooth(simplified.points_mm)
-        smoothed_rings = [_chaikin_smooth(ring) for ring in simplified.interior_rings_mm]
+        smoothed_pts = _chaikin_smooth(
+            _add_chaikin_support_points(simplified.points_mm)
+        )
+        smoothed_rings = [
+            _chaikin_smooth(_add_chaikin_support_points(ring))
+            for ring in simplified.interior_rings_mm
+        ]
         # clean up dense chaikin output — remove near-collinear points that
         # cause clipper2 chord artifacts, while keeping the smooth shape
         result = ScaledPolygon(polygon.id, smoothed_pts, polygon.label, polygon.finger_holes, smoothed_rings, depth_override=polygon.depth_override)

--- a/backend/tests/test_polygon_pipeline.py
+++ b/backend/tests/test_polygon_pipeline.py
@@ -2,6 +2,7 @@
 run before clearance so the requested clearance is never consumed."""
 import numpy as np
 import pytest
+from shapely.geometry import Point as SPPoint
 from shapely.geometry import Polygon as SP
 
 from app.services.polygon_scaler import PolygonScaler, ScaledPolygon, smooth_epsilon
@@ -17,6 +18,21 @@ def _dense_square(side: float, pts_per_edge: int = 200) -> list[tuple[float, flo
         pts.append((side - side * i / pts_per_edge, side))
     for i in range(pts_per_edge):
         pts.append((0.0, side - side * i / pts_per_edge))
+    return pts
+
+
+def _dense_rectangle(
+    width: float, height: float, pts_per_edge: int = 200
+) -> list[tuple[float, float]]:
+    pts = []
+    for i in range(pts_per_edge):
+        pts.append((width * i / pts_per_edge, 0.0))
+    for i in range(pts_per_edge):
+        pts.append((width, height * i / pts_per_edge))
+    for i in range(pts_per_edge):
+        pts.append((width - width * i / pts_per_edge, height))
+    for i in range(pts_per_edge):
+        pts.append((0.0, height - height * i / pts_per_edge))
     return pts
 
 
@@ -55,6 +71,15 @@ class TestSmoothEpsilon:
 
 
 class TestPrepareForGeneration:
+    def test_smoothing_preserves_long_straight_edges(self, scaler):
+        raw = _dense_rectangle(84.0, 20.0)
+
+        prepared = scaler.prepare_for_generation(
+            _sp(raw), 0.0, smoothed=True, smooth_level=0.5
+        )
+
+        assert SP(prepared.points_mm).covers(SPPoint(20.0, 0.1))
+
     def test_smoothed_clearance_measured_from_smoothed_shape(self, scaler):
         """pocket must equal the previewed (smoothed) shape grown by clearance."""
         raw = _dense_square(141.4)

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -13,7 +13,7 @@ SVG/layout/bin-space is Y-down (0 = top edge). build123d is Y-up. Always negate 
 
 ## Cutout pipeline order
 
-Smoothing/simplification runs BEFORE clearance (`prepare_for_generation`), never after -- vertex reduction erodes the outline by up to its tolerance and must not eat the clearance. The printed pocket is the previewed shape grown by exactly the clearance. The smoothing epsilon is absolute mm (`smooth_epsilon`), duplicated in `lib/svg.ts smoothEpsilon` -- change both together or preview and print diverge.
+Smoothing/simplification runs BEFORE clearance (`prepare_for_generation`), never after -- vertex reduction erodes the outline by up to its tolerance and must not eat the clearance. The printed pocket is the previewed shape grown by exactly the clearance. The smoothing epsilon is absolute mm (`smooth_epsilon`), duplicated in `lib/svg.ts smoothEpsilon`. After simplification, both pipelines add support points 2mm from each corner before Chaikin subdivision so corner influence cannot bow long edges. Keep the epsilon and Chaikin corner span in lockstep between backend and frontend or preview and print diverge.
 
 ## EXIF orientation
 

--- a/docs/usage/tool-editor.md
+++ b/docs/usage/tool-editor.md
@@ -40,7 +40,7 @@ not change which outline bins and exports use.
 
 **Accurate** -- the raw traced polygon with all vertices. You can add, remove, and drag points.
 
-**Smooth** -- a simplified outline. A slider controls smoothing aggressiveness: range 0 to 1, step 0.05. Uses Chaikin subdivision, which always stays within the control polygon and never overshoots. Vertex editing is unavailable in this preview.
+**Smooth** -- a simplified outline. A slider controls smoothing aggressiveness: range 0 to 1, step 0.05. Uses physically bounded Chaikin subdivision, which stays within the control polygon without bowing long straight runs. Vertex editing is unavailable in this preview.
 
 Use the separate **Output: Smooth/Accurate** button to choose which outline is
 used for bins and SVG exports. This preference is saved with the tool.

--- a/frontend/src/lib/svg.test.ts
+++ b/frontend/src/lib/svg.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from 'vitest'
-import { smoothEpsilon, simplifyPolygon } from './svg'
+import type { Point } from '@/types'
+import { smoothEpsilon, simplifyPolygon, smoothPathData } from './svg'
+
+function denseRectangle(width: number, height: number, pointsPerEdge = 200): Point[] {
+  const points: Point[] = []
+  for (let i = 0; i < pointsPerEdge; i++) points.push({ x: width * i / pointsPerEdge, y: 0 })
+  for (let i = 0; i < pointsPerEdge; i++) points.push({ x: width, y: height * i / pointsPerEdge })
+  for (let i = 0; i < pointsPerEdge; i++) points.push({ x: width - width * i / pointsPerEdge, y: height })
+  for (let i = 0; i < pointsPerEdge; i++) points.push({ x: 0, y: height - height * i / pointsPerEdge })
+  return points
+}
+
+function pathPoints(path: string): Point[] {
+  return [...path.matchAll(/[ML]\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g)]
+    .map((match) => ({ x: Number(match[1]), y: Number(match[2]) }))
+}
+
+function lowerEdgeYAt(points: Point[], x: number): number {
+  const intersections: number[] = []
+  for (let i = 0; i < points.length; i++) {
+    const p0 = points[i]
+    const p1 = points[(i + 1) % points.length]
+    if (p0.x === p1.x || x < Math.min(p0.x, p1.x) || x > Math.max(p0.x, p1.x)) continue
+    const t = (x - p0.x) / (p1.x - p0.x)
+    intersections.push(p0.y + t * (p1.y - p0.y))
+  }
+  return Math.min(...intersections)
+}
 
 describe('smoothEpsilon', () => {
   // must mirror backend polygon_scaler.smooth_epsilon exactly: absolute mm,
@@ -27,5 +54,16 @@ describe('simplifyPolygon', () => {
     ]
     const out = simplifyPolygon(pts, 0.3)
     expect(out.length).toBe(4)
+  })
+})
+
+describe('smoothPathData', () => {
+  it('preserves long straight edges away from corners', () => {
+    const raw = denseRectangle(84, 20)
+    const simplified = simplifyPolygon(raw, smoothEpsilon(0.5))
+
+    const smoothed = pathPoints(smoothPathData(simplified))
+
+    expect(lowerEdgeYAt(smoothed, 20)).toBeLessThanOrEqual(0.1)
   })
 })

--- a/frontend/src/lib/svg.ts
+++ b/frontend/src/lib/svg.ts
@@ -1,5 +1,9 @@
 import type { Point } from '@/types'
 
+// Two millimetres keeps a smoothed right-angle corner within about 0.4mm.
+// Mirrored in backend polygon_scaler.py; keep preview and generation in lockstep.
+const CHAIKIN_CORNER_SPAN_MM = 2
+
 // ramer-douglas-peucker polygon simplification
 function perpendicularDist(p: Point, a: Point, b: Point): number {
   const dx = b.x - a.x
@@ -77,6 +81,27 @@ function chaikinSmooth(pts: Point[], iterations = 3): Point[] {
   return result
 }
 
+function addChaikinSupportPoints(pts: Point[]): Point[] {
+  const result: Point[] = []
+  for (let i = 0; i < pts.length; i++) {
+    const p0 = pts[i]
+    const p1 = pts[(i + 1) % pts.length]
+    result.push(p0)
+    const length = Math.hypot(p1.x - p0.x, p1.y - p0.y)
+    if (length <= CHAIKIN_CORNER_SPAN_MM) continue
+    const supportPositions = length <= 2 * CHAIKIN_CORNER_SPAN_MM
+      ? [0.5]
+      : [CHAIKIN_CORNER_SPAN_MM / length, 1 - CHAIKIN_CORNER_SPAN_MM / length]
+    for (const t of supportPositions) {
+      result.push({
+        x: p0.x + (p1.x - p0.x) * t,
+        y: p0.y + (p1.y - p0.y) * t,
+      })
+    }
+  }
+  return result
+}
+
 // clean near-collinear points (matches backend's post-chaikin simplify)
 function cleanChaikinOutput(pts: Point[]): Point[] {
   return simplifyPolygon(pts, 0.05)
@@ -88,7 +113,7 @@ function cleanChaikinOutput(pts: Point[]): Point[] {
  */
 function smoothRingPath(pts: Point[], s: number): string {
   if (pts.length < 3) return pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * s} ${p.y * s}`).join(' ') + ' Z'
-  const smoothed = cleanChaikinOutput(chaikinSmooth(pts))
+  const smoothed = cleanChaikinOutput(chaikinSmooth(addChaikinSupportPoints(pts)))
   return smoothed.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x * s} ${p.y * s}`).join(' ') + ' Z'
 }
 


### PR DESCRIPTION
## Summary

- Bound Chaikin smoothing to a 2mm corner span so long simplified edges stay straight instead of bowing far into tool pockets.
- Keep SVG previews and generated geometry in lockstep, with regression coverage at both public seams.
- Document the physical smoothing bound and its backend/frontend parity requirement.

## Test evidence

- `backend/venv/bin/pytest backend/tests -q` — 326 passed.
- `pnpm exec vitest run src/lib/svg.test.ts --reporter=verbose` — 4 passed.
- `make lint` — passed (ruff, TypeScript, and ESLint with 9 pre-existing warnings).
- Full frontend Vitest reached 118 passing tests; five existing jsdom workers could not start because the installed `undici` package lacks `wrap-handler.js`.
- Local Playwright could not start because its Chromium binary is not installed; the E2E workflow installs Chromium before running.

Closes #184