### PR TITLE
Roll out product-scope triage

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -203,6 +203,11 @@ Keep scope and implementation status separate in GitHub:
 - `scope:out-of-scope`
 - `status:needs-demand`
 - `status:blocked-by-cost`
+- `status:needs-retriage`
+
+`status:needs-retriage` is a prompt for human review when a closed request gets
+new interest. It does not change the request's scope verdict or reopen it by
+itself.
 
 When this direction changes, update this document through a maintainer-approved
 pull request and update the affected precedent or canonical request. Changing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,13 @@ we currently plan to work on it. Those are different decisions.
 | `scope:out-of-scope` | Conflicts with a settled boundary |
 | `status:needs-demand` | Fits, but current interest does not justify the work |
 | `status:blocked-by-cost` | Fits, but the implementation or maintenance burden is disproportionate |
+| `status:needs-retriage` | New interest in a closed request needs human review |
 
 An issue can be in scope and still be closed as `Not planned`. Closed canonical
 requests stay unlocked so reactions, concrete use cases, and related requests
-can provide evidence for re-triage.
+can provide evidence for re-triage. `status:needs-retriage` only flags that
+evidence for a person to assess; it does not change the existing scope decision
+or reopen the request automatically.
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary

- define `status:needs-retriage` as a human-review signal without changing scope or reopening requests
- create the constitution-backed scope/status labels and apply them through individual backlog review
- record the settled decisions on #80, #139, and #166 directly, while keeping all declined requests unlocked for new evidence

## Test evidence

- `make lint` passed: ruff and TypeScript clean; ESLint reported 9 existing warnings and 0 errors
- `git diff --check origin/main..HEAD` passed
- independent spec and acceptance-criteria reviews found no actionable failures

Closes #196
