### PR TITLE
Restore frontend component tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,17 @@ jobs:
           cache-dependency-path: backend/requirements.txt
       - run: cd backend && pip install -r requirements.txt pytest
       - run: cd backend && python -m pytest
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - run: cd frontend && pnpm install --frozen-lockfile
+      - run: cd frontend && pnpm test

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,7 +21,7 @@ Tracefinity is the photo-tracing-to-gridfinity pipeline. Photos are the input; g
 
 - **Keep PRs focused.** One concern per PR. If you're touching unrelated files (sidebar width, dev scripts, polish), split them out.
 - **Backward compatible schemas.** New fields must have defaults. Existing data must load without migration.
-- **Tests must actually run.** Run `pytest` and check for failures before submitting, not just `py_compile`.
+- **Tests must actually run.** Run the backend `pytest` suite and frontend `pnpm test` suite before submitting; compilation alone is not enough.
 
 ## Frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev -p 4001",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix"
   },
@@ -40,6 +41,7 @@
       "postcss": ">=8.5.23",
       "js-yaml": ">=4.3.1",
       "undici": ">=7.29.0",
+      "jsdom@29>undici": "7.29.0",
       "brace-expansion@1": "1.1.18",
       "brace-expansion@2": "2.1.4"
     }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   postcss: '>=8.5.23'
   js-yaml: '>=4.3.1'
   undici: '>=7.29.0'
+  jsdom@29>undici: 7.29.0
   brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
 
@@ -2723,9 +2724,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -4837,7 +4838,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.10.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5723,7 +5724,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici@8.10.0: {}
+  undici@7.29.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Keep jsdom 29 on the Node 20-compatible, security-patched Undici 7.29.0 release without weakening the repository-wide Undici security floor.
- Add a stable frontend test command and execute the Vitest suite in CI.
- Keep contributor testing guidance aligned with the enforced test suites.

## Test evidence

- `pnpm test` — 16 files, 136 tests passed.
- `backend/venv/bin/python -m pytest backend/tests -q` — 326 tests passed.
- `make lint` — passed with 9 existing frontend warnings and no errors.
- `pnpm audit --audit-level high` — no known vulnerabilities.
- Frozen install and the full frontend suite passed on Node 20.20.2.

Closes #189
